### PR TITLE
Studio : Provide and use a new C++ class "ShapeSingle" for single Shape display

### DIFF
--- a/mapedit/exult_studio.glade
+++ b/mapedit/exult_studio.glade
@@ -3188,7 +3188,6 @@
                             <property name="label" translatable="yes">Files</property>
                             <property name="justify">center</property>
                           </object>
-                          <packing></packing>
                         </child>
                         <child>
                           <object class="GtkFrame" id="groups_frame">
@@ -4145,7 +4144,7 @@
                                     <property name="vexpand">False</property>
                                     <property name="primary-icon-activatable">False</property>
                                     <property name="secondary-icon-activatable">False</property>
-                                    <signal name="focus-out-event" handler="on_monst_shape_focus_out_event" swapped="no"/>
+                                    <!-- <signal name="focus-out-event" handler="on_monst_shape_focus_out_event" swapped="no"/> -->
                                   </object>
                                 </child>
                                 <child type="label">
@@ -4259,7 +4258,6 @@
                 <property name="label" translatable="yes">Monster</property>
                 <property name="justify">center</property>
               </object>
-              <packing></packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox8">
@@ -4736,17 +4734,45 @@
                     <property name="vexpand">False</property>
                     <property name="label-xalign">0</property>
                     <child>
-                      <object class="GtkEntry" id="missile_shape">
+                      <object class="GtkBox" id="missile_shape_box">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="valign">center</property>
+                        <property name="can-focus">False</property>
                         <property name="margin-start">4</property>
                         <property name="margin-end">4</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
-                        <property name="vexpand">False</property>
-                        <property name="primary-icon-activatable">False</property>
-                        <property name="secondary-icon-activatable">False</property>
+                        <property name="orientation">horizontal</property>
+                        <child>
+                          <object class="GtkEntry" id="missile_shape">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="valign">center</property>
+                            <property name="margin-start">4</property>
+                            <property name="margin-end">4</property>
+                            <property name="margin-top">2</property>
+                            <property name="margin-bottom">2</property>
+                            <property name="vexpand">False</property>
+                            <property name="primary-icon-activatable">False</property>
+                            <property name="secondary-icon-activatable">False</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkDrawingArea" id="missile_draw">
+                            <property name="width-request">40</property>
+                            <property name="height-request">40</property>
+                            <property name="visible">False</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">center</property>
+                            <property name="valign">center</property>
+                            <property name="margin-start">4</property>
+                            <property name="margin-end">4</property>
+                            <property name="margin-top">2</property>
+                            <property name="margin-bottom">2</property>
+                          </object>
+                          <packing>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                     <child type="label">
@@ -6230,7 +6256,7 @@ Coordinates</property>
                             <property name="vexpand">False</property>
                             <property name="primary-icon-activatable">False</property>
                             <property name="secondary-icon-activatable">False</property>
-                            <signal name="focus-out-event" handler="on_npc_shape_focus_out_event" swapped="no"/>
+                            <!-- <signal name="focus-out-event" handler="on_npc_shape_focus_out_event" swapped="no"/> -->
                           </object>
                         </child>
                         <child type="label">
@@ -6901,7 +6927,6 @@ Coordinates</property>
                 <property name="label" translatable="yes">Properties</property>
                 <property name="justify">center</property>
               </object>
-              <packing></packing>
             </child>
             <child>
               <!-- n-columns=3 n-rows=11 -->
@@ -10315,7 +10340,7 @@ Coordinates</property>
                         <property name="secondary-icon-activatable">False</property>
                         <property name="adjustment">adjustment104</property>
                         <property name="climb-rate">1</property>
-                        <signal name="changed" handler="on_obj_shape_changed" swapped="no"/>
+                        <!-- <signal name="changed" handler="on_obj_shape_changed" swapped="no"/> -->
                       </object>
                     </child>
                     <child type="label">
@@ -10359,7 +10384,7 @@ Coordinates</property>
                         <property name="adjustment">adjustment103</property>
                         <property name="climb-rate">1</property>
                         <property name="wrap">True</property>
-                        <signal name="changed" handler="on_obj_shape_changed" swapped="no"/>
+                        <!-- <signal name="changed" handler="on_obj_shape_changed" swapped="no"/> -->
                       </object>
                     </child>
                     <child type="label">
@@ -12791,7 +12816,6 @@ Coordinates</property>
                 <property name="label" translatable="yes">Object</property>
                 <property name="justify">center</property>
               </object>
-              <packing></packing>
             </child>
             <child>
               <object class="GtkBox" id="shinfo_weapon_box">
@@ -13056,6 +13080,23 @@ Coordinates</property>
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="shinfo_weapon_family_draw">
+                                        <property name="width-request">40</property>
+                                        <property name="height-request">40</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                                 <child type="label">
@@ -13141,6 +13182,23 @@ Coordinates</property>
                                       </object>
                                       <packing>
                                         <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="shinfo_weapon_projectile_draw">
+                                        <property name="width-request">40</property>
+                                        <property name="height-request">40</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">3</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -14120,20 +14178,48 @@ Coordinates</property>
                                 <property name="vexpand">False</property>
                                 <property name="label-xalign">0</property>
                                 <child>
-                                  <object class="GtkSpinButton" id="shinfo_ammo_family">
+                                  <object class="GtkBox" id="shinfo_ammo_family_box">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="valign">center</property>
+                                    <property name="can-focus">False</property>
                                     <property name="margin-start">4</property>
                                     <property name="margin-end">4</property>
                                     <property name="margin-top">2</property>
                                     <property name="margin-bottom">2</property>
-                                    <property name="vexpand">False</property>
-                                    <property name="width-chars">5</property>
-                                    <property name="primary-icon-activatable">False</property>
-                                    <property name="secondary-icon-activatable">False</property>
-                                    <property name="adjustment">adjustment81</property>
-                                    <property name="climb-rate">1</property>
+                                    <property name="orientation">horizontal</property>
+                                    <child>
+                                      <object class="GtkSpinButton" id="shinfo_ammo_family">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                        <property name="vexpand">False</property>
+                                        <property name="width-chars">5</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
+                                        <property name="adjustment">adjustment81</property>
+                                        <property name="climb-rate">1</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="shinfo_ammo_family_draw">
+                                        <property name="width-request">40</property>
+                                        <property name="height-request">40</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                                 <child type="label">
@@ -14219,6 +14305,23 @@ Coordinates</property>
                                       </object>
                                       <packing>
                                         <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="shinfo_ammo_sprite_draw">
+                                        <property name="width-request">40</property>
+                                        <property name="height-request">40</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">3</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -16878,7 +16981,7 @@ Coordinates</property>
                                         <property name="secondary-icon-activatable">False</property>
                                         <property name="adjustment">adjustment68</property>
                                         <property name="climb-rate">1</property>
