### PR TITLE
Store Text_effect in std::list

### DIFF
--- a/effects.cc
+++ b/effects.cc
@@ -280,9 +280,8 @@ void Effects_manager::paint(
 
 void Effects_manager::paint_text(
 ) {
-	std::for_each(texts.begin(), texts.end(),
-			[](auto& txt) { txt->paint(); }
-	);
+	for (auto& txt : texts)
+		txt->paint();
 }
 
 /**
@@ -290,9 +289,8 @@ void Effects_manager::paint_text(
  */
 void Effects_manager::update_dirty_text(
 ) {
-	std::for_each(texts.begin(), texts.end(),
-			[](auto& txt) { txt->update_dirty(); }
-	);
+	for (auto& txt : texts)
+		txt->update_dirty();
 }
 /**
  *  Some special effects may not need painting.

--- a/effects.cc
+++ b/effects.cc
@@ -81,7 +81,7 @@ void Effects_manager::add_text(
 
 //	txt->paint(this);        // Draw it.
 //	painted = 1;
-	texts.emplace_front(std::make_unique<Text_effect>(msg, item, *gwin));
+	texts.emplace_front(std::make_unique<Text_effect>(msg, item, gwin));
 }
 
 /**
@@ -100,7 +100,7 @@ void Effects_manager::add_text(
 		msg,
 		gwin->get_scrolltx() + x / c_tilesize,
 		gwin->get_scrollty() + y / c_tilesize,
-		*gwin)
+		gwin)
 	);
 }
 
@@ -982,7 +982,7 @@ void Homing_projectile::paint(
 Rectangle Text_effect::Figure_text_pos() {
     Game_object_shared item_obj = item.lock();
 	if (item_obj) {
-		Gump_manager *gumpman = gwin.get_gump_man();
+		Gump_manager *gumpman = gwin->get_gump_man();
 		// See if it's in a gump.
 		Gump *gump = gumpman->find_gump(item_obj.get());
 		if (gump)
@@ -990,15 +990,15 @@ Rectangle Text_effect::Figure_text_pos() {
 		else {
 			Game_object *outer = item_obj->get_outermost();
 			if (!outer->get_chunk()) return pos;
-			Rectangle r = gwin.get_shape_rect(outer);
-			r.x -= gwin.get_scrolltx_lo();
-			r.y -= gwin.get_scrollty_lo();
+			Rectangle r = gwin->get_shape_rect(outer);
+			r.x -= gwin->get_scrolltx_lo();
+			r.y -= gwin->get_scrollty_lo();
 			return r;
 		}
 	} else {
 		int x;
 		int y;
-		gwin.get_shape_location(tpos, x, y);
+		gwin->get_shape_location(tpos, x, y);
 		return Rectangle(x, y, c_tilesize, c_tilesize);
 	}
 }
@@ -1013,7 +1013,7 @@ void Text_effect::add_dirty(
 	Rectangle rect(pos.x - c_tilesize,
 	               pos.y - c_tilesize,
 	               width + 2 * c_tilesize, height + 2 * c_tilesize);
-	gwin.add_dirty(gwin.clip_to_win(rect));
+	gwin->add_dirty(gwin->clip_to_win(rect));
 }
 
 /**
@@ -1028,7 +1028,7 @@ void Text_effect::init(
 	height = 8 + sman->get_text_height(0);
 	add_dirty();            // Force first paint.
 	// Start immediately.
-	gwin.get_tqueue()->add(Game::get_ticks(), this);
+	gwin->get_tqueue()->add(Game::get_ticks(), this);
 	if (msg[0] == '@')
 		msg[0] = '"';
 	int len = msg.size();
@@ -1043,7 +1043,7 @@ void Text_effect::init(
 Text_effect::Text_effect(
     const string &m,        // A copy is made.
     Game_object *it,        // Item text is on, or null.
-    Game_window& gwin_      // Back-reference to gwin from Effects_manager
+    Game_window *gwin_      // Back-reference to gwin from Effects_manager
 ) : msg(m), item(weak_from_obj(it)), pos(Figure_text_pos()), num_ticks(0), gwin(gwin_) {
 	init();
 }
@@ -1055,7 +1055,7 @@ Text_effect::Text_effect(
 Text_effect::Text_effect(
     const string &m,        // A copy is made.
     int t_x, int t_y,       // Abs. tile coords.
-    Game_window& gwin_      // Back-reference to gwin from Effects_manager
+    Game_window *gwin_      // Back-reference to gwin from Effects_manager
 ) : msg(m), tpos(t_x, t_y, 0), pos(Figure_text_pos()), num_ticks(0), gwin(gwin_) {
 	init();
 }
@@ -1076,7 +1076,7 @@ void Text_effect::handle_event(
 		return;
 	}
 	// Back into queue.
-	gwin.get_tqueue()->add(Game::get_ticks() + gwin.get_std_delay(), this);
+	gwin->get_tqueue()->add(Game::get_ticks() + gwin->get_std_delay(), this);
 
 	update_dirty();
 }
@@ -1099,7 +1099,7 @@ void Text_effect::update_dirty(
 Text_effect::~Text_effect(
 ) {
 	if (in_queue())
-		gwin.get_tqueue()->remove(this);
+		gwin->get_tqueue()->remove(this);
 }
 
 

--- a/effects.cc
+++ b/effects.cc
@@ -76,7 +76,7 @@ void Effects_manager::add_text(
 		return;
 	// Don't duplicate for item.
 	if (std::find_if(texts.cbegin(), texts.cend(),
-		[&](const auto& el) { return el->is_text(item); }) != texts.cend())
+		[item](const auto& el) { return el->is_text(item); }) != texts.cend())
 		return; // Already have text on this.
 
 //	txt->paint(this);        // Draw it.
@@ -139,7 +139,7 @@ void Effects_manager::remove_text_effect(
     Game_object *item       // Item text was added for.
 ) {
 	auto effectToDelete = std::find_if(texts.begin(), texts.end(), 
-			[&item](const auto& el) { return el->is_text(item); });
+			[item](const auto& el) { return el->is_text(item); });
 	if (effectToDelete == texts.end())
 		return;
 	else {
@@ -173,7 +173,7 @@ void Effects_manager::remove_effect(
 void Effects_manager::remove_text_effect(
     Text_effect *txt
 ) {
-	texts.remove_if([&](const auto& el) { return el.get() == txt; });
+	texts.remove_if([txt](const auto& el) { return el.get() == txt; });
 }
 
 /**
@@ -201,7 +201,6 @@ void Effects_manager::remove_all_effects(
 
 void Effects_manager::remove_text_effects(
 ) {
-
 	texts.clear();
 	gwin->set_all_dirty();
 }

--- a/effects.cc
+++ b/effects.cc
@@ -91,7 +91,7 @@ void Effects_manager::add_text(
  *  @param y        y coord. on screen.
  */
 
-void Effects_manager::add_text(
+inline void Effects_manager::add_text(
     const char *msg,
     int x, int y
 ) {
@@ -148,12 +148,12 @@ void Effects_manager::add_text_effect(
 void Effects_manager::remove_text_effect(
     Game_object *item       // Item text was added for.
 ) {
-	auto itemToDelete = std::find_if(texts.begin(), texts.end(), 
-			[&](const auto& el) { return el->is_text(item); });
-	if (itemToDelete == texts.end())
+	auto effectToDelete = std::find_if(texts.begin(), texts.end(), 
+			[&item](const auto& el) { return el->is_text(item); });
+	if (effectToDelete == texts.end())
 		return;
 	else {
-		remove_text_effect((*itemToDelete).get());
+	    texts.erase(effectToDelete);
 		gwin->paint();
 	}
 }
@@ -200,9 +200,7 @@ void Effects_manager::remove_all_effects(
 		remove_effect(effects);
 		effects = next;
 	}
-	std::for_each(texts.begin(), texts.end(),
-			[&](auto& txt){ remove_text_effect(txt.get()); }
-	);
+	texts.clear();
 	if (repaint)
 		gwin->paint();      // Just paint whole screen.
 }
@@ -214,9 +212,7 @@ void Effects_manager::remove_all_effects(
 void Effects_manager::remove_text_effects(
 ) {
 
-	std::for_each(texts.begin(), texts.end(),
-			[&](auto& txt){ remove_text_effect(txt.get()); }
-	);
+	texts.clear();
 	gwin->set_all_dirty();
 }
 

--- a/effects.cc
+++ b/effects.cc
@@ -143,7 +143,7 @@ void Effects_manager::remove_text_effect(
 	if (effectToDelete == texts.end())
 		return;
 	else {
-	    texts.erase(effectToDelete);
+		texts.erase(effectToDelete);
 		gwin->paint();
 	}
 }

--- a/effects.cc
+++ b/effects.cc
@@ -79,10 +79,9 @@ void Effects_manager::add_text(
 		[&](const auto& el) { return el->is_text(item); }) != texts.cend())
 		return; // Already have text on this.
 
-	auto *txt = new Text_effect(msg, item);
 //	txt->paint(this);        // Draw it.
 //	painted = 1;
-	add_text_effect(txt);
+	texts.emplace_front(std::make_unique<Text_effect>(msg, item));
 }
 
 /**
@@ -96,10 +95,12 @@ void Effects_manager::add_text(
     const char *msg,
     int x, int y
 ) {
-	auto *txt = new Text_effect(msg,
-	                                   gwin->get_scrolltx() + x / c_tilesize,
-	                                   gwin->get_scrollty() + y / c_tilesize);
-	add_text_effect(txt);
+	                                   
+	texts.emplace_front(std::make_unique<Text_effect>(
+		msg,
+		gwin->get_scrolltx() + x / c_tilesize,
+		gwin->get_scrollty() + y / c_tilesize)
+	);
 }
 
 /**
@@ -151,7 +152,7 @@ void Effects_manager::remove_text_effect(
 	if (itemToDelete == texts.end())
 		return;
 	else {
-		remove_text_effect(*itemToDelete);
+		remove_text_effect((*itemToDelete).get());
 		gwin->paint();
 	}
 }
@@ -183,8 +184,7 @@ void Effects_manager::remove_text_effect(
 ) {
 	if (txt->in_queue())
 		gwin->get_tqueue()->remove(txt);
-	texts.remove(txt);
-	delete txt;
+	texts.remove_if([&](const auto& el) { return el.get() == txt; });
 }
 
 /**
@@ -202,7 +202,7 @@ void Effects_manager::remove_all_effects(
 		effects = next;
 	}
 	std::for_each(texts.begin(), texts.end(),
-			[&](auto& txt){ remove_text_effect(txt); }
+			[&](auto& txt){ remove_text_effect(txt.get()); }
 	);
 	if (repaint)
 		gwin->paint();      // Just paint whole screen.
@@ -216,7 +216,7 @@ void Effects_manager::remove_text_effects(
 ) {
 
 	std::for_each(texts.begin(), texts.end(),
-			[&](auto& txt){ remove_text_effect(txt); }
+			[&](auto& txt){ remove_text_effect(txt.get()); }
 	);
 	gwin->set_all_dirty();
 }

--- a/effects.cc
+++ b/effects.cc
@@ -981,10 +981,9 @@ void Homing_projectile::paint(
  */
 
 Rectangle Text_effect::Figure_text_pos() {
-	Game_window *gwin = Game_window::get_instance();
     Game_object_shared item_obj = item.lock();
 	if (item_obj) {
-		Gump_manager *gumpman = gwin->get_gump_man();
+		Gump_manager *gumpman = gwin.get_gump_man();
 		// See if it's in a gump.
 		Gump *gump = gumpman->find_gump(item_obj.get());
 		if (gump)
@@ -992,15 +991,15 @@ Rectangle Text_effect::Figure_text_pos() {
 		else {
 			Game_object *outer = item_obj->get_outermost();
 			if (!outer->get_chunk()) return pos;
-			Rectangle r = gwin->get_shape_rect(outer);
-			r.x -= gwin->get_scrolltx_lo();
-			r.y -= gwin->get_scrollty_lo();
+			Rectangle r = gwin.get_shape_rect(outer);
+			r.x -= gwin.get_scrolltx_lo();
+			r.y -= gwin.get_scrollty_lo();
 			return r;
 		}
 	} else {
 		int x;
 		int y;
-		gwin->get_shape_location(tpos, x, y);
+		gwin.get_shape_location(tpos, x, y);
 		return Rectangle(x, y, c_tilesize, c_tilesize);
 	}
 }
@@ -1011,12 +1010,11 @@ Rectangle Text_effect::Figure_text_pos() {
 
 void Text_effect::add_dirty(
 ) {
-	Game_window *gwin = Game_window::get_instance();
 	// Repaint slightly bigger rectangle.
 	Rectangle rect(pos.x - c_tilesize,
 	               pos.y - c_tilesize,
 	               width + 2 * c_tilesize, height + 2 * c_tilesize);
-	gwin->add_dirty(gwin->clip_to_win(rect));
+	gwin.add_dirty(gwin.clip_to_win(rect));
 }
 
 /**
@@ -1027,12 +1025,11 @@ void Text_effect::init(
 ) {
 	set_always(true);       // Always execute in time queue, even
 	//   when paused.
-	Game_window *gwin = Game_window::get_instance();
 	width = 8 + sman->get_text_width(0, msg.c_str());
 	height = 8 + sman->get_text_height(0);
 	add_dirty();            // Force first paint.
 	// Start immediately.
-	gwin->get_tqueue()->add(Game::get_ticks(), this);
+	gwin.get_tqueue()->add(Game::get_ticks(), this);
 	if (msg[0] == '@')
 		msg[0] = '"';
 	int len = msg.size();
@@ -1073,7 +1070,6 @@ void Text_effect::handle_event(
     uintptr udata          // Ignored.
 ) {
 	ignore_unused_variable_warning(curtime, udata);
-	Game_window *gwin = Game_window::get_instance();
 	if (++num_ticks == 10) {    // About 1-2 seconds.
 		// All done.
 		add_dirty();
@@ -1081,7 +1077,7 @@ void Text_effect::handle_event(
 		return;
 	}
 	// Back into queue.
-	gwin->get_tqueue()->add(Game::get_ticks() + gwin->get_std_delay(), this);
+	gwin.get_tqueue()->add(Game::get_ticks() + gwin.get_std_delay(), this);
 
 	update_dirty();
 }

--- a/effects.cc
+++ b/effects.cc
@@ -293,7 +293,6 @@ void Effects_manager::update_dirty_text(
 	std::for_each(texts.begin(), texts.end(),
 			[](auto& txt) { txt->update_dirty(); }
 	);
-
 }
 /**
  *  Some special effects may not need painting.
@@ -1766,7 +1765,6 @@ void Earthquake::handle_event(
 		eqsoundonce = 0;
 		delete this;
 	}
-
 }
 
 /**

--- a/effects.cc
+++ b/effects.cc
@@ -132,16 +132,6 @@ void Effects_manager::add_effect(
 }
 
 /**
- *  Add a text effect at the start of the chain.
- */
-
-void Effects_manager::add_text_effect(
-    Text_effect *effect
-) {
-	texts.emplace_front(effect);
-}
-
-/**
  *  Remove a given object's text effect.
  */
 

--- a/effects.cc
+++ b/effects.cc
@@ -91,7 +91,7 @@ void Effects_manager::add_text(
  *  @param y        y coord. on screen.
  */
 
-inline void Effects_manager::add_text(
+void Effects_manager::add_text(
     const char *msg,
     int x, int y
 ) {
@@ -1807,4 +1807,3 @@ void Fire_field_effect::handle_event(
 		gwin->get_tqueue()->add(curtime + gwin->get_std_delay(), this, udata);
 	}
 }
-

--- a/effects.h
+++ b/effects.h
@@ -28,6 +28,7 @@
 #include "rect.h"
 #include "tqueue.h"
 #include "tiles.h"
+#include <list>
 
 class Xform_palette;
 class PathFinder;
@@ -47,9 +48,9 @@ using Game_object_weak = std::weak_ptr<Game_object>;
 class Effects_manager {
 	Game_window *gwin;      // Handy pointer.
 	Special_effect *effects;    // Sprite effects, projectiles, etc.
-	Text_effect *texts;     // Text snippets.
+	std::list<Text_effect*> texts;     // Text snippets.
 public:
-	Effects_manager(Game_window *g) : gwin(g), effects(nullptr), texts(nullptr)
+	Effects_manager(Game_window *g) : gwin(g), effects(nullptr), texts{}
 	{  }
 	~Effects_manager();
 	// Add text item.
@@ -210,7 +211,6 @@ public:
  *  Game_window.
  */
 class Text_effect : public Time_sensitive, public Game_singletons {
-	Text_effect *next, *prev;   // All of them are chained together.
 	std::string msg;        // What to print.
 	Game_object_weak item;      // Item text is on.  May be null.
 	Tile_coord tpos;        // Position to display it at.

--- a/effects.h
+++ b/effects.h
@@ -29,6 +29,7 @@
 #include "tqueue.h"
 #include "tiles.h"
 #include <list>
+#include <memory>
 
 class Xform_palette;
 class PathFinder;
@@ -48,7 +49,7 @@ using Game_object_weak = std::weak_ptr<Game_object>;
 class Effects_manager {
 	Game_window *gwin;      // Handy pointer.
 	Special_effect *effects;    // Sprite effects, projectiles, etc.
-	std::list<Text_effect*> texts;     // Text snippets.
+	std::list<std::unique_ptr<Text_effect>> texts;     // Text snippets.
 public:
 	Effects_manager(Game_window *g) : gwin(g), effects(nullptr), texts{}
 	{  }

--- a/effects.h
+++ b/effects.h
@@ -221,10 +221,11 @@ class Text_effect : public Time_sensitive, public Game_singletons {
 	void add_dirty();
 	void init();
 	Rectangle Figure_text_pos();
+	Game_window& gwin;
 public:
 	friend class Effects_manager;
-	Text_effect(const std::string &m, Game_object *it);
-	Text_effect(const std::string &m, int t_x, int t_y);
+	Text_effect(const std::string &m, Game_object *it, Game_window& gwin_);
+	Text_effect(const std::string &m, int t_x, int t_y, Game_window& gwin_);
 	// At timeout, remove from screen.
 	void handle_event(unsigned long curtime, uintptr udata) override;
 	// Render.
@@ -234,6 +235,7 @@ public:
 	    return it == item.lock().get();
 	}
 	virtual void update_dirty();
+	~Text_effect() override;
 };
 
 /*

--- a/effects.h
+++ b/effects.h
@@ -59,7 +59,6 @@ public:
 	void add_text(const char *msg, int x, int y);
 	void center_text(const char *msg);
 	void add_effect(Special_effect *effect);
-	void add_text_effect(Text_effect *effect);
 	void remove_text_effect(Game_object *item);
 	// Remove text item & delete it.
 	void remove_effect(Special_effect *effect);

--- a/effects.h
+++ b/effects.h
@@ -222,7 +222,6 @@ class Text_effect : public Time_sensitive, public Game_singletons {
 	Rectangle Figure_text_pos();
 	Game_window& gwin;
 public:
-	friend class Effects_manager;
 	Text_effect(const std::string &m, Game_object *it, Game_window& gwin_);
 	Text_effect(const std::string &m, int t_x, int t_y, Game_window& gwin_);
 	// At timeout, remove from screen.

--- a/effects.h
+++ b/effects.h
@@ -51,7 +51,7 @@ class Effects_manager {
 	Special_effect *effects;    // Sprite effects, projectiles, etc.
 	std::list<std::unique_ptr<Text_effect>> texts;     // Text snippets.
 public:
-	Effects_manager(Game_window *g) : gwin(g), effects(nullptr), texts{}
+	Effects_manager(Game_window *g) : gwin(g), effects(nullptr)
 	{  }
 	~Effects_manager();
 	// Add text item.

--- a/effects.h
+++ b/effects.h
@@ -220,10 +220,10 @@ class Text_effect : public Time_sensitive, public Game_singletons {
 	void add_dirty();
 	void init();
 	Rectangle Figure_text_pos();
-	Game_window& gwin;
+	Game_window *gwin;
 public:
-	Text_effect(const std::string &m, Game_object *it, Game_window& gwin_);
-	Text_effect(const std::string &m, int t_x, int t_y, Game_window& gwin_);
+	Text_effect(const std::string &m, Game_object *it, Game_window* gwin_);
+	Text_effect(const std::string &m, int t_x, int t_y, Game_window* gwin_);
 	// At timeout, remove from screen.
 	void handle_event(unsigned long curtime, uintptr udata) override;
 	// Render.


### PR DESCRIPTION
I thought it might be reasonable to simplify the code by using STL instead of hand-made linked lists.
On top of that, I have added some RAII - hopefully - and simplified the code even more.
Special_effects to go, they are a logical next step, but I prefer to keep those PRs separate for clarity (and I'm certain there's at least one more place in the code with hand-made lists).
If you prefer it organized in any other way - I'm open for suggestions.

As for the code itself - lambda capture is a matter of taste, I decided to do it by value as raw pointers are dealt here with.
What I also do necessarily like about readability is the `remove`/`remove_if` member call on list, and I was a bit tempted to change that to standard erase/remove idiom (as done e.g. with `vector`)...