### PR TITLE
Gdk-pixbuf is an independent package from Gdk

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -293,13 +293,13 @@ else
 fi
 
 # ---------------------------------------------------------------------
-# Gdk (for Gnome shp thumbnailer)
+# Gdk-Pixbuf (for Gnome shp thumbnailer)
 # ---------------------------------------------------------------------
 
 if test "x$PKG_CONFIG" != "x"; then
-	PKG_CHECK_MODULES(GDK, gdk-3.0 >= 3.16, have_gdk=yes, have_gdk=no)
+	PKG_CHECK_MODULES(GDK_PIXBUF, gdk-pixbuf-2.0, have_gdk_pixbuf=yes, have_gdk_pixbuf=no)
 else
-	have_gdk=no
+	have_gdk_pixbuf=no
 fi
 
 # ---------------------------------------------------------------------
@@ -971,9 +971,9 @@ AC_ARG_ENABLE(gnome-shp-thumbnailer, AS_HELP_STRING([--enable-gnome-shp-thumbnai
 AC_MSG_CHECKING([whether to build the Gnome SHP Thumbnailer])
 if test x$enable_gnome_shp_thumbnailer = xyes; then
 	AC_MSG_RESULT(yes)
-	if test x$have_gdk = xno; then
-		echo "Umm, but we don't have any Gdk stuff."
-		echo "Try again, either with Gdk-3.16, or with --disable-gnome-shp-thumbnailer"
+	if test x$have_gdk_pixbuf = xno; then
+		echo "Umm, but we don't have any Gdk-Pixbuf stuff."
+		echo "Try again, either with Gdk-Pixbuf-2.0, or with --disable-gnome-shp-thumbnailer"
 		exit 1
 	fi
 	AM_CONDITIONAL(BUILD_GTHUMB, true)
@@ -1131,8 +1131,8 @@ if test x$have_gtk = xyes; then
 echo GLIB....................... : `$PKG_CONFIG --modversion glib-2.0`
 echo GTK+....................... : `$PKG_CONFIG --modversion gtk+-3.0`
 fi
-if test x$have_gdk = xyes; then
-echo GDK ....................... : `$PKG_CONFIG --modversion gdk-3.0`
+if test x$have_gdk_pixbuf = xyes; then
+echo GDK-Pixbuf................. : `$PKG_CONFIG --modversion gdk-pixbuf-2.0`
 fi
 echo 
 echo Build tools................ : $enable_tools

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(srcdir)/../headers -I$(srcdir)/../files -I$(srcdir)/../usecode \
 	-I$(srcdir)/.. -I$(srcdir)/../shapes -I$(srcdir)/../imagewin \
 	-I$(srcdir)/../conf $(DEBUG_FLAGS) $(CPPFLAGS) $(SDL_CFLAGS) \
-	$(GDK_CFLAGS)
+	$(GDK_PIXBUF_CFLAGS)
 
 if HAVE_PNG
 IPACK = ipack
@@ -50,7 +50,7 @@ gnome_shp_thumbnailer_LDADD = \
 	../shapes/libshapes.la \
 	../imagewin/libimagewin.la \
 	../files/libu7file.la \
-	-lpng -lz $(SYSLIBS) $(GDK_LIBS)
+	-lpng -lz $(SYSLIBS) $(GDK_PIXBUF_LIBS)
 
 if BUILD_GTHUMB
 ## Does not work:


### PR DESCRIPTION
  Commit 1 of 1 :
    configure.ac
      Replace the pkg-config requirement of GDK by GDK-PIXBUF
    tools/Makefile.am
      Replace the CFLAGS/LIBS variables from pkg-config GDK by GDK-PIXBUF