-                                        <signal name="changed" handler="on_shinfo_gump_num_changed" swapped="no"/>
+                                        <!-- <signal name="changed" handler="on_shinfo_gump_num_changed" swapped="no"/> -->
                                       </object>
                                     </child>
                                     <child type="label">
@@ -17701,7 +17804,7 @@ Coordinates</property>
                                     <property name="secondary-icon-activatable">False</property>
                                     <property name="adjustment">adjustment61</property>
                                     <property name="climb-rate">1</property>
-                                    <signal name="changed" handler="on_shinfo_body_shape_changed" swapped="no"/>
+                                    <!-- <signal name="changed" handler="on_shinfo_body_shape_changed" swapped="no"/> -->
                                   </object>
                                 </child>
                                 <child type="label">
@@ -17744,7 +17847,7 @@ Coordinates</property>
                                     <property name="secondary-icon-activatable">False</property>
                                     <property name="adjustment">adjustment60</property>
                                     <property name="climb-rate">1</property>
-                                    <signal name="changed" handler="on_shinfo_body_frame_changed" swapped="no"/>
+                                    <!-- <signal name="changed" handler="on_shinfo_body_frame_changed" swapped="no"/> -->
                                   </object>
                                 </child>
                                 <child type="label">
@@ -17787,8 +17890,8 @@ Coordinates</property>
               <object class="GtkLabel" id="label276">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
+                <property name="halign">fill</property>
+                <property name="valign">fill</property>
                 <property name="hexpand">False</property>
                 <property name="vexpand">False</property>
                 <property name="label" translatable="yes">Body</property>
@@ -17920,7 +18023,7 @@ Coordinates</property>
                                         <property name="secondary-icon-activatable">False</property>
                                         <property name="adjustment">adjustment59</property>
                                         <property name="climb-rate">1</property>
-                                        <signal name="changed" handler="on_shinfo_explosion_sprite_changed" swapped="no"/>
+                                        <!-- <signal name="changed" handler="on_shinfo_explosion_sprite_changed" swapped="no"/> -->
                                       </object>
                                     </child>
                                     <child type="label">
@@ -18756,20 +18859,48 @@ Coordinates</property>
                                         <property name="vexpand">False</property>
                                         <property name="label-xalign">0</property>
                                         <child>
-                                          <object class="GtkSpinButton" id="shinfo_npcpaperdoll_bframe">
+                                          <object class="GtkBox" id="shinfo_npcpaperdoll_bframe_box">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="valign">center</property>
+                                            <property name="can-focus">False</property>
                                             <property name="margin-start">4</property>
                                             <property name="margin-end">4</property>
                                             <property name="margin-top">2</property>
                                             <property name="margin-bottom">2</property>
-                                            <property name="vexpand">False</property>
-                                            <property name="width-chars">5</property>
-                                            <property name="primary-icon-activatable">False</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <property name="adjustment">adjustment56</property>
-                                            <property name="climb-rate">1</property>
+                                            <property name="orientation">horizontal</property>
+                                            <child>
+                                              <object class="GtkSpinButton" id="shinfo_npcpaperdoll_bframe">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                                <property name="vexpand">False</property>
+                                                <property name="width-chars">5</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
+                                                <property name="adjustment">adjustment56</property>
+                                                <property name="climb-rate">1</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkDrawingArea" id="shinfo_npcpaperdoll_bframe_draw">
+                                                <property name="width-request">40</property>
+                                                <property name="height-request">40</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                              </object>
+                                              <packing>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                         </child>
                                         <child type="label">
@@ -18877,20 +19008,48 @@ Coordinates</property>
                                         <property name="vexpand">False</property>
                                         <property name="label-xalign">0</property>
                                         <child>
-                                          <object class="GtkSpinButton" id="shinfo_npcpaperdoll_hframe">
+                                          <object class="GtkBox" id="shinfo_npcpaperdoll_hframe_box">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="valign">center</property>
+                                            <property name="can-focus">False</property>
                                             <property name="margin-start">4</property>
                                             <property name="margin-end">4</property>
                                             <property name="margin-top">2</property>
                                             <property name="margin-bottom">2</property>
-                                            <property name="vexpand">False</property>
-                                            <property name="width-chars">5</property>
-                                            <property name="primary-icon-activatable">False</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <property name="adjustment">adjustment54</property>
-                                            <property name="climb-rate">1</property>
+                                            <property name="orientation">horizontal</property>
+                                            <child>
+                                              <object class="GtkSpinButton" id="shinfo_npcpaperdoll_hframe">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                                <property name="vexpand">False</property>
+                                                <property name="width-chars">5</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
+                                                <property name="adjustment">adjustment54</property>
+                                                <property name="climb-rate">1</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkDrawingArea" id="shinfo_npcpaperdoll_hframe_draw">
+                                                <property name="width-request">40</property>
+                                                <property name="height-request">40</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                              </object>
+                                              <packing>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                         </child>
                                         <child type="label">
@@ -18919,20 +19078,48 @@ Coordinates</property>
                                         <property name="vexpand">False</property>
                                         <property name="label-xalign">0</property>
                                         <child>
-                                          <object class="GtkSpinButton" id="shinfo_npcpaperdoll_hhelm">
+                                          <object class="GtkBox" id="shinfo_npcpaperdoll_hhelm_box">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="valign">center</property>
+                                            <property name="can-focus">False</property>
                                             <property name="margin-start">4</property>
                                             <property name="margin-end">4</property>
                                             <property name="margin-top">2</property>
                                             <property name="margin-bottom">2</property>
-                                            <property name="vexpand">False</property>
-                                            <property name="width-chars">5</property>
-                                            <property name="primary-icon-activatable">False</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <property name="adjustment">adjustment53</property>
-                                            <property name="climb-rate">1</property>
+                                            <property name="orientation">horizontal</property>
+                                            <child>
+                                              <object class="GtkSpinButton" id="shinfo_npcpaperdoll_hhelm">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                                <property name="vexpand">False</property>
+                                                <property name="width-chars">5</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
+                                                <property name="adjustment">adjustment53</property>
+                                                <property name="climb-rate">1</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkDrawingArea" id="shinfo_npcpaperdoll_hhelm_draw">
+                                                <property name="width-request">40</property>
+                                                <property name="height-request">40</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                              </object>
+                                              <packing>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                         </child>
                                         <child type="label">
@@ -19071,20 +19258,48 @@ Coordinates</property>
                                             <property name="vexpand">False</property>
                                             <property name="label-xalign">0</property>
                                             <child>
