### PR TITLE
FluidSynth MIDI : Use default SoundFont when no fluidsynth_soundfont

### DIFF
--- a/audio/midi_drivers/FMOplMidiDriver.cpp
+++ b/audio/midi_drivers/FMOplMidiDriver.cpp
@@ -223,11 +223,12 @@ int FMOplMidiDriver::open()
 		i.enabled = 1;
 		i.pitchbend = 0x2000;
 		i.pan = 64;
+		i.sustain = 0;
 	}
 
 	/* General init */
 	for (auto& i : chp) {
-		i = {-1, 0, 0, 0};
+		i = {-1, 0, 0, 0, false};
 	}
 
 	opl = FMOpl_Pentagram::makeAdLibOPL(sample_rate);

--- a/audio/midi_drivers/FMOplMidiDriver.h
+++ b/audio/midi_drivers/FMOplMidiDriver.h
@@ -76,7 +76,7 @@ private:
 		int inum;
 		xinstrument ins;
 		bool xmidi;
-		int	xmidi_bank;
+		int xmidi_bank;
 		int vol;
 		int expression;
 		int nshift;

--- a/audio/midi_drivers/FluidSynthMidiDriver.h
+++ b/audio/midi_drivers/FluidSynthMidiDriver.h
@@ -40,9 +40,10 @@ public:
 
 protected:
 	// Because GCC complains about casting from const to non-const...
-	void setInt(const char *name, int val);
-	void setNum(const char *name, double val);
-	void setStr(const char *name, const char *val);
+	int setInt(const char *name, int val);
+	int setNum(const char *name, double val);
+	int setStr(const char *name, const char *val);
+	int getStr(const char *name, char **pval);
 
 	// LowLevelMidiDriver implementation
 	int open() override;


### PR DESCRIPTION
  Some changes in MIDI for Exult :

- Put a cosmetic change in FMOpl MIDI to silence a compiler warning,
- Get the synth.default-soundfont in FluidSynth to supply a default SoundFont when fluidsynth_soundfont is missing in exult.cfg.
- Remove the explicit FluidSynth SoundFont unload that cause warnings.