### PR TITLE
Silence g++ and clang++ over gnome_shp_thumbnailer.cc

### DIFF
--- a/tools/gnome_shp_thumbnailer.cc
+++ b/tools/gnome_shp_thumbnailer.cc
@@ -29,9 +29,13 @@
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wcast-qual"
+#if !defined(__llvm__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#else
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
 #endif  // __GNUC__
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #ifdef __GNUC__


### PR DESCRIPTION
  Commit 1 of 1 :
    tools/gnome_shp_thumbnailer.cc
      Use the same pragma gcc diagnostic ignored as mapedit/studio.cc