-                                              <object class="GtkSpinButton" id="shinfo_npcpaperdoll_aframe">
+                                              <object class="GtkBox" id="shinfo_npcpaperdoll_aframe_box">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="valign">center</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="margin-start">4</property>
                                                 <property name="margin-end">4</property>
                                                 <property name="margin-top">2</property>
                                                 <property name="margin-bottom">2</property>
-                                                <property name="vexpand">False</property>
-                                                <property name="width-chars">5</property>
-                                                <property name="primary-icon-activatable">False</property>
-                                                <property name="secondary-icon-activatable">False</property>
-                                                <property name="adjustment">adjustment51</property>
-                                                <property name="climb-rate">1</property>
+                                                <property name="orientation">horizontal</property>
+                                                <child>
+                                                  <object class="GtkSpinButton" id="shinfo_npcpaperdoll_aframe">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="valign">center</property>
+                                                    <property name="margin-start">4</property>
+                                                    <property name="margin-end">4</property>
+                                                    <property name="margin-top">2</property>
+                                                    <property name="margin-bottom">2</property>
+                                                    <property name="vexpand">False</property>
+                                                    <property name="width-chars">5</property>
+                                                    <property name="primary-icon-activatable">False</property>
+                                                    <property name="secondary-icon-activatable">False</property>
+                                                    <property name="adjustment">adjustment51</property>
+                                                    <property name="climb-rate">1</property>
+                                                  </object>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkDrawingArea" id="shinfo_npcpaperdoll_aframe_draw">
+                                                    <property name="width-request">40</property>
+                                                    <property name="height-request">40</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="halign">center</property>
+                                                    <property name="valign">center</property>
+                                                    <property name="margin-start">4</property>
+                                                    <property name="margin-end">4</property>
+                                                    <property name="margin-top">2</property>
+                                                    <property name="margin-bottom">2</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="position">2</property>
+                                                  </packing>
+                                                </child>
                                               </object>
                                             </child>
                                             <child type="label">
@@ -19113,20 +19328,48 @@ Coordinates</property>
                                             <property name="vexpand">False</property>
                                             <property name="label-xalign">0</property>
                                             <child>
-                                              <object class="GtkSpinButton" id="shinfo_npcpaperdoll_atwohanded">
+                                              <object class="GtkBox" id="shinfo_npcpaperdoll_atwohanded_box">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="valign">center</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="margin-start">4</property>
                                                 <property name="margin-end">4</property>
                                                 <property name="margin-top">2</property>
                                                 <property name="margin-bottom">2</property>
-                                                <property name="vexpand">False</property>
-                                                <property name="width-chars">5</property>
-                                                <property name="primary-icon-activatable">False</property>
-                                                <property name="secondary-icon-activatable">False</property>
-                                                <property name="adjustment">adjustment50</property>
-                                                <property name="climb-rate">1</property>
+                                                <property name="orientation">horizontal</property>
+                                                <child>
+                                                  <object class="GtkSpinButton" id="shinfo_npcpaperdoll_atwohanded">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="valign">center</property>
+                                                    <property name="margin-start">4</property>
+                                                    <property name="margin-end">4</property>
+                                                    <property name="margin-top">2</property>
+                                                    <property name="margin-bottom">2</property>
+                                                    <property name="vexpand">False</property>
+                                                    <property name="width-chars">5</property>
+                                                    <property name="primary-icon-activatable">False</property>
+                                                    <property name="secondary-icon-activatable">False</property>
+                                                    <property name="adjustment">adjustment50</property>
+                                                    <property name="climb-rate">1</property>
+                                                  </object>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkDrawingArea" id="shinfo_npcpaperdoll_atwohanded_draw">
+                                                    <property name="width-request">40</property>
+                                                    <property name="height-request">40</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="halign">center</property>
+                                                    <property name="valign">center</property>
+                                                    <property name="margin-start">4</property>
+                                                    <property name="margin-end">4</property>
+                                                    <property name="margin-top">2</property>
+                                                    <property name="margin-bottom">2</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="position">2</property>
+                                                  </packing>
+                                                </child>
                                               </object>
                                             </child>
                                             <child type="label">
@@ -19155,20 +19398,48 @@ Coordinates</property>
                                             <property name="vexpand">False</property>
                                             <property name="label-xalign">0</property>
                                             <child>
-                                              <object class="GtkSpinButton" id="shinfo_npcpaperdoll_astaff">
+                                              <object class="GtkBox" id="shinfo_npcpaperdoll_astaff_box">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="valign">center</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="margin-start">4</property>
                                                 <property name="margin-end">4</property>
                                                 <property name="margin-top">2</property>
                                                 <property name="margin-bottom">2</property>
-                                                <property name="vexpand">False</property>
-                                                <property name="width-chars">5</property>
-                                                <property name="primary-icon-activatable">False</property>
-                                                <property name="secondary-icon-activatable">False</property>
-                                                <property name="adjustment">adjustment49</property>
-                                                <property name="climb-rate">1</property>
+                                                <property name="orientation">horizontal</property>
+                                                <child>
+                                                  <object class="GtkSpinButton" id="shinfo_npcpaperdoll_astaff">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="valign">center</property>
+                                                    <property name="margin-start">4</property>
+                                                    <property name="margin-end">4</property>
+                                                    <property name="margin-top">2</property>
+                                                    <property name="margin-bottom">2</property>
+                                                    <property name="vexpand">False</property>
+                                                    <property name="width-chars">5</property>
+                                                    <property name="primary-icon-activatable">False</property>
+                                                    <property name="secondary-icon-activatable">False</property>
+                                                    <property name="adjustment">adjustment49</property>
+                                                    <property name="climb-rate">1</property>
+                                                  </object>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkDrawingArea" id="shinfo_npcpaperdoll_astaff_draw">
+                                                    <property name="width-request">40</property>
+                                                    <property name="height-request">40</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="halign">center</property>
+                                                    <property name="valign">center</property>
+                                                    <property name="margin-start">4</property>
+                                                    <property name="margin-end">4</property>
+                                                    <property name="margin-top">2</property>
+                                                    <property name="margin-bottom">2</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="position">2</property>
+                                                  </packing>
+                                                </child>
                                               </object>
                                             </child>
                                             <child type="label">
@@ -19776,6 +20047,23 @@ Coordinates</property>
                                         <property name="position">2</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="shinfo_cntrules_shape_draw">
+                                        <property name="width-request">40</property>
+                                        <property name="height-request">40</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">4</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                                 <child type="label">
@@ -20032,6 +20320,23 @@ Coordinates</property>
                                       </object>
                                       <packing>
                                         <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="shinfo_frameflags_frame_draw">
