### PR TITLE
Simplify tqueue

### DIFF
--- a/npcnear.h
+++ b/npcnear.h
@@ -22,6 +22,7 @@
 #define NPCNEAR_H   1
 
 #include "tqueue.h"
+#include <vector>
 
 class Game_window;
 class Npc_actor;

--- a/tqueue.cc
+++ b/tqueue.cc
@@ -92,17 +92,15 @@ int Time_queue::remove(
     Time_sensitive *obj,
     uintptr udata
 ) {
-	if (data.empty())
-		return 0;
-	for (auto it = data.begin();
-	        it != data.end(); ++it) {
-		if (it->handler == obj && it->udata == udata) {
-			obj->queue_cnt--;
-			data.erase(it);
-			return 1;
-		}
+    auto it = std::find_if(data.begin(), data.end(),
+            [&](const auto& el) { return el.handler == obj && el.udata == udata; }
+    );
+    bool found = it != data.end();
+    if (found) {
+		obj->queue_cnt--;
+		data.erase(it);
 	}
-	return 0;         // Not found.
+    return found;
 }
 
 /*

--- a/tqueue.cc
+++ b/tqueue.cc
@@ -166,8 +166,6 @@ void Time_queue::activate0(
 void Time_queue::activate_always(
     uint32 curtime      // Current time.
 ) {
-	if (data.empty())
-		return;
 	auto newStart = std::stable_partition(data.begin(), data.end(),
 		[&] (const auto& el) { return !(curtime < el.time); });
 

--- a/tqueue.cc
+++ b/tqueue.cc
@@ -53,9 +53,7 @@ void Time_queue::add(
 		// Messy, but we need to fix time.
 		t -= SDL_GetTicks() - pause_time;
 	newent.set(t, obj, ud);
-	auto insertionPoint = 
-		std::find_if(data.begin(), data.end(),
-			[&](const auto& el) { return newent < el; });
+	auto insertionPoint = std::lower_bound(data.begin(), data.end(), newent);
 	data.insert(insertionPoint, newent);
 }
 

--- a/tqueue.cc
+++ b/tqueue.cc
@@ -149,8 +149,6 @@ long Time_queue::find_delay(
 void Time_queue::activate0(
     uint32 curtime      // Current time.
 ) {
-	if (data.empty())
-		return;
 	Queue_entry ent;
 	do {
 		ent = data.front();

--- a/tqueue.cc
+++ b/tqueue.cc
@@ -215,9 +215,13 @@ int Time_queue_iterator::operator()(
     Time_sensitive  *&obj,      // Main object.
     uintptr &data          // Data that was added with it.
 ) {
-	while (iter != tqueue->data.end() && this_obj &&
-	        (*iter).handler != this_obj)
-		++iter;
+	auto remain = iter;
+	iter = this_obj == nullptr
+		? remain
+		: std::find_if(iter, tqueue->data.end(), [&](const auto& el) {
+			return el.handler == this_obj;
+		}
+	);
 	if (iter == tqueue->data.end())
 		return 0;
 	obj = (*iter).handler;      // Return fields.

--- a/tqueue.cc
+++ b/tqueue.cc
@@ -72,14 +72,12 @@ int Time_queue::remove(
 ) {
 	auto toRemove = std::find_if(data.begin(), data.end(),
 			[obj](const auto& el) { return el.handler == obj; });
-	if (toRemove == data.end()) {
-		return 0;
-	} else {
+	auto found = toRemove != data.end();
+	if (found) {
 		(*toRemove).handler->queue_cnt--;
 		data.erase(toRemove);
-		return 1;
 	}
-	return 0;         // Not found.
+	return found;
 }
 
 /*
@@ -100,7 +98,7 @@ int Time_queue::remove(
 		obj->queue_cnt--;
 		data.erase(it);
 	}
-    return found;
+	return found;
 }
 
 /*

--- a/tqueue.h
+++ b/tqueue.h
@@ -22,7 +22,6 @@
 #define TQUEUE_H    1
 
 
-#include <vector>
 #include <list>
 
 #include "common_types.h"


### PR DESCRIPTION
Some code clean-up, mostly moving from bare loops to STL algos/ranged for loops.
I actually wanted to use upper bound in `activate0`, too, but it seems objects are deletign themselves sometimes, which ends in double-free again, so I gave it up, temporarily at least.
@marzojr two questions related to tqueue:
1. What will you say about using a different data structure? As it's supposed to be sorted, multimap with time being the key seems more viable than list. I was also thinking about priority queue, but it does not allow random access.
2. What do you think about including Boost? Some classes like Tqeue could greatly benefit from it, e.g. thanks to its filter_iterator (which currently Tqeue_iteratator replaces). License-wise that should not be a problem, technically not a big issue either, as IIRC when iterator is a header-only lib, question is if an extra dependency is to be tolerated there.