### PR TITLE
Update all Makefile.am - Autotools driven Build for Linux and MacOSX

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/headers -I$(srcdir)/imagewin -I$(srcdir)/s
 	$(SDL_CFLAGS) $(VORBIS_CFLAGS) $(OGG_CFLAGS) $(INCDIRS) $(WINDOWING_SYSTEM) \
 	$(DEBUG_FLAGS) $(CPPFLAGS) -DEXULT_DATADIR=\"$(EXULT_DATADIR)\"
 
-CXXLINK = $(LIBTOOL) --mode=link $(CXXLD) $(AM_CXXFLAGS) $(DEBUG_FLAGS) $(CXXFLAGS) $(LDFLAGS) -o $(EXE_TARGET)
+CXXLINK = $(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) $(AM_CXXFLAGS) $(DEBUG_FLAGS) $(CXXFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $(EXE_TARGET)
 
 if BUILD_MODS
 MODSDIR=content
@@ -28,6 +28,7 @@ exult_SOURCES =	\
 	actors.h	\
 	args.cc		\
 	args.h		\
+	headers/array_size.h	\
 	browser.cc	\
 	browser.h	\
 	cheat.cc	\
@@ -37,13 +38,14 @@ exult_SOURCES =	\
 	combat.cc	\
 	combat.h	\
 	combat_opts.h	\
-	common_types.h	\
+	headers/common_types.h	\
 	dir.cc		\
 	dir.h		\
 	drag.cc		\
 	drag.h		\
 	effects.cc	\
 	effects.h	\
+	headers/exceptions.h	\
 	exult.cc	\
 	exult.h		\
 	exulticon.h	\
@@ -63,8 +65,10 @@ exult_SOURCES =	\
 	gamerend.h	\
 	gamewin.cc	\
 	gamewin.h	\
+	headers/gamma.h	\
 	hash_utils.h	\
-	ignore_unused_variable_warning.h	\
+	headers/ignore_unused_variable_warning.h	\
+	headers/ios_state.hpp	\
 	istring.cc	\
 	istring.h	\
 	keys.cc		\
@@ -87,8 +91,8 @@ exult_SOURCES =	\
 	party.h		\
 	paths.cc	\
 	paths.h		\
+	headers/pent_include.h	\
 	readnpcs.cc	\
-	ready.h		\
 	rect.h		\
 	schedule.cc	\
 	schedule.h	\
@@ -102,8 +106,8 @@ exult_SOURCES =	\
 	tqueue.h	\
 	txtscroll.cc	\
 	txtscroll.h	\
-	verify.cc \
-	verify.h \
+	verify.cc	\
+	verify.h	\
 	version.cc	\
 	version.h
 
@@ -137,71 +141,146 @@ EXTRA_DIST = 	\
 	autogen.sh \
 	README \
 	FAQ \
+	README.md \
 	README.win32 \
 	README.MacOSX \
 	Makefile.common \
 	Makefile.mingw \
-	Makefile.studio.mingw \
 	Info.plist.in \
-	exult.spec \
-	windrag.cc	\
+	stamp-h.in \
+	windrag.cc \
 	windrag.h \
 	win32/exult.ico \
 	win32/exultico.rc \
 	win32/exultstudio.ico \
 	win32/exultstudioico.rc \
+	win32/exconfig.cc \
+	win32/exconfig.def \
+	win32/exconfig.h \
+	win32/exconfig.rc \
+	win32/exult.exe.manifest \
+	win32/exult_installer.iss \
+	win32/exult_shpplugin_installer.iss \
+	win32/exult_studio.exe.manifest \
+	win32/exult_studio_installer.iss \
+	win32/exult_tools_installer.iss \
+	win32/glib-xp.patch \
+	win32/README-SDL.txt \
 	macosx/exult.icns \
 	macosx/exult_studio_info.plist.in \
-	msvcstuff/expack.vcproj \
-	msvcstuff/Exult.vcproj \
-	msvcstuff/Exult.sln \
-	msvcstuff/Exult_bg_flx.vcproj \
-	msvcstuff/Exult_flx.vcproj \
-	msvcstuff/Exult_si_flx.vcproj \
-	msvcstuff/mklink.vcproj \
-	msvcstuff/msvc_kludges.cc \
-	msvcstuff/msvc_kludges.h \
-	msvcstuff/rip.vcproj \
-	msvcstuff/shp2pcx.vcproj \
-	msvcstuff/splitshp.vcproj \
-	msvcstuff/unistd.h \
-	msvcstuff/wuc.vcproj \
-	msvcstuff/Zip.vcproj \
-	msvcstuff/exconfig/exconfig.cpp \
-	msvcstuff/exconfig/exconfig.def \
-	msvcstuff/exconfig/exconfig.vcproj \
-	msvcstuff/exconfig/exconfig.h \
-	msvcstuff/exconfig/exconfig.rc \
-	msvcstuff/exconfig/resource.h \
-	msvcstuff/exconfig/StdAfx.cpp \
-	msvcstuff/exconfig/StdAfx.h \
-	msvc9/expack.vcproj \
-	msvc9/Exult.vcproj \
-	msvc9/Exult.sln \
-	msvc9/Exult_bg_flx.vcproj \
-	msvc9/Exult_flx.vcproj \
-	msvc9/Exult_si_flx.vcproj \
-	msvc9/mklink.vcproj \
-	msvc9/msvc_kludges.cc \
-	msvc9/msvc_kludges.h \
-	msvc9/rip.vcproj \
-	msvc9/shp2pcx.vcproj \
-	msvc9/splitshp.vcproj \
-	msvc9/unistd.h \
-	msvc9/wuc.vcproj \
-	msvc9/Zip.vcproj \
-	msvc9/exconfig/exconfig.cpp \
-	msvc9/exconfig/exconfig.def \
-	msvc9/exconfig/exconfig.vcproj \
-	msvc9/exconfig/exconfig.h \
-	msvc9/exconfig/exconfig.rc \
-	msvc9/exconfig/resource.h \
-	msvc9/exconfig/StdAfx.cpp \
-	msvc9/exconfig/StdAfx.h \
-	headers/common_types.h \
-	headers/exceptions.h \
-	headers/gamma.h	\
-	headers/pent_include.h \
+	macosx/diskback.png \
+	macosx/DS_Store \
+	macosx/exult_studio.bundle \
+	macosx/exult_studio_entitlements.plist \
+	macosx/exult_studio.icns \
+	macosx/exult_studio_launcher.sh \
+	msvcstuff/vs2019/.gitignore \
+	msvcstuff/vs2019/Exult.sln \
+	msvcstuff/vs2019/Exult.vcxproj \
+	msvcstuff/vs2019/Exult.vcxproj.filters \
+	msvcstuff/vs2019/dirent.h \
+	msvcstuff/vs2019/expack/expack.vcxproj \
+	msvcstuff/vs2019/expack/expack.vcxproj.filters \
+	msvcstuff/vs2019/msvc_include.h \
+	msvcstuff/vs2019/packages.config \
+	msvcstuff/vs2019/unistd.h \
+	ios/Exult.xcodeproj \
+	ios/Exult.xcodeproj/project.pbxproj \
+	ios/GamePadView.h \
+	ios/GamePadView.m \
+	ios/Images/Icon.png \
+	ios/Images/btn.png \
+	ios/Images/btnpressed.png \
+	ios/Images/dpadglass-east.png \
+	ios/Images/dpadglass-north.png \
+	ios/Images/dpadglass-northeast.png \
+	ios/Images/dpadglass-northwest.png \
+	ios/Images/dpadglass-south.png \
+	ios/Images/dpadglass-southeast.png \
+	ios/Images/dpadglass-southwest.png \
+	ios/Images/dpadglass-west.png \
+	ios/Images/dpadglass.png \
+	ios/Images/joypad-glass-east.png \
+	ios/Images/joypad-glass-north.png \
+	ios/Images/joypad-glass-northeast.png \
+	ios/Images/joypad-glass-northwest.png \
+	ios/Images/joypad-glass-south.png \
+	ios/Images/joypad-glass-southeast.png \
+	ios/Images/joypad-glass-southwest.png \
+	ios/Images/joypad-glass-west.png \
+	ios/Images/joypad-glass.png \
+	ios/Images/joythumb-glass.png \
+	ios/Info.plist \
+	ios/Media.xcassets/Contents.json \
+	ios/Media.xcassets/AppIcon.appiconset/Contents.json \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-20x20@1x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-20x20@3x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-29x29@1x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-29x29@2x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-29x29@3x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-40x40@1x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-40x40@2x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-40x40@3x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-57x57@1x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-57x57@2x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-60x60@2x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-60x60@3x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-72x72@1x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-72x72@2x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-76x76@1x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-76x76@2x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-App-83.5x83.5@2x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-AppStore.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-Small-50x50@1x.png \
+	ios/Media.xcassets/AppIcon.appiconset/Icon-Small-50x50@2x.png \
+	ios/SDL2/dummy \
+	ios/data/dummy \
+	ios/include/config.h \
+	ios/include/ios_utils.h \
+	ios/ios_utils.mm \
+	ios/libmt32emu/dummy \
+	ios/libmt32emu.xcodeproj/project.pbxproj \
+	ios/libogg/dummy \
+	ios/libogg.xcodeproj/project.pbxproj \
+	ios/libvorbis/dummy \
+	ios/libvorbis.xcodeproj/project.pbxproj \
+	mapedit/tools/mockup/LICENCE \
+	mapedit/tools/mockup/Makefile \
+	mapedit/tools/mockup/README \
+	mapedit/tools/mockup/defs.h \
+	mapedit/tools/mockup/main.h \
+	mapedit/tools/mockup/map.png \
+	mapedit/tools/mockup/mappings.txt \
+	mapedit/tools/mockup/mappings_alternative.txt \
+	mapedit/tools/mockup/main.c \
+	mapedit/tools/smooth/AUTHORS \
+	mapedit/tools/smooth/COPYING \
+	mapedit/tools/smooth/ChangeLog \
+	mapedit/tools/smooth/INSTALL \
+	mapedit/tools/smooth/README \
+	mapedit/tools/smooth/config.h \
+	mapedit/tools/smooth/globals.h \
+	mapedit/tools/smooth/image.h \
+	mapedit/tools/smooth/linked.h \
+	mapedit/tools/smooth/param.h \
+	mapedit/tools/smooth/plugin.h \
+	mapedit/tools/smooth/plugins/README \
+	mapedit/tools/smooth/plugins/README.Stream \
+	mapedit/tools/smooth/plugins/plugin_randomize.c \
+	mapedit/tools/smooth/plugins/plugin_smooth.c \
+	mapedit/tools/smooth/plugins/plugin_stream.c \
+	mapedit/tools/smooth/rough.bmp \
+	mapedit/tools/smooth/smooth.c \
+	mapedit/tools/smooth/smooth.h \
+	mapedit/tools/smooth/smooth.sln \
+	mapedit/tools/smooth/smooth.vcproj \
+	mapedit/tools/smooth/smoothed.bmp \
+	mapedit/tools/smooth/config.c \
+	mapedit/tools/smooth/image.c \
+	mapedit/tools/smooth/linked.c \
+	mapedit/tools/smooth/param.c \
+	mapedit/tools/smooth/plugin.c \
 	server/servewin32.cc \
 	server/servewin32.h
 

--- a/audio/Makefile.am
+++ b/audio/Makefile.am
@@ -16,7 +16,7 @@ libaudio_la_SOURCES =	\
 	conv.cc		\
 	conv.h		\
 	soundtest.cc	\
-	soundtest.h	    \
+	soundtest.h	\
 	convmusic.h     \
 	AudioChannel.cc \
 	AudioChannel.h  \
@@ -34,6 +34,8 @@ libaudio_la_SOURCES =	\
 	WavAudioSample.h
 
 EXTRA_DIST = 		\
+	module.mk	\
+	mtest		\
 	README
 
 CLEANFILES = *~

--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -23,6 +23,7 @@ confregress_LDADD =	\
 
 EXTRA_DIST = 		\
 	config.xml	\
+	module.mk	\
 	README
 
 CLEANFILES = *~

--- a/content/Makefile.am
+++ b/content/Makefile.am
@@ -1,2 +1,4 @@
 SUBDIRS = bg bgkeyring islefaq si sifixes
 
+EXTRA_DIST = makefile_builder.sh
+

--- a/content/bg/Makefile.am
+++ b/content/bg/Makefile.am
@@ -23,6 +23,11 @@ bgpatchdir = $(bgdir)/lbjoin/patch
 bgpatch_DATA = \
 	usecode	
 
+EXTRA_DIST = \
+	$(bg_DATA) \
+	Makefile.mingw \
+	$(USECODE_OBJECTS)
+
 CLEANFILES = \
 	usecode	
 

--- a/content/bgkeyring/Makefile.am
+++ b/content/bgkeyring/Makefile.am
@@ -165,6 +165,8 @@ MAINSHP_FLX_OBJECTS = \
 
 PAPERDOL_VGA_OBJECTS = \
 	src/graphics/paperdol.in	\
+	src/graphics/paperdol/Buckethead_Body_Paperdoll.shp	\
+	src/graphics/paperdol/Buckethead_Face_Paperdoll.shp	\
 	src/graphics/paperdol/Female_Paperdoll.shp	\
 	src/graphics/paperdol/FlyingCarpet.shp	\
 	src/graphics/paperdol/Laurianna_Paperdoll.shp	\
@@ -256,13 +258,15 @@ bgkeyring_DATA = \
 
 bgkeyringdatadir = $(bgkeyringdir)/Keyring/data
 
-bgkeyringdata_DATA = \
+nodist_bgkeyringdata_DATA = \
 	data/usecode	\
 	data/faces.vga	\
 	data/gumps.vga	\
 	data/mainshp.flx	\
 	data/paperdol.vga	\
-	data/shapes.vga	\
+	data/shapes.vga
+
+bgkeyringdata_DATA = \
 	data/armor.dat	\
 	data/occlude.dat	\
 	data/avatar_data.txt	\
@@ -305,6 +309,23 @@ bgkeyringdatamap01_DATA = \
 	data/map01/u7ifix77	\
 	data/map01/u7ifix7d	\
 	data/map01/u7map	
+
+EXTRA_DIST = \
+	Keyring.ico \
+	Keyring.png \
+	Makefile.mingw \
+	Readme.txt \
+	src/make.bat \
+	src/make.sh \
+	$(bgkeyringdatamap01_DATA) \
+	$(bgkeyringdata_DATA) \
+	$(bgkeyring_DATA) \
+	$(USECODE_OBJECTS) \
+	$(FACES_VGA_OBJECTS) \
+	$(GUMPS_VGA_OBJECTS) \
+	$(MAINSHP_FLX_OBJECTS) \
+	$(PAPERDOL_VGA_OBJECTS) \
+	$(SHAPES_VGA_OBJECTS)
 
 CLEANFILES = \
 	data/usecode	\

--- a/content/islefaq/Makefile.am
+++ b/content/islefaq/Makefile.am
@@ -28,10 +28,12 @@ islefaq_DATA = \
 
 islefaqpatchdir = $(islefaqdir)/islefaq/patch
 
-islefaqpatch_DATA = \
+nodist_islefaqpatch_DATA = \
 	patch/usecode	\
 	patch/faces.vga	\
-	patch/shapes.vga	\
+	patch/shapes.vga
+
+islefaqpatch_DATA = \
 	patch/initgame.dat	\
 	patch/ready.dat	\
 	patch/shpdims.dat	\
@@ -41,6 +43,14 @@ islefaqpatch_DATA = \
 	patch/u7ifix65	\
 	patch/u7map	\
 	patch/wihh.dat	
+
+EXTRA_DIST = \
+	Makefile.mingw \
+	$(islefaqpatch_DATA) \
+	$(islefaq_DATA) \
+	$(USECODE_OBJECTS) \
+	$(FACES_VGA_OBJECTS) \
+	$(SHAPES_VGA_OBJECTS)
 
 CLEANFILES = \
 	patch/usecode	\

--- a/content/si/Makefile.am
+++ b/content/si/Makefile.am
@@ -23,6 +23,11 @@ sipatchdir = $(sidir)/curecantra/patch
 sipatch_DATA = \
 	usecode	
 
+EXTRA_DIST = \
+	$(si_DATA) \
+	Makefile.mingw \
+	$(USECODE_OBJECTS)
+
 CLEANFILES = \
 	usecode	
 

--- a/content/sifixes/Makefile.am
+++ b/content/sifixes/Makefile.am
@@ -32,6 +32,11 @@ USECODE_OBJECTS = \
 	src/misc/egg_starting_hints.uc	\
 	src/misc/exchanged_item_list.uc	\
 	src/misc/fawn_tower_cleanup.uc	\
+	src/misc/draxinar_cloth_riddle.uc	\
+	src/misc/draxinar_earrings_riddle.uc	\
+	src/misc/egg_gwani_attack.uc	\
+	src/misc/egg_skullcrusher_automatons.uc	\
+	src/misc/gwani_cloak_check.uc	\
 	src/misc/inn_keys.uc	\
 	src/misc/location_ids.uc	\
 	src/misc/luther_return_shield.uc	\
@@ -46,6 +51,14 @@ USECODE_OBJECTS = \
 	src/npcs/iolo.uc	\
 	src/npcs/shamino.uc	\
 	src/npcs/thoxa.uc	\
+	src/npcs/bwundiai.uc	\
+	src/npcs/delin.uc	\
+	src/npcs/edrin.uc	\
+	src/npcs/kylista.uc	\
+	src/npcs/mwaerno.uc	\
+	src/npcs/myauri.uc	\
+	src/npcs/neyobi.uc	\
+	src/npcs/skullcrusher_automatons.uc	\
 	src/spells/spells.uc	\
 	src/usecode.uc	
 
@@ -78,12 +91,28 @@ sifixes_DATA = \
 
 sifixesdatadir = $(sifixesdir)/sifixes/data
 
-sifixesdata_DATA = \
+nodist_sifixesdata_DATA = \
 	data/usecode	\
 	data/gumps.vga	\
 	data/mainshp.flx	\
-	data/shapes.vga	\
+	data/shapes.vga
+
+sifixesdata_DATA = \
 	data/initgame.dat	
+
+EXTRA_DIST = \
+	Makefile.mingw \
+	Readme.txt \
+	sifixes.ico \
+	sifixes.png \
+	src/make.bat \
+	src/make.sh \
+	$(sifixesdata_DATA) \
+	$(sifixes_DATA) \
+	$(USECODE_OBJECTS) \
+	$(GUMPS_VGA_OBJECTS) \
+	$(MAINSHP_FLX_OBJECTS) \
+	$(SHAPES_VGA_OBJECTS)
 
 CLEANFILES = \
 	data/usecode	\

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -50,8 +50,6 @@ EXULT_BG_FLX_OBJECTS = \
 	bg/BGmap.shp \
 	bg/defaultkeys.txt	\
 	bg/u7menupal.pal \
-	bg/bg_paperdol.vga \
-	bg/bg_mr_faces.vga \
 	bg/bodies.txt \
 	bg/paperdol_info.txt \
 	bg/shape_files.txt \
@@ -60,9 +58,7 @@ EXULT_BG_FLX_OBJECTS = \
 	bg/blends.dat \
 	bg/container.dat \
 	bg/autonotes.txt \
-	bg/intro_hand.shp \
-	bg/introsfx_mt32.flx \
-	bg/introsfx_sb.flx
+	bg/intro_hand.shp
 
 EXULT_BG_INTROSFX_MT32_OBJECTS = \
 	bg/introsfx_mt.in \
@@ -175,6 +171,7 @@ EXULT_BG_MR_FACES_VGA_OBJECTS = \
 	bg/bg_mr_faces.in
 
 ESTUDIO_NEW_FILES = \
+	estudio/new/avatar_data.txt \
 	estudio/new/combos.flx \
 	estudio/new/faces.vga \
 	estudio/new/gumps.vga \
@@ -206,7 +203,7 @@ endif
 
 flex_DATA =  \
 		$(EXULT_FLX) $(EXULT_BG_FLX) $(EXULT_SI_FLX) midisfx.flx \
-		exultmsg.txt $(EXULT_BG_PAPERDOL_VGA) $(EXULT_BG_MR_FACES_VGA)
+		exultmsg.txt
 
 if BUILD_STUDIO
 estudionew_DATA = $(ESTUDIO_NEW_FILES)
@@ -214,11 +211,13 @@ else
 estudionew_DATA =
 endif
 
-CLEANFILES = exult.flx exult_bg.flx exult_si.flx bg/bg_paperdol.vga bg/bg_mr_faces.vga *~
+CLEANFILES = exult.flx exult_bg.flx exult_si.flx bg/bg_paperdol.vga bg/bg_mr_faces.vga bg/introsfx_mt32.flx bg/introsfx_mt.flx *~
 
 EXTRA_DIST = flx.in $(EXULT_FLX_OBJECTS) $(EXULT_BG_FLX_OBJECTS) \
 	$(EXULT_SI_FLX_OBJECTS) $(ESTUDIO_NEW_FILES) midisfx.flx \
-	exultmsg.txt bginclude.uc \
+	$(ESTUDIO_NEW_FILES) \
+	$(EXULT_BG_INTROSFX_MT32_OBJECTS) $(EXULT_BG_INTROSFX_SB_OBJECTS) \
+	exultmsg.txt bginclude.uc marketpl.mid myusecode.uc \
 	$(EXULT_BG_PAPERDOL_VGA_OBJECTS) $(EXULT_BG_MR_FACES_VGA_OBJECTS)
 
 if CROSS_COMPILING
@@ -239,7 +238,7 @@ bg/bg_mr_faces.vga: $(expack) $(EXULT_BG_MR_FACES_VGA_OBJECTS)
 exult.flx: $(expack) $(EXULT_FLX_OBJECTS)
 	$(expack) -i $(srcdir)/flx.in
 
-exult_bg.flx: $(expack) $(EXULT_BG_FLX_OBJECTS)
+exult_bg.flx: $(expack) $(EXULT_BG_FLX_OBJECTS) bg/bg_paperdol.vga bg/bg_mr_faces.vga bg/introsfx_mt32.flx bg/introsfx_sb.flx
 	$(expack) -i $(srcdir)/bg/flx.in
 
 bg/introsfx_mt32.flx: $(expack) $(EXULT_BG_INTROSFX_MT32_OBJECTS)

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -26,24 +26,46 @@ nobase_doc_DATA = \
 	images/studiosiiregs.png
 
 EXTRA_DIST =		\
+	xml/docs.dtd	\
+	xml/docs.xml	\
+	xml/exult_studio.xml	\
+	xml/faq.xml	\
+	xml/HowTo	\
+	xml/html.xsl	\
+	xml/Makefile	\
+	xml/Makefile.win32	\
+	xml/php.xsl	\
+	xml/text.xsl	\
 	$(man_MANS)	\
-	$(nobase_doc_DATA)
-
-#	FLI.txt 	\
-#	exscript.txt	\
-#	items.txt	\
-#	schedule.txt	\
-#	u7combat.txt	\
-#	u7edit.txt	\
-#	u7eggs.txt	\
-#	u7itemtypes.txt	\
-#	u7monst.txt	\
-#	u7playend.zip	\
-#	u7ready.txt	\
-#	u7tech.txt	\
-#	unknown		\
-#	usedis.zip	\
-#	weapons.txt	\
-#	wuc.zip
+	$(nobase_doc_DATA)	\
+	art.txt		\
+	bgitems.txt	\
+	exult2.txt	\
+	exult_intrinsics.txt	\
+	exult_studio.txt	\
+	FLI.txt 	\
+	interview	\
+	IslandAddOn.txt	\
+	MidiInfo.txt	\
+	newgame.txt	\
+	Planets.txt	\
+	release.txt	\
+	schedule.txt	\
+	serpentsfx.txt	\
+	siitems.txt	\
+	u7combat.txt	\
+	u7edit.txt	\
+	u7eggs.txt	\
+	u7itemtypes.txt	\
+	u7monst.txt	\
+	u7ready.txt	\
+	u7tech.txt	\
+	ucc.txt		\
+	usecode32.txt	\
+	usecode_bugs.txt	\
+	usecode.dis	\
+	usecode_ff.txt	\
+	unknown		\
+	weapons.txt
 
 CLEANFILES = *~

--- a/files/Makefile.am
+++ b/files/Makefile.am
@@ -41,6 +41,7 @@ libu7file_la_SOURCES =	\
 	msgfile.h
 
 EXTRA_DIST = 		\
+	module.mk	\
 	README
 
 CLEANFILES = *~

--- a/mapedit/Makefile.am
+++ b/mapedit/Makefile.am
@@ -51,7 +51,6 @@ exult_studio_SOURCES = \
 	objbrowse.cc \
 	paledit.cc \
 	paledit.h \
-	ready.h		\
 	shapedraw.cc \
 	shapedraw.h \
 	shapefile.cc \
@@ -94,7 +93,10 @@ u7shp$(EXEEXT): u7shp.cc $(top_builddir)/config.h
 	CPPFLAGS="$(u7shp_CFLAGS)" CXXFLAGS="-O2 -I$(top_srcdir) -DHAVE_CONFIG_H" $(GIMPTOOL) --build $<
 
 EXTRA_DIST=	\
+	gimpwin32.txt \
+	PhotoshopShapePlugin.zip \
 	exult_studio.glade \
+	uniquepal.c \
 	logo.xpm
 
 if GIMP_PLUGIN

--- a/shapes/Makefile.am
+++ b/shapes/Makefile.am
@@ -9,6 +9,8 @@ SUBDIRS = shapeinf
 noinst_LTLIBRARIES = libshapes.la
 
 libshapes_la_SOURCES = \
+	baseinf.h \
+	data_utils.h \
 	font.cc \
 	font.h \
 	fontgen.cc \
@@ -21,6 +23,7 @@ libshapes_la_SOURCES = \
 	miscinf.h \
 	pngio.cc \
 	pngio.h \
+	ready.h \
 	shapeinf.cc \
 	shapeinf.h \
 	shapevga.cc \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -121,6 +121,17 @@ EXTRA_DIST = \
 	u7bgflag.txt \
 	u7siflag.txt \
 	ucformat.txt \
+	expack.1 \
+	gnome_u7shapes.thumbnailer.in \
+	ipack.1 \
+	ipack.txt \
+	shp2pcx.1 \
+	shp2pcx.txt \
+	splitshp.1 \
+	splitshp.txt \
+	textpack.1 \
+	textpack.txt \
+	x-shapefile.xml \
 	expack.txt
 
 CLEANFILES = *~ gnome_u7shapes.thumbnailer

--- a/usecode/Makefile.am
+++ b/usecode/Makefile.am
@@ -9,6 +9,7 @@ SUBDIRS = . compiler ucxt
 noinst_LTLIBRARIES = libusecode.la
 
 libusecode_la_SOURCES = \
+	opcodes.h	\
 	bgintrinsics.h	\
 	siintrinsics.h	\
 	sibetaintrinsics.h	\

--- a/usecode/compiler/Makefile.am
+++ b/usecode/compiler/Makefile.am
@@ -4,14 +4,13 @@ AM_CPPFLAGS = -I$(srcdir)/../../headers -I$(srcdir)/.. -I$(srcdir)/../../files -
 AM_YFLAGS = -d -v				# Want ucparse.h.
 
 ucc_SOURCES = ucparse.yy uclex.ll ucmain.cc \
-	opcodes.h	\
+	basic_block.h	\
 	ucclass.cc	\
 	ucclass.h	\
 	ucexpr.cc	\
 	ucexpr.h	\
 	ucfun.cc	\
 	ucfun.h		\
-	uclabel.h	\
 	ucloc.cc	\
 	ucloc.h		\
 	ucparse.h	\
@@ -33,6 +32,9 @@ ucparse.h: ucparse.cc
 
 uclex.o: uclex.cc ucparse.h
 
+EXTRA_DIST = \
+	test1.uc \
+	ucdefs.h
 
 CLEANFILES = *~
 MAINTAINERCLEANFILES = uclex.cc ucparse.cc ucparse.h ucparse.hh

--- a/usecode/ucxt/Docs/Makefile.am
+++ b/usecode/ucxt/Docs/Makefile.am
@@ -1,4 +1,5 @@
 EXTRA_DIST = \
 	flags_pre.txt \
 	newopcodes.txt \
+	ucxt.1 \
 	ucxtread.txt

--- a/usecode/ucxt/data/Makefile.am
+++ b/usecode/ucxt/data/Makefile.am
@@ -20,6 +20,5 @@ ucxt_DATA = \
 EXTRA_DIST = \
 	events.data	\
 	flags.data	\
-	opcodes.txt	\
 	u7opcodes.data	\
 	u7misc.data


### PR DESCRIPTION
Revalidate `make dist` on Autotools builds [ Linux and MacOSX ]  
```
Commit 1 of 1 :
    Makefile.am
      Respect (AM_)LIBTOOLFLAGS in CXXLINK
    Makefile.am and all nested Makefile.am
      Update the source file lists
      Separate the original data files from the built data files
        and make the built datafiles "nodist_'
```