+                                        <property name="width-request">40</property>
+                                        <property name="height-request">40</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">3</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -20720,6 +21025,23 @@ Coordinates</property>
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="shinfo_effhps_frame_draw">
+                                        <property name="width-request">40</property>
+                                        <property name="height-request">40</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                                 <child type="label">
@@ -21137,6 +21459,23 @@ Coordinates</property>
                                       </object>
                                       <packing>
                                         <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="shinfo_framenames_frame_draw">
+                                        <property name="width-request">40</property>
+                                        <property name="height-request">40</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">3</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -21733,6 +22072,23 @@ Coordinates</property>
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="shinfo_frameusecode_frame_draw">
+                                        <property name="width-request">40</property>
+                                        <property name="height-request">40</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                                 <child type="label">
@@ -22147,6 +22503,23 @@ Coordinates</property>
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="shinfo_objpaperdoll_wframe_draw">
+                                        <property name="width-request">40</property>
+                                        <property name="height-request">40</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                                 <child type="label">
@@ -22234,20 +22607,48 @@ Coordinates</property>
                                     <property name="vexpand">False</property>
                                     <property name="label-xalign">0</property>
                                     <child>
-                                      <object class="GtkSpinButton" id="shinfo_objpaperdoll_spotframe">
+                                      <object class="GtkBox" id="shinfo_objpaperdoll_spotframe_box">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="valign">center</property>
+                                        <property name="can-focus">False</property>
                                         <property name="margin-start">4</property>
                                         <property name="margin-end">4</property>
                                         <property name="margin-top">2</property>
                                         <property name="margin-bottom">2</property>
-                                        <property name="vexpand">False</property>
-                                        <property name="width-chars">5</property>
-                                        <property name="primary-icon-activatable">False</property>
-                                        <property name="secondary-icon-activatable">False</property>
-                                        <property name="adjustment">adjustment33</property>
-                                        <property name="climb-rate">1</property>
+                                        <property name="orientation">horizontal</property>
+                                        <child>
+                                          <object class="GtkSpinButton" id="shinfo_objpaperdoll_spotframe">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="valign">center</property>
+                                            <property name="margin-start">4</property>
+                                            <property name="margin-end">4</property>
+                                            <property name="margin-top">2</property>
+                                            <property name="margin-bottom">2</property>
+                                            <property name="vexpand">False</property>
+                                            <property name="width-chars">5</property>
+                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="secondary-icon-activatable">False</property>
+                                            <property name="adjustment">adjustment33</property>
+                                            <property name="climb-rate">1</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkDrawingArea" id="shinfo_objpaperdoll_spotframe_draw">
+                                            <property name="width-request">40</property>
+                                            <property name="height-request">40</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="halign">center</property>
+                                            <property name="valign">center</property>
+                                            <property name="margin-start">4</property>
+                                            <property name="margin-end">4</property>
+                                            <property name="margin-top">2</property>
+                                            <property name="margin-bottom">2</property>
+                                          </object>
+                                          <packing>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                     </child>
                                     <child type="label">
@@ -22303,20 +22704,48 @@ Coordinates</property>
                                         <property name="vexpand">False</property>
                                         <property name="label-xalign">0</property>
                                         <child>
-                                          <object class="GtkSpinButton" id="shinfo_objpaperdoll_frame3">
+                                          <object class="GtkBox" id="shinfo_objpaperdoll_frame3_box">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="valign">center</property>
+                                            <property name="can-focus">False</property>
                                             <property name="margin-start">4</property>
                                             <property name="margin-end">4</property>
                                             <property name="margin-top">2</property>
                                             <property name="margin-bottom">2</property>
-                                            <property name="vexpand">False</property>
-                                            <property name="width-chars">5</property>
-                                            <property name="primary-icon-activatable">False</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <property name="adjustment">adjustment32</property>
-                                            <property name="climb-rate">1</property>
+                                            <property name="orientation">horizontal</property>
+                                            <child>
+                                              <object class="GtkSpinButton" id="shinfo_objpaperdoll_frame3">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                                <property name="vexpand">False</property>
+                                                <property name="width-chars">5</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
+                                                <property name="adjustment">adjustment32</property>
+                                                <property name="climb-rate">1</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkDrawingArea" id="shinfo_objpaperdoll_frame3_draw">
+                                                <property name="width-request">40</property>
+                                                <property name="height-request">40</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                              </object>
+                                              <packing>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                         </child>
                                         <child type="label">
@@ -22348,20 +22777,48 @@ Coordinates</property>
                                         <property name="vexpand">False</property>
                                         <property name="label-xalign">0</property>
                                         <child>
-                                          <object class="GtkSpinButton" id="shinfo_objpaperdoll_frame0">
+                                          <object class="GtkBox" id="shinfo_objpaperdoll_frame0_box">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="valign">center</property>
+                                            <property name="can-focus">False</property>
                                             <property name="margin-start">4</property>
                                             <property name="margin-end">4</property>
                                             <property name="margin-top">2</property>
                                             <property name="margin-bottom">2</property>
-                                            <property name="vexpand">False</property>
-                                            <property name="width-chars">5</property>
-                                            <property name="primary-icon-activatable">False</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <property name="adjustment">adjustment31</property>
-                                            <property name="climb-rate">1</property>
+                                            <property name="orientation">horizontal</property>
+                                            <child>
+                                              <object class="GtkSpinButton" id="shinfo_objpaperdoll_frame0">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                                <property name="vexpand">False</property>
+                                                <property name="width-chars">5</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
+                                                <property name="adjustment">adjustment31</property>
+                                                <property name="climb-rate">1</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkDrawingArea" id="shinfo_objpaperdoll_frame0_draw">
+                                                <property name="width-request">40</property>
+                                                <property name="height-request">40</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                              </object>
+                                              <packing>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                         </child>
                                         <child type="label">
@@ -22486,20 +22943,48 @@ Coordinates</property>
                                         <property name="vexpand">False</property>
                                         <property name="label-xalign">0</property>
                                         <child>
-                                          <object class="GtkSpinButton" id="shinfo_objpaperdoll_frame1">
+                                          <object class="GtkBox" id="shinfo_objpaperdoll_frame1_box">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="valign">center</property>
+                                            <property name="can-focus">False</property>
                                             <property name="margin-start">4</property>
                                             <property name="margin-end">4</property>
                                             <property name="margin-top">2</property>
                                             <property name="margin-bottom">2</property>
