### PR TITLE
Use derivation instead of macro to prevent copying

### DIFF
--- a/audio/Audio.h
+++ b/audio/Audio.h
@@ -86,10 +86,9 @@ public:
 
 //---- Audio -----------------------------------------------------------
 
-class Audio 
+class Audio : nonreplicatable
 {
 private:
-	UNREPLICATABLE_CLASS(Audio)
 	static	Audio	*self;
 	static	const int *bg2si_songs;	// Converts BG songs to SI songs.
 	static	const int *bg2si_sfxs;	// Converts BG sfx's to SI sfx's.

--- a/audio/Midi.h
+++ b/audio/Midi.h
@@ -36,7 +36,7 @@ namespace Pentagram {
 
 //---- MyMidiPlayer -----------------------------------------------------------
 
-class	MyMidiPlayer
+class	MyMidiPlayer : nonreplicatable
 {
 public:
 	enum TimbreLibrary {
@@ -50,7 +50,6 @@ public:
 	MyMidiPlayer();
 	~MyMidiPlayer();
 
-	UNREPLICATABLE_CLASS(MyMidiPlayer)
 
 	void			destroyMidiDriver();
 

--- a/gamemgr/modmgr.h
+++ b/gamemgr/modmgr.h
@@ -190,8 +190,7 @@ public:
 	}
 };
 
-class GameManager {
-	UNREPLICATABLE_CLASS(GameManager)
+class GameManager : nonreplicatable {
 protected:
 	// -> to original games.
 	ModManager *bg;

--- a/gumps/Actor_gump.h
+++ b/gumps/Actor_gump.h
@@ -31,7 +31,6 @@ class Combat_mode_button;
  *  A rectangular area showing a character and his/her possessions:
  */
 class Actor_gump : public Gump {
-
 protected:
 	struct Position {
 		short x;

--- a/gumps/Actor_gump.h
+++ b/gumps/Actor_gump.h
@@ -31,7 +31,6 @@ class Combat_mode_button;
  *  A rectangular area showing a character and his/her possessions:
  */
 class Actor_gump : public Gump {
-	UNREPLICATABLE_CLASS(Actor_gump)
 
 protected:
 	struct Position {

--- a/gumps/AudioOptions_gump.h
+++ b/gumps/AudioOptions_gump.h
@@ -27,7 +27,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 class Gump_button;
 
 class AudioOptions_gump : public Modal_gump {
-
 private:
 	enum button_ids {
 	    id_first = 0,

--- a/gumps/AudioOptions_gump.h
+++ b/gumps/AudioOptions_gump.h
@@ -27,7 +27,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 class Gump_button;
 
 class AudioOptions_gump : public Modal_gump {
-	UNREPLICATABLE_CLASS(AudioOptions_gump)
 
 private:
 	enum button_ids {

--- a/gumps/Book_gump.h
+++ b/gumps/Book_gump.h
@@ -25,7 +25,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *  A book shows text side-by-side.
  */
 class Book_gump : public Text_gump {
-
 public:
 	Book_gump(int fnt = 4, int gump = -1);
 	// Paint it and its contents.

--- a/gumps/Book_gump.h
+++ b/gumps/Book_gump.h
@@ -25,7 +25,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *  A book shows text side-by-side.
  */
 class Book_gump : public Text_gump {
-	UNREPLICATABLE_CLASS(Book_gump)
 
 public:
 	Book_gump(int fnt = 4, int gump = -1);

--- a/gumps/CombatStats_gump.h
+++ b/gumps/CombatStats_gump.h
@@ -30,7 +30,6 @@ class Actor;
  *  A rectangular area showing party combat statistics:
  */
 class CombatStats_gump : public Gump {
-
 public:
 	CombatStats_gump(int initx, int inity);
 	// Add object.

--- a/gumps/CombatStats_gump.h
+++ b/gumps/CombatStats_gump.h
@@ -30,7 +30,6 @@ class Actor;
  *  A rectangular area showing party combat statistics:
  */
 class CombatStats_gump : public Gump {
-	UNREPLICATABLE_CLASS(CombatStats_gump)
 
 public:
 	CombatStats_gump(int initx, int inity);

--- a/gumps/Face_stats.h
+++ b/gumps/Face_stats.h
@@ -26,7 +26,6 @@ class Actor;
 class Portrait_button;
 
 class Face_stats : public Gump {
-	UNREPLICATABLE_CLASS(Face_stats)
 	// Only allow for one to be made
 	static Face_stats   *self;
 	static int      mode;

--- a/gumps/File_gump.h
+++ b/gumps/File_gump.h
@@ -27,7 +27,6 @@ class Gump_text;
  *  The file save/load box:
  */
 class File_gump : public Modal_gump {
-	UNREPLICATABLE_CLASS(File_gump)
 
 protected:
 	static short textx, texty;  // Where to draw first text field.

--- a/gumps/File_gump.h
+++ b/gumps/File_gump.h
@@ -27,7 +27,6 @@ class Gump_text;
  *  The file save/load box:
  */
 class File_gump : public Modal_gump {
-
 protected:
 	static short textx, texty;  // Where to draw first text field.
 	static short texth;     // Distance down to next text field.

--- a/gumps/Gamemenu_gump.h
+++ b/gumps/Gamemenu_gump.h
@@ -27,7 +27,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 class Gump_button;
 
 class Gamemenu_gump : public Modal_gump {
-
 private:
 	enum button_ids {
 	    id_first = 0,

--- a/gumps/Gamemenu_gump.h
+++ b/gumps/Gamemenu_gump.h
@@ -27,7 +27,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 class Gump_button;
 
 class Gamemenu_gump : public Modal_gump {
-	UNREPLICATABLE_CLASS(Gamemenu_gump)
 
 private:
 	enum button_ids {

--- a/gumps/GameplayOptions_gump.h
+++ b/gumps/GameplayOptions_gump.h
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 class Gump_button;
 
 class GameplayOptions_gump : public Modal_gump {
-
 private:
 	int facestats;
 	int fastmouse;

--- a/gumps/GameplayOptions_gump.h
+++ b/gumps/GameplayOptions_gump.h
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 class Gump_button;
 
 class GameplayOptions_gump : public Modal_gump {
-	UNREPLICATABLE_CLASS(GameplayOptions_gump)
 
 private:
 	int facestats;

--- a/gumps/Gump.h
+++ b/gumps/Gump.h
@@ -36,8 +36,7 @@ class Gump_widget;
 /*
  *  A gump contains an image of an open container from "gumps.vga".
  */
-class Gump : public ShapeID, public Paintable {
-	UNREPLICATABLE_CLASS(Gump)
+class Gump : nonreplicatable, public ShapeID, public Paintable {
 
 protected:
 	Gump() = default;
@@ -144,7 +143,6 @@ public:
  *  A generic gump used by generic containers:
  */
 class Container_gump : public Gump {
-	UNREPLICATABLE_CLASS(Container_gump)
 
 	void initialize(int shnum);     // Initialize object_area.
 

--- a/gumps/Gump.h
+++ b/gumps/Gump.h
@@ -37,7 +37,6 @@ class Gump_widget;
  *  A gump contains an image of an open container from "gumps.vga".
  */
 class Gump : nonreplicatable, public ShapeID, public Paintable {
-
 protected:
 	Gump() = default;
 	Container_game_object *container;// What this gump shows.
@@ -143,7 +142,6 @@ public:
  *  A generic gump used by generic containers:
  */
 class Container_gump : public Gump {
-
 	void initialize(int shnum);     // Initialize object_area.
 
 public:

--- a/gumps/Gump_button.h
+++ b/gumps/Gump_button.h
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *  A pushable button on a gump:
  */
 class Gump_button : public Gump_widget {
-	UNREPLICATABLE_CLASS(Gump_button)
 
 private:
 	int pushed_button;      // 1 if in pushed state.

--- a/gumps/Gump_button.h
+++ b/gumps/Gump_button.h
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *  A pushable button on a gump:
  */
 class Gump_button : public Gump_widget {
-
 private:
 	int pushed_button;      // 1 if in pushed state.
 

--- a/gumps/Gump_widget.h
+++ b/gumps/Gump_widget.h
@@ -32,8 +32,7 @@ class Gump_button;
 /*
  *  A gump widget, such as a button or text field:
  */
-class Gump_widget : public ShapeID {
-	UNREPLICATABLE_CLASS(Gump_widget)
+class Gump_widget : nonreplicatable, public ShapeID {
 
 protected:
 	Gump_widget() = default;

--- a/gumps/Gump_widget.h
+++ b/gumps/Gump_widget.h
@@ -33,7 +33,6 @@ class Gump_button;
  *  A gump widget, such as a button or text field:
  */
 class Gump_widget : nonreplicatable, public ShapeID {
-
 protected:
 	Gump_widget() = default;
 	Gump *parent = nullptr;       // Who this is in.

--- a/gumps/InputOptions_gump.h
+++ b/gumps/InputOptions_gump.h
@@ -28,7 +28,6 @@ class Gump_button;
 
 class InputOptions_gump : public Modal_gump {
 public:
-	UNREPLICATABLE_CLASS(InputOptions_gump)
 	InputOptions_gump();
 
 	// Paint it and its contents.

--- a/gumps/ItemMenu_gump.h
+++ b/gumps/ItemMenu_gump.h
@@ -40,7 +40,6 @@ class Itemmenu_gump : public Modal_gump {
 	};
 
 public:
-	UNREPLICATABLE_CLASS(Itemmenu_gump)
 	Itemmenu_gump(Game_object_map_xy *mobjxy, int cx, int cy);
 	Itemmenu_gump(Game_object *obj, int ox, int oy, int cx, int cy);
 	~Itemmenu_gump() override;

--- a/gumps/MiscOptions_gump.h
+++ b/gumps/MiscOptions_gump.h
@@ -27,7 +27,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 class Gump_button;
 
 class MiscOptions_gump : public Modal_gump {
-	UNREPLICATABLE_CLASS(MiscOptions_gump)
 
 private:
 	int difficulty;         // Setting for the buttons.

--- a/gumps/MiscOptions_gump.h
+++ b/gumps/MiscOptions_gump.h
@@ -27,7 +27,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 class Gump_button;
 
 class MiscOptions_gump : public Modal_gump {
-
 private:
 	int difficulty;         // Setting for the buttons.
 	int show_hits;

--- a/gumps/Modal_gump.h
+++ b/gumps/Modal_gump.h
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *  the user clicks okay.
  */
 class Modal_gump : public Gump {
-	UNREPLICATABLE_CLASS(Modal_gump)
 
 protected:
 	bool done;          // true when user clicks checkmark.

--- a/gumps/Modal_gump.h
+++ b/gumps/Modal_gump.h
@@ -71,7 +71,6 @@ public:
 	virtual bool run() {
 		return false;
 	}
-
 };
 
 #endif

--- a/gumps/Newfile_gump.h
+++ b/gumps/Newfile_gump.h
@@ -84,7 +84,6 @@ struct SaveGame_Party {
  *  The file save/load box:
  */
 class Newfile_gump : public Modal_gump {
-	UNREPLICATABLE_CLASS(Newfile_gump)
 
 public:
 	struct SaveInfo {

--- a/gumps/Newfile_gump.h
+++ b/gumps/Newfile_gump.h
@@ -101,7 +101,6 @@ public:
 		void            SetSeqNumber();
 
 		~SaveInfo();
-
 	};
 
 protected:

--- a/gumps/Notebook_gump.h
+++ b/gumps/Notebook_gump.h
@@ -42,7 +42,6 @@ public:
  *  A notebook gump represents the in-game journal.
  */
 class Notebook_gump : public Gump {
-	UNREPLICATABLE_CLASS(Notebook_gump)
 	static std::vector<One_note *> notes;// The text.
 	// Indexed by page#.
 	static std::vector<Notebook_top> page_info;

--- a/gumps/Paperdoll_gump.h
+++ b/gumps/Paperdoll_gump.h
@@ -35,7 +35,6 @@ class Paperdoll_npc;
 
 class Paperdoll_gump : public Gump {
 private:
-	UNREPLICATABLE_CLASS(Paperdoll_gump)
 
 protected:
 	struct Position {

--- a/gumps/Paperdoll_gump.h
+++ b/gumps/Paperdoll_gump.h
@@ -34,8 +34,6 @@ class Paperdoll_npc;
 //
 
 class Paperdoll_gump : public Gump {
-private:
-
 protected:
 	struct Position {
 		short x;

--- a/gumps/Scroll_gump.h
+++ b/gumps/Scroll_gump.h
@@ -25,7 +25,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *  A scroll:
  */
 class Scroll_gump : public Text_gump {
-
 public:
 	Scroll_gump(int fnt = 4, int gump = -1);
 	// Paint it and its contents.

--- a/gumps/Scroll_gump.h
+++ b/gumps/Scroll_gump.h
@@ -25,7 +25,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *  A scroll:
  */
 class Scroll_gump : public Text_gump {
-	UNREPLICATABLE_CLASS(Scroll_gump)
 
 public:
 	Scroll_gump(int fnt = 4, int gump = -1);

--- a/gumps/Sign_gump.h
+++ b/gumps/Sign_gump.h
@@ -26,7 +26,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *  A sign showing runes.
  */
 class Sign_gump : public Gump {
-	UNREPLICATABLE_CLASS(Sign_gump)
 
 protected:
 	std::string *lines;         // Lines of text.

--- a/gumps/Sign_gump.h
+++ b/gumps/Sign_gump.h
@@ -26,7 +26,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *  A sign showing runes.
  */
 class Sign_gump : public Gump {
-
 protected:
 	std::string *lines;         // Lines of text.
 	int num_lines;

--- a/gumps/Slider_gump.h
+++ b/gumps/Slider_gump.h
@@ -27,7 +27,6 @@ class Slider_button;
  *  A slider for choosing a number.
  */
 class Slider_gump : public Modal_gump {
-	UNREPLICATABLE_CLASS(Slider_gump)
 
 protected:
 	int diamondx;           // Rel. pos. where diamond is shown.

--- a/gumps/Slider_gump.h
+++ b/gumps/Slider_gump.h
@@ -27,7 +27,6 @@ class Slider_button;
  *  A slider for choosing a number.
  */
 class Slider_gump : public Modal_gump {
-
 protected:
 	int diamondx;           // Rel. pos. where diamond is shown.
 	static short diamondy;

--- a/gumps/Stats_gump.h
+++ b/gumps/Stats_gump.h
@@ -29,7 +29,6 @@ class Actor;
  *  A rectangular area showing a character's statistics:
  */
 class Stats_gump : public Gump {
-	UNREPLICATABLE_CLASS(Stats_gump)
 
 protected:
 	Actor *get_actor() {

--- a/gumps/Stats_gump.h
+++ b/gumps/Stats_gump.h
@@ -29,7 +29,6 @@ class Actor;
  *  A rectangular area showing a character's statistics:
  */
 class Stats_gump : public Gump {
-
 protected:
 	Actor *get_actor() {
 		return reinterpret_cast<Actor *>(container);

--- a/gumps/Text_gump.h
+++ b/gumps/Text_gump.h
@@ -25,7 +25,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *  A text gump is the base class for books and scrolls.
  */
 class Text_gump : public Gump {
-
 protected:
 	char *text;         // The text.
 	int textlen;            // Length of text.

--- a/gumps/Text_gump.h
+++ b/gumps/Text_gump.h
@@ -25,7 +25,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *  A text gump is the base class for books and scrolls.
  */
 class Text_gump : public Gump {
-	UNREPLICATABLE_CLASS(Text_gump)
 
 protected:
 	char *text;         // The text.

--- a/gumps/VideoOptions_gump.h
+++ b/gumps/VideoOptions_gump.h
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 class Gump_button;
 
 class VideoOptions_gump : public Modal_gump {
-	UNREPLICATABLE_CLASS(VideoOptions_gump)
 	static VideoOptions_gump *video_options_gump;
 
 private:

--- a/gumps/Yesno_gump.h
+++ b/gumps/Yesno_gump.h
@@ -31,7 +31,6 @@ class Yesno_button;
  *  A yes/no box.
  */
 class Yesno_gump : public Modal_gump {
-	UNREPLICATABLE_CLASS(Yesno_gump)
 
 protected:
 	static short yesx, yesnoy, nox; // Coords. of the buttons.

--- a/gumps/Yesno_gump.h
+++ b/gumps/Yesno_gump.h
@@ -31,7 +31,6 @@ class Yesno_button;
  *  A yes/no box.
  */
 class Yesno_gump : public Modal_gump {
-
 protected:
 	static short yesx, yesnoy, nox; // Coords. of the buttons.
 	std::string text;           // Text of question.  It is drawn in

--- a/headers/exceptions.h
+++ b/headers/exceptions.h
@@ -55,21 +55,16 @@ public:
 	}
 };
 
-/*
- *  Classes which should not be replicatable throw an replication_exception
- */
-
-class replication_exception : public exult_exception {
-public:
-	explicit replication_exception(std::string what_arg): exult_exception(std::move(what_arg)) {  }
+//Per analogiam to boost::noncopyable
+class nonreplicatable {
+protected:
+	constexpr nonreplicatable() = default;
+	nonreplicatable(const nonreplicatable&) = delete;
+	nonreplicatable(nonreplicatable&&) = delete;
+	nonreplicatable& operator=(const nonreplicatable&) = delete;
+	nonreplicatable& operator=(nonreplicatable&&) = delete;
+	~nonreplicatable() = default;
 };
-
-// Some handy macros which you can use to make a class non-replicable
-#define UNREPLICATABLE_CLASS(NAME)  NAME(const NAME &) = delete; \
-	NAME &operator=(const NAME &) = delete; \
-	NAME(NAME &&) = delete; \
-	NAME &operator=(NAME &&) = delete;
-
 
 
 /*

--- a/usecode/ucmachine.h
+++ b/usecode/ucmachine.h
@@ -42,8 +42,7 @@ class Tile_coord;
  *  Here's our virtual machine for running usecode.  The actual internals
  *  are in Usecode_internal.
  */
-class Usecode_machine : public Game_singletons {
-	UNREPLICATABLE_CLASS(Usecode_machine)
+class Usecode_machine : nonreplicatable, public Game_singletons {
 protected:
 	unsigned char gflags[c_last_gflag + 1]; // Global flags.
 	Keyring *keyring = nullptr;


### PR DESCRIPTION
Solution per analogiam to boost::noncopyable, see http://bajamircea.github.io/coding/cpp/2017/02/22/noncopyable-adl.html