### PR TITLE
Prototype: remove checks for weather effects

### DIFF
--- a/effects.cc
+++ b/effects.cc
@@ -224,7 +224,7 @@ void Effects_manager::remove_weather_effects(
 	Actor *main_actor = gwin->get_main_actor();
 	Tile_coord apos = main_actor ? main_actor->get_tile()
 	                  : Tile_coord(-1, -1, -1);
-	auto removal_iterator = std::remove_if(
+	auto removal_iterator = std::stable_partition(
 		weather_effects.begin(),
 		weather_effects.end(),
 		[&](const auto& ef) {

--- a/effects.cc
+++ b/effects.cc
@@ -245,12 +245,22 @@ void Effects_manager::remove_weather_effects(
 
 void Effects_manager::remove_usecode_lightning(
 ) {
-	effects.remove_if([](const auto& ef) {
+	auto lightning_begin = std::stable_partition(
+		weather_effects.begin(),
+		weather_effects.end(),
+		[](auto&& ef) {
 			return ef->is_usecode_lightning();
-	});
-    weather_effects.remove_if([](const auto& ef) {
-			return ef->is_usecode_lightning();
-	});
+		}
+	);
+	auto wend = weather_effects.end();
+	std::for_each(
+		lightning_begin,
+		wend,
+		[&](auto&& el) {
+			effects.remove(el.get());
+		}
+	);
+	weather_effects.erase(lightning_begin, wend);
 	gwin->set_all_dirty();
 }
 

--- a/effects.h
+++ b/effects.h
@@ -89,9 +89,6 @@ public:
 	~Special_effect() override;
 	// Render.
 	virtual void paint();
-	virtual bool is_usecode_lightning() const {
-		return false;
-	}
 };
 
 /*
@@ -251,6 +248,7 @@ public:
 	Weather_effect(int duration, int delay, int n, Game_object *egg = nullptr);
 	// Avatar out of range?
 	bool out_of_range(Tile_coord &avpos, int dist);
+	virtual bool is_usecode_lightning() const { return false; }
 	int get_num() {
 		return num;
 	}

--- a/effects.h
+++ b/effects.h
@@ -41,6 +41,7 @@ class Actor;
 class Special_effect;
 class Weather_effect;
 class Text_effect;
+class Paintable_effect;
 
 using Game_object_weak = std::weak_ptr<Game_object>;
 
@@ -51,7 +52,7 @@ class Effects_manager {
 	Game_window *gwin;      // Handy pointer.
 	std::list<std::unique_ptr<Weather_effect>> weather_effects;    // Sprite effects, projectiles, etc.
 	std::list<std::unique_ptr<Special_effect>> other_effects;    // Sprite effects, projectiles, etc.
-	std::list<Special_effect*> effects;
+	std::list<Paintable_effect*> effects;
 	std::list<std::unique_ptr<Text_effect>> texts;     // Text snippets.
 public:
 	Effects_manager(Game_window *g) : gwin(g)
@@ -62,10 +63,11 @@ public:
 	void add_text(const char *msg, int x, int y);
 	void center_text(const char *msg);
 	void add_effect(std::unique_ptr<Special_effect> effect);
-	void add_weather_effect(std::unique_ptr<Weather_effect> effect);
+	void add_effect(std::unique_ptr<Weather_effect> effect);
 	void remove_text_effect(Game_object *item);
 	// Remove text item & delete it.
 	void remove_effect(Special_effect *effect);
+	void remove_effect(Weather_effect *effect);
 	void remove_text_effect(Text_effect *txt);
 	void remove_all_effects(bool repaint = false);
 	void remove_text_effects();
@@ -81,14 +83,24 @@ public:
 /*
  *  Base class for special-effects:
  */
-class Special_effect : public Time_sensitive, public Game_singletons {
+class Paintable_effect
+{
+public:
+	virtual void paint();
+protected:
+	~Paintable_effect() = default;
+};
+
+class Special_effect
+	: public Time_sensitive
+	, public Game_singletons
+	, public Paintable_effect
+{
 protected:
 	Game_window *gwin;
 public:
 	Special_effect();
-	~Special_effect() override;
-	// Render.
-	virtual void paint();
+	virtual ~Special_effect();
 };
 
 /*
@@ -239,8 +251,13 @@ public:
 /*
  *  Weather.
  */
-class Weather_effect : public Special_effect {
+class Weather_effect
+	: public Time_sensitive
+	, public Game_singletons
+	, public Paintable_effect
+{
 protected:
+	Game_window *gwin;
 	uint32 stop_time;       // Time in 1/1000 secs. to stop.
 	int num;            // Weather ID (0-6), or -1.
 	Tile_coord eggloc;      // Location of egg that started this.
@@ -252,6 +269,7 @@ public:
 	int get_num() {
 		return num;
 	}
+	virtual ~Weather_effect();
 };
 
 /*

--- a/effects.h
+++ b/effects.h
@@ -39,6 +39,7 @@ class Image_window8;
 class Shape_frame;
 class Actor;
 class Special_effect;
+class Weather_effect;
 class Text_effect;
 
 using Game_object_weak = std::weak_ptr<Game_object>;
@@ -48,7 +49,9 @@ using Game_object_weak = std::weak_ptr<Game_object>;
  */
 class Effects_manager {
 	Game_window *gwin;      // Handy pointer.
-	std::list<std::unique_ptr<Special_effect>> effects;    // Sprite effects, projectiles, etc.
+	std::list<std::unique_ptr<Weather_effect>> weather_effects;    // Sprite effects, projectiles, etc.
+	std::list<std::unique_ptr<Special_effect>> other_effects;    // Sprite effects, projectiles, etc.
+	std::list<Special_effect*> effects;
 	std::list<std::unique_ptr<Text_effect>> texts;     // Text snippets.
 public:
 	Effects_manager(Game_window *g) : gwin(g)
@@ -59,6 +62,7 @@ public:
 	void add_text(const char *msg, int x, int y);
 	void center_text(const char *msg);
 	void add_effect(std::unique_ptr<Special_effect> effect);
+	void add_weather_effect(std::unique_ptr<Weather_effect> effect);
 	void remove_text_effect(Game_object *item);
 	// Remove text item & delete it.
 	void remove_effect(Special_effect *effect);
@@ -85,9 +89,6 @@ public:
 	~Special_effect() override;
 	// Render.
 	virtual void paint();
-	virtual bool is_weather() const {  // Need to distinguish weather.
-		return false;
-	}
 	virtual bool is_usecode_lightning() const {
 		return false;
 	}
@@ -250,9 +251,6 @@ public:
 	Weather_effect(int duration, int delay, int n, Game_object *egg = nullptr);
 	// Avatar out of range?
 	bool out_of_range(Tile_coord &avpos, int dist);
-	bool is_weather() const override {
-		return true;
-	}
 	int get_num() {
 		return num;
 	}


### PR DESCRIPTION
@marzojr
Early stage of prototype, lots to do still,
so please don't be too harsh on the review, it is
not meant to be merged yet; I wanted to consult if
you like the whole idea, if so, I will be continuing work
on this brach. Otherwise, I will simple delete that.

The whole concept is this:
there is a `paintable` interface, `Weather_effect`
class and `Special_effect` class (name to be decided,
can be `Other_effect`, anything really):
`class Weather_effect : public paintable`
`class Other_effect : public paintable`.
Now, there are three lists:
`list<smartptr<Weather_effect>> //obvious`
`list<smartptr<Other_effect>> //obvious`
`list<paintable*> paintables //pointers to both only for painting`.
Adding via overloaded methods (not yet added here).
Pardon the `dynamic_cast`, it will disappear once
the class hierarchy is remade.

Potentially (but not sure now) this can additionally
be wrapped into helper class, say ManagedEffect<T>,
that would store a reference to `paintables` and autodelete
the observer pointer from there once the effect is removed
from its corresponding unique_ptr list.

Second thought: I wonder if `remove_effect` should not be
changed to sth like `relaseManagedEffect` and return the smart
pointer. This way it could return it in `handle_event` so
it should be more explicit that object is soon going to
"commit suicide" (by leaving scope in unique_ptr), thus leading
to less likely use_after_free (see previous PR).