-                                            <property name="vexpand">False</property>
-                                            <property name="width-chars">5</property>
-                                            <property name="primary-icon-activatable">False</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <property name="adjustment">adjustment29</property>
-                                            <property name="climb-rate">1</property>
+                                            <property name="orientation">horizontal</property>
+                                            <child>
+                                              <object class="GtkSpinButton" id="shinfo_objpaperdoll_frame1">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                                <property name="vexpand">False</property>
+                                                <property name="width-chars">5</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
+                                                <property name="adjustment">adjustment29</property>
+                                                <property name="climb-rate">1</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkDrawingArea" id="shinfo_objpaperdoll_frame1_draw">
+                                                <property name="width-request">40</property>
+                                                <property name="height-request">40</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                              </object>
+                                              <packing>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                         </child>
                                         <child type="label">
@@ -22531,20 +23016,48 @@ Coordinates</property>
                                         <property name="vexpand">False</property>
                                         <property name="label-xalign">0</property>
                                         <child>
-                                          <object class="GtkSpinButton" id="shinfo_objpaperdoll_frame2">
+                                          <object class="GtkBox" id="shinfo_objpaperdoll_frame2_box">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="valign">center</property>
+                                            <property name="can-focus">False</property>
                                             <property name="margin-start">4</property>
                                             <property name="margin-end">4</property>
                                             <property name="margin-top">2</property>
                                             <property name="margin-bottom">2</property>
-                                            <property name="vexpand">False</property>
-                                            <property name="width-chars">5</property>
-                                            <property name="primary-icon-activatable">False</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <property name="adjustment">adjustment28</property>
-                                            <property name="climb-rate">1</property>
+                                            <property name="orientation">horizontal</property>
+                                            <child>
+                                              <object class="GtkSpinButton" id="shinfo_objpaperdoll_frame2">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                                <property name="vexpand">False</property>
+                                                <property name="width-chars">5</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
+                                                <property name="adjustment">adjustment28</property>
+                                                <property name="climb-rate">1</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkDrawingArea" id="shinfo_objpaperdoll_frame2_draw">
+                                                <property name="width-request">40</property>
+                                                <property name="height-request">40</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <property name="margin-start">4</property>
+                                                <property name="margin-end">4</property>
+                                                <property name="margin-top">2</property>
+                                                <property name="margin-bottom">2</property>
+                                              </object>
+                                              <packing>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                         </child>
                                         <child type="label">
@@ -22818,6 +23331,23 @@ Coordinates</property>
                                       </object>
                                       <packing>
                                         <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="shinfo_brightness_frame_draw">
+                                        <property name="width-request">40</property>
+                                        <property name="height-request">40</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">3</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -23136,6 +23666,23 @@ Coordinates</property>
                                       </object>
                                       <packing>
                                         <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkDrawingArea" id="shinfo_warmth_frame_draw">
+                                        <property name="width-request">40</property>
+                                        <property name="height-request">40</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">center</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">4</property>
+                                        <property name="margin-end">4</property>
+                                        <property name="margin-top">2</property>
+                                        <property name="margin-bottom">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">3</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -26998,7 +27545,7 @@ Coordinates</property>
                         <property name="secondary-icon-activatable">False</property>
                         <property name="adjustment">adjustment5</property>
                         <property name="climb-rate">1</property>
-                        <signal name="changed" handler="on_cont_shape_changed" swapped="no"/>
+                        <!-- <signal name="changed" handler="on_cont_shape_changed" swapped="no"/> -->
                       </object>
                     </child>
                     <child type="label">
@@ -27043,7 +27590,7 @@ Coordinates</property>
                         <property name="adjustment">adjustment4</property>
                         <property name="climb-rate">1</property>
                         <property name="wrap">True</property>
-                        <signal name="changed" handler="on_cont_shape_changed" swapped="no"/>
+                        <!-- <signal name="changed" handler="on_cont_shape_changed" swapped="no"/> -->
                       </object>
                     </child>
                     <child type="label">

