### PR TITLE
[1.6.x branch] Fix compile for wuc.cc on Xcode12

### DIFF
--- a/tools/wuc.cc
+++ b/tools/wuc.cc
@@ -29,7 +29,7 @@ static const char *compiler_table[] = {
 
 char token[TOKEN_LENGTH], *token2, curlabel[256], indata;
 int pass,offset;
-unsigned byte, word, funcnum, datasize, codesize;
+unsigned byteval, word, funcnum, datasize, codesize;
 int extended;
 
 char labels[MAX_LABELS][10];
@@ -249,8 +249,8 @@ int main(int argc,char *argv[]) {
 					for (i = 1; i < strlen(token); i++)
 						emit_byte(token[i]);
 				else {
-					sscanf(token, "%x", &byte);
-					emit_byte(byte);
+					sscanf(token, "%x", &byteval);
+					emit_byte(byteval);
 				}
 			} else if (!strcasecmp(token, "dw")) {
 				read_token(fi);


### PR DESCRIPTION
The 1.6 release fails to complie on Xcode 12.1 because of "byte" conflicting with "std::byte".  I noticed that this was already
renamed "byteval" in the master branch (part of the larger set of changes in d7998ecace00daa0469494377f916db386396406). I thought it would be useful to backport this to the v1.6.x branch as well.

I don't know anything about exult's release cycle or if there is going to be any more releases from 1.6.x but I am just trying to get the Homebrew formula for exult building again.