### PR TITLE
Make address sanitizer happy about Special_effects being removed

### DIFF
--- a/effects.cc
+++ b/effects.cc
@@ -1629,7 +1629,6 @@ Clouds_effect::Clouds_effect(
 	num_clouds = 2 + rand() % 5; // Pick #.
 	if (overcast)
 		num_clouds += rand() % 2;
-	clouds = new Cloud *[num_clouds];
 	// Figure wind direction.
 	int dx = rand() % 5 - 2;
 	int dy = rand() % 5 - 2;
@@ -1645,7 +1644,7 @@ Clouds_effect::Clouds_effect(
 			deltax += deltax / 2;
 			deltay += deltay / 2;
 		}
-		clouds[i] = new Cloud(deltax, deltay);
+		clouds.emplace_back(std::make_unique<Cloud>(deltax, deltay));
 	}
 }
 
@@ -1666,8 +1665,8 @@ void Clouds_effect::handle_event(
 	}
 	int w = gwin->get_width();
 	int h = gwin->get_height();
-	for (int i = 0; i < num_clouds; i++)
-		clouds[i]->next(gwin, curtime, w, h);
+	for (auto& cloud : clouds)
+		cloud->next(gwin, curtime, w, h);
 	gwin->get_tqueue()->add(curtime + delay, this, udata);
 }
 
@@ -1678,8 +1677,8 @@ void Clouds_effect::handle_event(
 void Clouds_effect::paint(
 ) {
 	if (!gwin->is_main_actor_inside())
-		for (int i = 0; i < num_clouds; i++)
-			clouds[i]->paint();
+		for (auto& cloud : clouds)
+			cloud->paint();
 }
 
 /**
@@ -1687,7 +1686,6 @@ void Clouds_effect::paint(
  */
 
 Clouds_effect::~Clouds_effect() {
-	delete [] clouds;
 	if (overcast)
 		Game_window::get_instance()->get_clock()->set_overcast(false);
 }

--- a/effects.h
+++ b/effects.h
@@ -350,7 +350,7 @@ public:
  */
 class Clouds_effect : public Weather_effect {
 	int num_clouds;
-	Cloud **clouds;         // ->clouds.
+	std::vector<std::unique_ptr<Cloud>> clouds;	
 	bool overcast;
 public:
 	Clouds_effect(int duration, int delay = 0, Game_object *egg = nullptr, int n = -1);

--- a/effects.h
+++ b/effects.h
@@ -61,7 +61,7 @@ public:
 	void add_effect(std::unique_ptr<Special_effect> effect);
 	void remove_text_effect(Game_object *item);
 	// Remove text item & delete it.
-	void remove_effect(Special_effect *effect);
+	std::unique_ptr<Special_effect> remove_effect(Special_effect *effect);
 	void remove_text_effect(Text_effect *txt);
 	void remove_all_effects(bool repaint = false);
 	void remove_text_effects();


### PR DESCRIPTION
Technically a method can `delete this` but should return immediately afterwards. This is kind of a workaround for address sanitizer being picky about that, but in fact it also makes a clear indication in the code that the object acquires its own handle. 
Branch name stems from Cloud_effects that would trigger the problem with asan ;)