--- a/mapedit/objedit.cc
+++ b/mapedit/objedit.cc
@@ -100,48 +100,6 @@ C_EXPORT gboolean on_obj_window_delete_event(
 }
 
 /*
- *  Draw shape in object shape area.
- */
-gboolean ExultStudio::on_obj_draw_expose_event(
-    GtkWidget *widget,      // The view window.
-    cairo_t *cairo,
-    gpointer data           // -> ExultStudio.
-) {
-	ignore_unused_variable_warning(widget, data);
-	auto *studio = static_cast<ExultStudio *>(data);
-	GdkRectangle area = { 0, 0, 0, 0 };
-	gdk_cairo_get_clip_rectangle(cairo, &area);
-	studio->obj_draw->set_graphic_context(cairo);
-	studio->show_obj_shape(area.x, area.y, area.width, area.height);
-	studio->obj_draw->set_graphic_context(nullptr);
-	return TRUE;
-}
-
-/*
- *  Object shape/frame # changed, so update shape displayed.
- */
-C_EXPORT gboolean on_obj_shape_changed(
-    GtkWidget *widget,
-    GdkEventFocus *event,
-    gpointer user_data
-) {
-	ignore_unused_variable_warning(widget, event, user_data);
-	ExultStudio *studio = ExultStudio::get_instance();
-	int shnum = studio->get_num_entry("obj_shape");
-	int frnum = studio->get_num_entry("obj_frame");
-	int nframes =
-	    studio->get_vgafile()->get_ifile()->get_num_frames(shnum);
-	int xfrnum = frnum & 31;    // Look at unrotated value.
-	int newfrnum = xfrnum >= nframes ? 0 : frnum;
-	if (newfrnum != frnum) {
-		studio->set_spin("obj_frame", newfrnum);
-		return TRUE;
-	}
-	studio->show_obj_shape();
-	return TRUE;
-}
-
-/*
  *  Object shape/frame # changed, so update shape displayed.
  */
 C_EXPORT gboolean on_obj_pos_changed(
@@ -154,27 +112,13 @@ C_EXPORT gboolean on_obj_pos_changed(
 	return TRUE;
 }
 
-/*
- *  Callback for when a shape is dropped on the draw area.
- */
-
-static void Obj_shape_dropped(
-    int file,           // U7_SHAPE_SHAPES.
-    int shape,
-    int frame,
-    void *udata
-) {
-	if (file == U7_SHAPE_SHAPES &&
-	        shape >= c_first_obj_shape && shape < c_max_shapes)
-		static_cast<ExultStudio *>(udata)->set_obj_shape(shape, frame);
-}
-
 #ifdef _WIN32
 
-static void Drop_dragged_shape(int shape, int frame, int x, int y, void *data) {
+void ExultStudio::Obj_shape_dropped(int shape, int frame, int x, int y, void *data) {
 	cout << "Dropped a shape: " << shape << "," << frame << " " << data << endl;
 	ignore_unused_variable_warning(x, y);
-	Obj_shape_dropped(U7_SHAPE_SHAPES, shape, frame, data);
+	auto *studio = static_cast<ExultStudio *>(data);
+	Shape_single::on_shape_dropped(U7_SHAPE_SHAPES, shape, frame, studio->obj_single);
 }
 
 #endif
@@ -198,22 +142,26 @@ void ExultStudio::open_obj_window(
 		objwin = get_widget("obj_window");
 		// Note: vgafile can't be null here.
 		if (palbuf) {
-			obj_draw = new Shape_draw(vgafile->get_ifile(),
-			                          palbuf.get(),
-			                          get_widget("obj_draw"));
-			obj_draw->enable_drop(Obj_shape_dropped, this);
+			obj_single = new Shape_single(
+			    get_widget("obj_shape"), get_widget("obj_name"),
+			    [](int shnum)->bool{ return (shnum >= c_first_obj_shape) &&
+			                                (shnum < c_max_shapes); },
+			    get_widget("obj_frame"),
+			    U7_SHAPE_SHAPES,
+			    vgafile->get_ifile(),
+			    palbuf.get(),
+			    get_widget("obj_draw"));
 		}
 	}
 	// Init. obj address to null.
 	g_object_set_data(G_OBJECT(objwin), "user_data", nullptr);
-	g_signal_connect(G_OBJECT(get_widget("obj_draw")), "draw",
-	                 G_CALLBACK(on_obj_draw_expose_event), this);
 	if (!init_obj_window(data, datalen))
 		return;
 	gtk_widget_show(objwin);
 #ifdef _WIN32
 	if (first_time || !objdnd)
-		Windnd::CreateStudioDropDest(objdnd, objhwnd, Drop_dragged_shape,
+		Windnd::CreateStudioDropDest(objdnd, objhwnd,
+		                             ExultStudio::Obj_shape_dropped,
 		                             nullptr, nullptr, this);
 #endif
 }
@@ -329,45 +277,5 @@ void ExultStudio::rotate_obj(
 	const Shape_info &info = shfile->get_info(shnum);
 	frnum = info.get_rotated_frame(frnum, 1);
 	set_spin("obj_frame", frnum);
-	show_obj_shape();
+	obj_single->render();
 }
-
-/*
- *  Paint the shape in the draw area.
- */
-
-void ExultStudio::show_obj_shape(
-    int x, int y, int w, int h  // Rectangle. w=-1 to show all.
-) {
-	if (!obj_draw)
-		return;
-	if (w == -1) {
-		obj_draw->render();
-		return;
-	}
-	obj_draw->configure();
-	// Yes, this is kind of redundant...
-	int shnum = get_num_entry("obj_shape");
-	int frnum = get_num_entry("obj_frame");
-	if (!shnum)         // Don't draw shape 0.
-		shnum = -1;
-	obj_draw->draw_shape_centered(shnum, frnum);
-	obj_draw->show(x, y, w, h);
-}
-
-/*
- *  Set object shape.
- */
-
-void ExultStudio::set_obj_shape(
-    int shape,
-    int frame
-) {
-	set_spin("obj_shape", shape);
-	set_spin("obj_frame", frame);
-	const char *nm = get_shape_name(shape);
-	set_entry("obj_name", nm ? nm : "", false);
-	show_obj_shape();
-}
-
-

--- a/mapedit/shapedraw.h
+++ b/mapedit/shapedraw.h
@@ -82,13 +82,53 @@ public:
 	                               gint x, gint y,
 	                               GtkSelectionData *seldata,
 	                               guint info, guint time, gpointer udata);
-	void enable_drop(Drop_callback callback, void *udata);
+	gulong enable_drop(Drop_callback callback, void *udata);
 	void set_drag_icon(GdkDragContext *context, Shape_frame *shape);
 	// Start/end dragging from here.
 	void start_drag(const char *target, int id, GdkEvent *event);
 	void mouse_up() {
 		dragging = false;
 	}
+};
+
+class Shape_single : public Shape_draw {
+protected:
+	GtkWidget *shape;         // The ShapeID   holding GtkWidget :
+	                          //     GtkSpinButton / GtkEntry,
+	                          //     or GtkFrame ( NPCEditor NPC Face ).
+	GtkWidget *shapename;     // The ShapeName holding GtkLabel.
+	bool(*shapevalid)(int s); // The ShapeID   validating lambda.
+	GtkWidget *frame;         // The FrameID   holding GtkWidget :
+	                          //     GtkSpinButton / GtkEntry.
+	int vganum;               // For a Drag and Drop enabled Shape_single :
+	bool hide;                // Whether the Shape should be hidden.
+	gulong shape_connect;     // The Shape Widget g_signal_connect changed ID
+	gulong frame_connect;     // The Frame Widget g_signal_connect changed ID
+	gulong draw_connect;      // The Draw  Widget g_signal_connect draw ID
+	gulong drop_connect;      // The Draw  Widget g_signal_connect drop ID
+	gulong hide_connect;      // The Hide  Widget g_signal_connect changed ID
+public:
+	Shape_single(
+	    GtkWidget *shp,       // The ShapeID   holding GtkWidget.
+	    GtkWidget *shpnm,     // The ShapeName holding GtkWidget.
+	    bool (*shvld)(int),   // The ShapeUD   validating lambda.
+	    GtkWidget *frm,       // The FrameID   holding GtkWidget.
+	    int vgnum,            // The D&D U7_SHAPE_xxx VGA file category.
+	    Vga_file *vg,         // The VGA File         for the Shape_draw constructor.
+	    const unsigned char *palbuf, // The Palette for the Shape_draw constructor.
+	    GtkWidget *drw,       // The GtkDrawingArea   for the Shape_draw constructor.
+	    bool hdd = false);    // Whether the Shape should be hidden.
+	~Shape_single() override;
+	static void on_shape_changed(
+	    GtkWidget *widget, gpointer user_data);
+	static void on_frame_changed(
+	    GtkWidget *widget, gpointer user_data);
+	static gboolean on_draw_expose_event(
+	    GtkWidget *widget, cairo_t  *cairo, gpointer user_data);
+	static void on_shape_dropped(
+	    int filenum, int shapenum, int framenum, gpointer user_data);
+	static void on_state_changed(
+	    GtkWidget *widget, GtkStateFlags flags, gpointer user_data);
 };
 
 #endif

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -524,14 +524,27 @@ ExultStudio::ExultStudio(int argc, char **argv): glade_path(nullptr),
 	shape_info_modified(false), shape_names_modified(false), npc_modified(false),
 	files(nullptr), curfile(nullptr),
 	vgafile(nullptr), facefile(nullptr), fontfile(nullptr), gumpfile(nullptr),
-	spritefile(nullptr), browser(nullptr),
+	spritefile(nullptr), paperdolfile(nullptr), browser(nullptr),
 	bargewin(nullptr), barge_ctx(0), barge_status_id(0),
