### PR TITLE
Studio : Fix Rotate button in Container and Object Editors

### DIFF
--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -125,8 +125,12 @@ void Shape_draw::draw_shape_centered(
     int framenum
 ) {
 	iwin->fill8(255);       // Background (transparent) color.
-	if (shapenum < 0 || shapenum >= ifile->get_num_shapes()
-	        || framenum >= ifile->get_num_frames(shapenum))
+	if (shapenum < 0 || shapenum >= ifile->get_num_shapes())
+		return;
+	int num_frames = ifile->get_num_frames(shapenum);
+	if ((framenum <  0 || framenum >= num_frames) &&
+	    (num_frames > 32 ||
+	     framenum < 32 || framenum >= (32 + num_frames)))
 		return;
 	Shape_frame *shape = ifile->get_shape(shapenum, framenum);
 	if (!shape || shape->is_empty())


### PR DESCRIPTION
The Rotate frame button in the Container Editor and the Object Editor does not work : the shape becomes black instead of rotated.

### Reason
The `Shape_draw::draw_shape_centered` method ignores the two editors convention of ORing the frame number with 32 to ask for a rotated frame. It leaves the shape black as its frame number exceeds the frame count of the shape.

### Action
Ensure that frame numbers in the range 32 .. 32 + frame count - 1 are accepted too.