### PR TITLE
ExultStudio : Fixes in Shape Groups and in Shape Editor

### DIFF
--- a/mapedit/exult_studio.glade
+++ b/mapedit/exult_studio.glade
@@ -449,6 +449,7 @@
     <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment24">
+    <property name="lower">-100</property>
     <property name="upper">100</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
@@ -1119,10 +1120,16 @@
         <col id="0" translatable="yes">Frame names</col>
       </row>
       <row>
+        <col id="0" translatable="yes">Frame usecode</col>
+      </row>
+      <row>
         <col id="0" translatable="yes">Object paperdoll</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Warrmth</col>
+        <col id="0" translatable="yes">Warmth</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Light</col>
       </row>
       <row>
         <col id="0" translatable="yes">Unusable</col>

--- a/mapedit/shapeedit.cc
+++ b/mapedit/shapeedit.cc
@@ -1448,7 +1448,7 @@ C_EXPORT void on_shinfo_brightness_list_cursor_changed(
 static inline void Get_warmth_fields(
     ExultStudio *studio,
     unsigned int &frnum,
-    unsigned int *warm = nullptr
+    int *warm = nullptr
 ) {
 	bool anyfr = studio->get_toggle("shinfo_warmth_frame_type");
 	frnum = anyfr ? ~0u :
@@ -1477,7 +1477,7 @@ C_EXPORT void on_shinfo_warmth_update_clicked(
 	ignore_unused_variable_warning(btn, user_data);
 	ExultStudio *studio = ExultStudio::get_instance();
 	unsigned int newfrnum;
-	unsigned int newwarm;
+	int newwarm;
 	Get_warmth_fields(studio, newfrnum, &newwarm);
 
 	GtkTreeView *warmtree = GTK_TREE_VIEW(
@@ -1493,10 +1493,10 @@ C_EXPORT void on_shinfo_warmth_update_clicked(
 		else
 			gtk_tree_store_insert_before(store, &newiter, nullptr, iter);
 		gtk_tree_store_set(store, &newiter, WARM_FRAME_COLUMN, static_cast<int>(newfrnum),
-		                   WARM_VALUE_COLUMN, static_cast<int>(newwarm), WARM_FROM_PATCH, 1,
+		                   WARM_VALUE_COLUMN, newwarm, WARM_FROM_PATCH, 1,
 		                   WARM_MODIFIED, 1, -1);
 	} else {
-		unsigned int warm;
+		int warm;
 		gtk_tree_model_get(model, iter, WARM_VALUE_COLUMN, &warm, -1);
 		if (warm != newwarm)
 			gtk_tree_store_set(store, iter, WARM_VALUE_COLUMN, newwarm,
@@ -1936,7 +1936,7 @@ C_EXPORT void on_shinfo_frameusecode_list_cursor_changed(
 	gtk_tree_model_get_iter(model, &iter, path);
 	gtk_tree_path_free(path);
 	gtk_tree_model_get(model, &iter, FRUC_FRAME_COLUMN, &frnum,
-	                   FRUC_QUAL_COLUMN, &qual, FRUC_FROM_PATCH, &ucfun, -1);
+	                   FRUC_QUAL_COLUMN, &qual, FRUC_USEFUN_COLUMN, &ucfun, -1);
 	Set_frameusecode_fields(frnum, qual, ucfun);
 }
 

--- a/mapedit/shapegroup.cc
+++ b/mapedit/shapegroup.cc
@@ -159,6 +159,11 @@ Shape_group::Shape_group(
 				if (vgafile->get_info(i).has_frame_name_info())
 					add(i);
 			break;
+		case frameusecode_group:
+			for (i = 0; i < cnt; i++)
+				if (vgafile->get_info(i).has_frame_usecode_info())
+					add(i);
+			break;
 		case objpaperdoll_group:
 			for (i = 0; i < cnt; i++)
 				if (vgafile->get_info(i).has_paperdoll_info())
@@ -167,6 +172,11 @@ Shape_group::Shape_group(
 		case warmth_group:
 			for (i = 0; i < cnt; i++)
 				if (vgafile->get_info(i).has_warmth_info())
+					add(i);
+			break;
+		case light_group:
+			for (i = 0; i < cnt; i++)
+				if (vgafile->get_info(i).has_light_info())
 					add(i);
 			break;
 		}

--- a/mapedit/shapegroup.h
+++ b/mapedit/shapegroup.h
@@ -86,8 +86,10 @@ public:
 		frameflags_group,
 		framehps_group,
 		framenames_group,
+		frameusecode_group,
 		objpaperdoll_group,
 		warmth_group,
+		light_group,
 		last_builtin_group
 	};
 };


### PR DESCRIPTION
  Commit 1 of 1 :
    mapedit/shapedit.cc + exult_studio.glade
      Negative Warmth values : unsigned int -> int, lower bound of adjustment
      Frame usecode : Fix wrong column to retrieve function name
    mapedit/shapegroup.cc+h + exult_studio.glade
      Add two builtin groups for Frame usecode and Light

Fixes issue #73