-	eggwin(nullptr), egg_monster_draw(nullptr), egg_ctx(0), egg_status_id(0),
-	npcwin(nullptr), npc_draw(nullptr), npc_face_draw(nullptr),
+	eggwin(nullptr), egg_monster_single(nullptr), egg_missile_single(nullptr),
+	egg_ctx(0), egg_status_id(0),
+	npcwin(nullptr), npc_single(nullptr), npc_face_single(nullptr),
 	npc_ctx(0), npc_status_id(0),
-	objwin(nullptr), obj_draw(nullptr), contwin(nullptr), cont_draw(nullptr), shapewin(nullptr),
-	shape_draw(nullptr), gump_draw(nullptr),
-	body_draw(nullptr), explosion_draw(nullptr),
+	objwin(nullptr), obj_single(nullptr), contwin(nullptr), cont_single(nullptr), shapewin(nullptr),
+	shape_single(nullptr), gump_single(nullptr),
+	body_single(nullptr), explosion_single(nullptr),
+	weapon_family_single(nullptr), weapon_projectile_single(nullptr),
+	ammo_family_single(nullptr), ammo_sprite_single(nullptr),
+	cntrules_shape_single(nullptr),
+	frameflags_frame_single(nullptr), effhps_frame_single(nullptr),
+	framenames_frame_single(nullptr), frameusecode_frame_single(nullptr),
+	objpaperdoll_wframe_single(nullptr), objpaperdoll_spotframe_single(nullptr),
+	brightness_frame_single(nullptr), warmth_frame_single(nullptr),
+	npcpaperdoll_aframe_single(nullptr), npcpaperdoll_atwohanded_single(nullptr),
+	npcpaperdoll_astaff_single(nullptr), npcpaperdoll_bframe_single(nullptr),
+	npcpaperdoll_hframe_single(nullptr), npcpaperdoll_hhelm_single(nullptr),
+	objpaperdoll_frame0_single(nullptr), objpaperdoll_frame1_single(nullptr),
+	objpaperdoll_frame2_single(nullptr), objpaperdoll_frame3_single(nullptr),
 	equipwin(nullptr), locwin(nullptr), combowin(nullptr),
 	compilewin(nullptr), compile_box(nullptr),
 	ucbrowsewin(nullptr), gameinfowin(nullptr),
