### PR TITLE
ExultStudio : Fix initial jump of reference point in Locator used in Drag

### DIFF
--- a/mapedit/locator.cc
+++ b/mapedit/locator.cc
@@ -547,6 +547,6 @@ gboolean Locator::mouse_motion(
 	if (!dragging || !(state & GDK_BUTTON1_MASK))
 		return FALSE;       // Not dragging with left button.
 	// Delay sending location to Exult.
-	goto_mouse(mx + drag_relx, my + drag_rely, true);
+	goto_mouse(mx - drag_relx, my - drag_rely, true);
 	return TRUE;
 }


### PR DESCRIPTION
Studio : Locator window, use Drag mode to move the reference location of the Avatar :
  The reference location jumps at start of the Drag if the cursor was not exactly centered on the reference location.
Reason : the Delta ( drag_relx & drag_rely ) is applied with the wrong sign, it is added, should be subtracted.

  Commit 1 of 1 :
    mapedit/locator.cc
      Subtract drag_relx/y to mx/y instead of adding them.