### PR TITLE
Install three Documentation HTML and dependent images in Linux

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,7 +1,33 @@
 man_MANS = exult.6 expack.1 ipack.1 shp2pcx.1 splitshp.1 textpack.1 exult_studio.1 ucc.1
 
+nobase_doc_DATA = \
+	exult_studio.html		\
+	faq.html			\
+	ReadMe.html			\
+	images/back.gif			\
+	images/docs01.png		\
+	images/docs02.png		\
+	images/docs03.png		\
+	images/docs04.png		\
+	images/docs05.png		\
+	images/docs06.png		\
+	images/exult_logo.gif		\
+	images/studio01.png		\
+	images/studio02.png		\
+	images/studio03.png		\
+	images/studio04.png		\
+	images/studio05.png		\
+	images/studio06.png		\
+	images/studio07.png		\
+	images/studio08.png		\
+	images/studio09.png		\
+	images/studio10.png		\
+	images/studiobgiregs.png	\
+	images/studiosiiregs.png
+
 EXTRA_DIST =		\
-	$(man_MANS)
+	$(man_MANS)	\
+	$(nobase_doc_DATA)
 
 #	FLI.txt 	\
 #	exscript.txt	\


### PR DESCRIPTION
To align to Win32 and macOS/iOS :
     install Readme.html ( Exult ), faq.html ( FAQ ), exult_studio.html( ExultStudio ) and dependent images
     into /usr/share/doc/exult and /usr/share/doc/exult/images on Linux.