@@ -838,24 +851,48 @@ ExultStudio::~ExultStudio() {
 	palbuf.reset();
 	if (objwin)
 		gtk_widget_destroy(objwin);
-	delete obj_draw;
+	delete obj_single;
 	if (contwin)
 		gtk_widget_destroy(contwin);
-	delete cont_draw;
+	delete cont_single;
 	if (eggwin)
 		gtk_widget_destroy(eggwin);
-	delete egg_monster_draw;
+	delete egg_monster_single;
+	delete egg_missile_single;
 	eggwin = nullptr;
 	if (npcwin)
 		gtk_widget_destroy(npcwin);
-	delete npc_draw;
+	delete npc_single;
 	npcwin = nullptr;
 	if (shapewin)
 		gtk_widget_destroy(shapewin);
-	delete shape_draw;
-	delete gump_draw;
-	delete body_draw;
-	delete explosion_draw;
+	delete shape_single;
+	delete gump_single;
+	delete body_single;
+	delete explosion_single;
+	delete weapon_family_single;
+	delete weapon_projectile_single;
+	delete ammo_family_single;
+	delete ammo_sprite_single;
+	delete cntrules_shape_single;
+	delete frameflags_frame_single;
+	delete effhps_frame_single;
+	delete framenames_frame_single;
+	delete frameusecode_frame_single;
+	delete objpaperdoll_wframe_single;
+	delete objpaperdoll_spotframe_single;
+	delete brightness_frame_single;
+	delete warmth_frame_single;
+	delete npcpaperdoll_aframe_single;
+	delete npcpaperdoll_atwohanded_single;
+	delete npcpaperdoll_astaff_single;
+	delete npcpaperdoll_bframe_single;
+	delete npcpaperdoll_hframe_single;
+	delete npcpaperdoll_hhelm_single;
+	delete objpaperdoll_frame0_single;
+	delete objpaperdoll_frame1_single;
+	delete objpaperdoll_frame2_single;
+	delete objpaperdoll_frame3_single;
 	shapewin = nullptr;
 	if (equipwin)
 		gtk_widget_destroy(equipwin);
@@ -1449,6 +1486,8 @@ void ExultStudio::set_game_path(const string &gamename, const string &modname) {
 	fontfile = open_shape_file("fonts.vga");
 	gumpfile = open_shape_file("gumps.vga");
 	spritefile = open_shape_file("sprites.vga");
+	if (game_type == SERPENT_ISLE)
+		paperdolfile = open_shape_file("paperdol.vga");
 	Setup_text(game_type == SERPENT_ISLE, expansion, sibeta);   // Read in shape names.
 	misc_name_map.clear();
 	for (int i = 0; i < get_num_misc_names(); i++)

--- a/mapedit/studio.h
+++ b/mapedit/studio.h
@@ -79,7 +79,7 @@ struct Equip_row_widgets;
 class Shape_file_set;
 class Shape_file_info;
 class Shape_group_file;
-class Shape_draw;
+class Shape_single;
 class Object_browser;
 class Shape_group;
 class Locator;
@@ -125,6 +125,7 @@ private:
 	Shape_file_info     *fontfile;  // 'font.vga'.
 	Shape_file_info     *gumpfile;  // 'gumps.vga'.
 	Shape_file_info     *spritefile;    // 'sprites.vga'.
+	Shape_file_info     *paperdolfile;  // 'paperdol.vga'.
 	Object_browser      *browser;
 	std::unique_ptr<unsigned char[]> palbuf;    // 3*256 rgb's, each 0-63.
 	// Barge editor:
@@ -133,24 +134,37 @@ private:
 	guint           barge_status_id;
 	// Egg editor:
 	GtkWidget       *eggwin;// Egg window.
-	Shape_draw      *egg_monster_draw;
+	Shape_single    *egg_monster_single;
+	Shape_single    *egg_missile_single;
 	int             egg_ctx;
 	guint           egg_status_id;
 	// Npc editor:
 	GtkWidget       *npcwin;
-	Shape_draw      *npc_draw, *npc_face_draw;
+	Shape_single    *npc_single, *npc_face_single;
 	int             npc_ctx;
 	guint           npc_status_id;
 	// Object editor:
 	GtkWidget       *objwin;
-	Shape_draw      *obj_draw;
+	Shape_single    *obj_single;
 	// Container editor:
 	GtkWidget       *contwin;
-	Shape_draw      *cont_draw;
+	Shape_single    *cont_single;
 	// Shape info. editor:
 	GtkWidget       *shapewin;
-	Shape_draw      *shape_draw, *gump_draw,
-	                *body_draw, *explosion_draw;
+	Shape_single    *shape_single, *gump_single,
+	                *body_single, *explosion_single;
+	Shape_single    *weapon_family_single, *weapon_projectile_single;
+	Shape_single    *ammo_family_single, *ammo_sprite_single;
+	Shape_single    *cntrules_shape_single;
+	Shape_single    *frameflags_frame_single, *effhps_frame_single,
+	                *framenames_frame_single, *frameusecode_frame_single;
+	Shape_single    *objpaperdoll_wframe_single, *objpaperdoll_spotframe_single;
+	Shape_single    *brightness_frame_single, *warmth_frame_single;
+	Shape_single    *npcpaperdoll_aframe_single, *npcpaperdoll_atwohanded_single,
+	                *npcpaperdoll_astaff_single, *npcpaperdoll_bframe_single,
+	                *npcpaperdoll_hframe_single, *npcpaperdoll_hhelm_single;
+	Shape_single    *objpaperdoll_frame0_single, *objpaperdoll_frame1_single,
+	                *objpaperdoll_frame2_single, *objpaperdoll_frame3_single;
 	GtkWidget       *equipwin;
 	// Map locator:
 	Locator         *locwin;
@@ -291,20 +305,18 @@ public:
 	int init_obj_window(unsigned char *data, int datalen);
 	int save_obj_window();
 	void rotate_obj();
-	void show_obj_shape(int x = 0, int y = 0, int w = -1, int h = -1);
-	void set_obj_shape(int shape, int frame);
-	static gboolean on_obj_draw_expose_event(
-	    GtkWidget *widget, cairo_t *cairo, gpointer data);
+#ifdef _WIN32
+	static void Obj_shape_dropped(int shape, int frame, int x, int y, void *data);
+#endif
 	// Containers:
 	void open_cont_window(unsigned char *data, int datalen);
 	void close_cont_window();
 	int init_cont_window(unsigned char *data, int datalen);
 	int save_cont_window();
 	void rotate_cont();
-	void show_cont_shape(int x = 0, int y = 0, int w = -1, int h = -1);
-	void set_cont_shape(int shape, int frame);
-	static gboolean on_cont_draw_expose_event(
-	    GtkWidget *widget, cairo_t *cairo, gpointer data);
+#ifdef _WIN32
+	static void Cont_shape_dropped(int shape, int frame, int x, int y, void *data);
+#endif
 	// Barges:
 	void open_barge_window(unsigned char *data = nullptr, int datalen = 0);
 	void close_barge_window();
@@ -315,10 +327,9 @@ public:
 	void close_egg_window();
 	int init_egg_window(unsigned char *data, int datalen);
 	int save_egg_window();
-	void show_egg_monster(int x = 0, int y = 0, int w = -1, int h = -1);
-	void set_egg_monster(int shape, int frame);
-	static gboolean on_egg_monster_draw_expose_event(
-	    GtkWidget *widget, cairo_t *cairo, gpointer data);
+#ifdef _WIN32
+	static void Egg_monster_dropped(int shape, int frame, int x, int y, void *data);
+#endif
 	// NPC's:
 	void open_npc_window(unsigned char *data = nullptr, int datalen = 0);
 	void close_npc_window();
@@ -326,22 +337,18 @@ public:
 	int init_npc_window(unsigned char *data, int datalen);
 	int save_npc_window();
 	void update_npc(); // updates the npc browser if it is open
-	void show_npc_shape(int x = 0, int y = 0, int w = -1, int h = -1);
-	void set_npc_shape(int shape, int frame);
-	void show_npc_face(int x = 0, int y = 0, int w = -1, int h = -1);
-	void set_npc_face(int shape, int frame);
 	static void schedule_btn_clicked(GtkWidget *btn, gpointer data);
-	static gboolean on_npc_draw_expose_event(
-	    GtkWidget *widget, cairo_t *cairo, gpointer data);
-	static gboolean on_npc_face_draw_expose_event(
-	    GtkWidget *widget, cairo_t *cairo, gpointer data);
+#ifdef _WIN32
+	static void Npc_shape_dropped(int shape, int frame, int x, int y, void *data);
+	static void Npc_face_dropped(int shape, int frame, int x, int y, void *data);
+#endif
 	// Shapes:
+	GdkPixbuf *shape_image(     // The GdkPixbuf should be g_object_unrefed.
+	    Vga_file *shpfile, int shnum, int frnum, bool transparent);
 	void init_equip_window(int recnum);
 	void save_equip_window();
 	void open_equip_window(int recnum);
 	void close_equip_window();
-	void show_equip_shape(Equip_row_widgets *eq,
-	                      int x = 0, int y = 0, int w = -1, int h = -1);
 	void new_equip_record();
 	void set_shape_notebook_frame(int frnum);
 	void init_shape_notebook(const Shape_info &info, GtkWidget *book,
@@ -352,19 +359,6 @@ public:
 	                       const char *shname, Shape_info *info = nullptr);
 	void save_shape_window();
 	void close_shape_window();
-	void show_shinfo_shape(int x = 0, int y = 0, int w = -1, int h = -1);
-	void show_shinfo_gump(int x = 0, int y = 0, int w = -1, int h = -1);
-	void show_shinfo_npcgump(int x = 0, int y = 0, int w = -1, int h = -1);
-	void show_shinfo_body(int x = 0, int y = 0, int w = -1, int h = -1);
-	void show_shinfo_explosion(int x = 0, int y = 0, int w = -1, int h = -1);
-	static gboolean on_shinfo_draw_expose_event(
-	    GtkWidget *widget, cairo_t *cairo, gpointer data);
-	static gboolean on_shinfo_gump_draw_expose_event(
-	    GtkWidget *widget, cairo_t *cairo, gpointer data);
-	static gboolean on_shinfo_body_draw_expose_event(
-	    GtkWidget *widget, cairo_t *cairo, gpointer data);
-	static gboolean on_shinfo_explosion_draw_expose_event(
-	    GtkWidget *widget, cairo_t *cairo, gpointer data);
 	// Map locator.
 	void open_locator_window();
 	// Combo editor.


### PR DESCRIPTION
Contrarily to the discussion in issue #71, the code compiles and runs on Linux and on Windows, I figured out what the Drag and Drop WIN32 problem was and fixed it.

By the way, this highlighted that I should have had more compilation failures. Indeed, the three stand alone shape displays of the Shape Editor [ Gump, Body and Explosion ] claim to be Drop targets ( enable_drop ) but do not use the WIN32 path. 
