### PR TITLE
Prototype : Studio in WIN32 : Use GTK+ 3 OLE2 provided Drag and Drop instead of Windrag

### DIFF
--- a/exult.cc
+++ b/exult.cc
@@ -202,13 +202,14 @@ static void set_scaleval(int new_scaleval);
 #ifdef USE_EXULTSTUDIO
 static void Move_dragged_shape(int shape, int frame, int x, int y,
                                int prevx, int prevy, bool show);
+#ifdef _WIN32
 static void Move_dragged_combo(int xtiles, int ytiles, int tiles_right,
                                int tiles_below, int x, int y, int prevx, int prevy, bool show);
-static void Drop_dragged_shape(int shape, int frame, int x, int y, void *d);
-static void Drop_dragged_chunk(int chunknum, int x, int y, void *d);
-static void Drop_dragged_npc(int npcnum, int x, int y, void *d);
-static void Drop_dragged_combo(int cnt, U7_combo_data *combo,
-                               int x, int y, void *d);
+#endif
+static void Drop_dragged_shape(int shape, int frame, int x, int y);
+static void Drop_dragged_chunk(int chunknum, int x, int y);
+static void Drop_dragged_npc(int npcnum, int x, int y);
+static void Drop_dragged_combo(int cnt, U7_combo_data *combo, int x, int y);
 #endif
 static void BuildGameMap(BaseGameInfo *game, int mapnum);
 static void Handle_events();
@@ -973,7 +974,7 @@ static void Paint_with_shape(
 		cheat.set_edit_shape(shnum, nextframe);
 	} else
 		frnum = cheat.get_edit_frame();
-	Drop_dragged_shape(shnum, frnum, event.button.x, event.button.y, nullptr);
+	Drop_dragged_shape(shnum, frnum, event.button.x, event.button.y);
 }
 
 /*
@@ -998,7 +999,7 @@ static void Paint_with_chunk(
 	lastcx = cx;
 	lastcy = cy;
 	int chnum = cheat.get_edit_chunknum();
-	Drop_dragged_chunk(chnum, event.button.x, event.button.y, nullptr);
+	Drop_dragged_chunk(chnum, event.button.x, event.button.y);
 }
 
 /*
@@ -1692,7 +1693,7 @@ static void Handle_event(
 			if (shape >= 0) {   // Dropping a shape?
 				if (file == U7_SHAPE_SHAPES)
 					// For now, just allow "shapes.vga".
-					Drop_dragged_shape(shape, frame, x, y, nullptr);
+					Drop_dragged_shape(shape, frame, x, y);
 			}
 		} else if (Is_u7_chunkid(data) == true) {
 			// A whole chunk.
@@ -1700,14 +1701,14 @@ static void Handle_event(
 			Get_u7_chunkid(data, chunknum);
 			cout << "(EXULT) SDL_DROPFILE Event, Chunk: num = " << chunknum << endl;
 			if (chunknum >= 0) { // A whole chunk.
-				Drop_dragged_chunk(chunknum, x, y, nullptr);
+				Drop_dragged_chunk(chunknum, x, y);
 			}
 		} else if (Is_u7_npcid(data) == true) {
 			int npcnum;
 			Get_u7_npcid(data, npcnum);
 			cout << "(EXULT) SDL_DROPFILE Event, Npc: num = " << npcnum << endl;
 			if (npcnum >= 0) { // An NPC.
-				Drop_dragged_npc(npcnum, x, y, nullptr);
+				Drop_dragged_npc(npcnum, x, y);
 			}
 		} else if (Is_u7_comboid(data) == true) {
 			int combo_xtiles, combo_ytiles, combo_tiles_right, combo_tiles_below, combo_cnt;
@@ -1719,7 +1720,7 @@ static void Handle_event(
 			     << ", tiles_below = " << combo_tiles_below
 			     << ", count = " << combo_cnt << endl;
 			if (combo_cnt >= 0 && combo) {
-				Drop_dragged_combo(combo_cnt, combo, x, y, nullptr);
+				Drop_dragged_combo(combo_cnt, combo, x, y);
 			}
 			delete[] combo;
 		}
@@ -2567,6 +2568,7 @@ static void Move_dragged_shape(
 		gwin->show();
 }
 
+#ifdef _WIN32
 /*
  *  Show where a shape dragged from a shape-chooser will go.
  */
@@ -2584,6 +2586,7 @@ static void Move_dragged_combo(
 	if (show)
 		gwin->show();
 }
+#endif
 
 /*
  *  Create an object as moveable (IREG) or fixed.
@@ -2612,11 +2615,9 @@ static Game_object_shared Create_object(
  */
 
 static void Drop_dragged_shape(
-    int shape, int frame,       // What to create.
-    int x, int y,           // Mouse coords. within window.
-    void *data          // Passed data, unused by exult
+    int shape, int frame,   // What to create.
+    int x, int y            // Mouse coords. within window.
 ) {
-	ignore_unused_variable_warning(data);
 	if (!cheat.in_map_editor()) // Get into editing mode.
 		cheat.toggle_map_editor();
 	cheat.clear_selected();     // Remove old selected.
@@ -2659,10 +2660,8 @@ static void Drop_dragged_shape(
 
 static void Drop_dragged_chunk(
     int chunknum,           // Index in 'u7chunks'.
-    int x, int y,           // Mouse coords. within window.
-    void *data          // Passed data, unused by exult
+    int x, int y            // Mouse coords. within window.
 ) {
-	ignore_unused_variable_warning(data);
 	if (!cheat.in_map_editor()) // Get into editing mode.
 		cheat.toggle_map_editor();
 	gwin->get_win()->screen_to_game(x, y, false, x, y);
@@ -2683,10 +2682,8 @@ static void Drop_dragged_chunk(
 
 static void Drop_dragged_npc(
     int npcnum,
-    int x, int y,           // Mouse coords. within window.
-    void *data          // Passed data, unused by exult
+    int x, int y            // Mouse coords. within window.
 ) {
-	ignore_unused_variable_warning(data);
 	if (!cheat.in_map_editor()) // Get into editing mode.
 		cheat.toggle_map_editor();
 	gwin->get_win()->screen_to_game(x, y, false, x, y);
@@ -2714,10 +2711,8 @@ static void Drop_dragged_npc(
 void Drop_dragged_combo(
     int cnt,            // # shapes.
     U7_combo_data *combo,       // The shapes.
-    int x, int y,           // Mouse coords. within window.
-    void *data          // Passed data, unused by exult
+    int x, int y            // Mouse coords. within window.
 ) {
-	ignore_unused_variable_warning(data);
 	if (!cheat.in_map_editor()) // Get into editing mode.
 		cheat.toggle_map_editor();
 	cheat.clear_selected();     // Remove old selected.

--- a/mapedit/chunklst.cc
+++ b/mapedit/chunklst.cc
@@ -481,8 +481,8 @@ void Chunk_chooser::drag_data_received(
 	     << gdk_atom_name(gtk_selection_data_get_data_type(seldata))
 	     << "'" << endl;
 	if ((gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_CHUNKID_NAME, 0) ||
-	     gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_GENERIC_NAME_X11, 0) ||
-	     gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_GENERIC_NAME_MACOSX, 0)) &&
+	     gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_DROPFILE_NAME_MIME, 0) ||
+	     gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_DROPFILE_NAME_MACOSX, 0)) &&
 	        Is_u7_chunkid(gtk_selection_data_get_data(seldata)) &&
 	        gtk_selection_data_get_format(seldata) == 8 &&
 	        gtk_selection_data_get_length(seldata) > 0) {
@@ -504,11 +504,10 @@ void Chunk_chooser::enable_drop(
 		return;
 	drop_enabled = true;
 	gtk_widget_realize(draw);//???????
-#ifndef _WIN32
 	GtkTargetEntry tents[3];
 	tents[0].target = const_cast<char *>(U7_TARGET_CHUNKID_NAME);
-	tents[1].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_X11);
-	tents[2].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_MACOSX);
+	tents[1].target = const_cast<char *>(U7_TARGET_DROPFILE_NAME_MIME);
+	tents[2].target = const_cast<char *>(U7_TARGET_DROPFILE_NAME_MACOSX);
 	tents[0].flags = 0;
 	tents[1].flags = 0;
 	tents[2].flags = 0;
@@ -520,7 +519,6 @@ void Chunk_chooser::enable_drop(
 
 	g_signal_connect(G_OBJECT(draw), "drag-data-received",
 	                 G_CALLBACK(drag_data_received), this);
-#endif
 }
 
 /*

--- a/mapedit/chunklst.h
+++ b/mapedit/chunklst.h
@@ -134,13 +134,8 @@ public:
 	void delete_response(const unsigned char *data, int datalen);
 	void move(bool upwards) override;    // Move current selected chunk.
 	void swap_response(const unsigned char *data, int datalen);
-#ifdef _WIN32
-	static gint win32_drag_motion(GtkWidget *widget, GdkEventMotion *event,
-	                              gpointer data);
-#else
 	static gint drag_motion(GtkWidget *widget, GdkEventMotion *event,
 	                        gpointer data);
-#endif
 };
 
 #endif

--- a/mapedit/combo.h
+++ b/mapedit/combo.h
@@ -209,13 +209,8 @@ public:
 	static void scrolled(GtkAdjustment *adj, gpointer data);
 	void move(bool upwards) override;// Move current selected combo.
 	void search(const char *srch, int dir) override;
-#ifdef _WIN32
-	static gint win32_drag_motion(GtkWidget *widget, GdkEventMotion *event,
-	                              gpointer data);
-#else
 	static gint drag_motion(GtkWidget *widget, GdkEventMotion *event,
 	                        gpointer data);
-#endif
 };
 
 

--- a/mapedit/contedit.cc
+++ b/mapedit/contedit.cc
@@ -134,18 +134,6 @@ C_EXPORT gboolean on_cont_pos_changed(
 	return TRUE;
 }
 
-#ifdef _WIN32
-
-void ExultStudio::Cont_shape_dropped(int shape, int frame, int x, int y, void *data) {
-	cout << "Dropped a shape: " << shape << "," << frame << " " << data << endl;
-	ignore_unused_variable_warning(x, y);
-	auto *studio = static_cast<ExultStudio *>(data);
-	Shape_single::on_shape_dropped(U7_SHAPE_SHAPES, shape, frame, studio->cont_single);
-}
-
-#endif
-
-
 /*
  *  Open the container-editing window.
  */
@@ -154,13 +142,7 @@ void ExultStudio::open_cont_window(
     unsigned char *data,        // Serialized object.
     int datalen
 ) {
-#ifdef _WIN32
-	bool first_time = false;
-#endif
 	if (!contwin) {         // First time?
-#ifdef _WIN32
-		first_time = true;
-#endif
 		contwin = get_widget("cont_window");
 		// Note: vgafile can't be null here.
 		if (palbuf) {
@@ -180,12 +162,6 @@ void ExultStudio::open_cont_window(
 	if (!init_cont_window(data, datalen))
 		return;
 	gtk_widget_show(contwin);
-#ifdef _WIN32
-	if (first_time || !contdnd)
-		Windnd::CreateStudioDropDest(contdnd, conthwnd,
-		                             ExultStudio::Cont_shape_dropped,
-		                             nullptr, nullptr, this);
-#endif
 }
 
 /*
@@ -196,9 +172,6 @@ void ExultStudio::close_cont_window(
 ) {
 	if (contwin) {
 		gtk_widget_hide(contwin);
-#ifdef _WIN32
-		Windnd::DestroyStudioDropDest(contdnd, conthwnd);
-#endif
 	}
 }
 

--- a/mapedit/eggedit.cc
+++ b/mapedit/eggedit.cc
@@ -119,19 +119,6 @@ C_EXPORT void on_teleport_coord_toggled(
 	studio->set_sensitive("teleport_eggnum", !on);
 }
 
-#ifdef _WIN32
-
-void ExultStudio::Egg_monster_dropped(int shape, int frame, int x, int y, void *data) {
-	ignore_unused_variable_warning(x, y);
-	if (shape < 150)
-		return;
-	cout << "Dropped a shape: " << shape << "," << frame << " " << data << endl;
-	auto *studio = static_cast<ExultStudio *>(data);
-	Shape_single::on_shape_dropped(U7_SHAPE_SHAPES, shape, frame, studio->egg_monster_single);
-}
-
-#endif
-
 /*
  *  Open the egg-editing window.
  */
@@ -183,13 +170,6 @@ void ExultStudio::open_egg_window(
 		set_sensitive("teleport_eggnum", false);
 	}
 	gtk_widget_show(eggwin);
-
-#ifdef _WIN32
-	if (first_time || !eggdnd)
-		Windnd::CreateStudioDropDest(eggdnd, egghwnd,
-		                             ExultStudio::Egg_monster_dropped,
-		                             nullptr, nullptr, this);
-#endif
 }
 
 /*
@@ -200,9 +180,6 @@ void ExultStudio::close_egg_window(
 ) {
 	if (eggwin) {
 		gtk_widget_hide(eggwin);
-#ifdef _WIN32
-		Windnd::DestroyStudioDropDest(eggdnd, egghwnd);
-#endif
 	}
 }
 

--- a/mapedit/npcedit.cc
+++ b/mapedit/npcedit.cc
@@ -40,10 +40,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <cstdlib>
 #include <cstring>
 
-#ifdef _WIN32
-#	include "windrag.h"
-#endif
-
 using std::cout;
 using std::endl;
 
@@ -220,37 +216,11 @@ static bool Get_schedule_line(
  *  Open the npc-editing window.
  */
 
-#ifdef _WIN32
-
-void ExultStudio::Npc_shape_dropped(int shape, int frame, int x, int y, void *data) {
-	ignore_unused_variable_warning(x, y);
-	if (shape < 150)
-		return;
-	cout << "Dropped a shape: " << shape << "," << frame << " " << data << endl;
-	auto *studio = static_cast<ExultStudio *>(data);
-	Shape_single::on_shape_dropped(U7_SHAPE_SHAPES, shape, frame, studio->npc_single);
-}
-
-void ExultStudio::Npc_face_dropped(int shape, int frame, int x, int y, void *data) {
-	cout << "Dropped a face: " << shape << "," << frame << " " << data << endl;
-	ignore_unused_variable_warning(x, y);
-	auto *studio = static_cast<ExultStudio *>(data);
-	Shape_single::on_shape_dropped(U7_SHAPE_FACES, shape, frame, studio->npc_face_single);
-}
-
-#endif
-
 void ExultStudio::open_npc_window(
     unsigned char *data,        // Serialized npc, or null.
     int datalen
 ) {
-#ifdef _WIN32
-	bool first_time = false;
-#endif
 	if (!npcwin) {          // First time?
-#ifdef _WIN32
-		first_time = true;
-#endif
 		npcwin = get_widget("npc_window");
 
 		if (vgafile && palbuf) {
@@ -292,14 +262,6 @@ void ExultStudio::open_npc_window(
 	} else
 		init_new_npc();
 	gtk_widget_show(npcwin);
-#ifdef _WIN32
-	if (first_time || !npcdnd)
-		Windnd::CreateStudioDropDest(npcdnd, npchwnd,
-		                             ExultStudio::Npc_shape_dropped,
-		                             nullptr,
-		                             ExultStudio::Npc_face_dropped, this);
-
-#endif
 }
 
 /*
@@ -310,9 +272,6 @@ void ExultStudio::close_npc_window(
 ) {
 	if (npcwin) {
 		gtk_widget_hide(npcwin);
-#ifdef _WIN32
-		Windnd::DestroyStudioDropDest(npcdnd, npchwnd);
-#endif
 	}
 }
 

--- a/mapedit/npclst.cc
+++ b/mapedit/npclst.cc
@@ -683,8 +683,8 @@ void Npc_chooser::drag_data_received(
 	     << gdk_atom_name(gtk_selection_data_get_data_type(seldata))
 	     << "'" << endl;
 	if ((gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_NPCID_NAME, 0) ||
-	     gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_GENERIC_NAME_X11, 0) ||
-	     gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_GENERIC_NAME_MACOSX, 0)) &&
+	     gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_DROPFILE_NAME_MIME, 0) ||
+	     gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_DROPFILE_NAME_MACOSX, 0)) &&
 	        Is_u7_npcid(gtk_selection_data_get_data(seldata)) &&
 	        gtk_selection_data_get_format(seldata) == 8 &&
 	        gtk_selection_data_get_length(seldata) > 0) {
@@ -706,11 +706,10 @@ void Npc_chooser::enable_drop(
 		return;
 	drop_enabled = true;
 	gtk_widget_realize(draw);//???????
-#ifndef _WIN32
 	GtkTargetEntry tents[3];
 	tents[0].target = const_cast<char *>(U7_TARGET_NPCID_NAME);
-	tents[1].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_X11);
-	tents[2].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_MACOSX);
+	tents[1].target = const_cast<char *>(U7_TARGET_DROPFILE_NAME_MIME);
+	tents[2].target = const_cast<char *>(U7_TARGET_DROPFILE_NAME_MACOSX);
 	tents[0].flags = 0;
 	tents[1].flags = 0;
 	tents[2].flags = 0;
@@ -722,7 +721,6 @@ void Npc_chooser::enable_drop(
 
 	g_signal_connect(G_OBJECT(draw), "drag-data-received",
 	                 G_CALLBACK(drag_data_received), this);
-#endif
 }
 
 /*

--- a/mapedit/npclst.cc
+++ b/mapedit/npclst.cc
@@ -37,11 +37,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "u7drag.h"
 #include "utils.h"
 
-#ifdef _WIN32
-#	include "windrag.h"
-#	include <windows.h>
-#endif
-
 #include <glib.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -479,46 +474,6 @@ gint Npc_chooser::expose(
  *  Handle a mouse drag event.
  */
 
-#ifdef _WIN32
-
-static bool win32_button = false;
-
-gint Npc_chooser::win32_drag_motion(
-    GtkWidget *widget,      // The view window.
-    GdkEventMotion *event,
-    gpointer data           // ->Npc_chooser.
-) {
-	ignore_unused_variable_warning(widget, event);
-	if (win32_button) {
-		win32_button = false;
-
-		// prepare the dragged data
-		windragdata wdata;
-
-		// This call allows us to recycle the data transfer initialization code.
-		//  It's clumsy, but far easier to maintain.
-		drag_data_get(nullptr, nullptr, reinterpret_cast<GtkSelectionData *>(&wdata),
-		              U7_TARGET_NPCID, 0, data);
-
-		POINT pnt;
-		GetCursorPos(&pnt);
-
-		LPDROPSOURCE idsrc = new Windropsource(nullptr, pnt.x, pnt.y);
-		LPDATAOBJECT idobj = new Winstudioobj(wdata);
-		DWORD dndout;
-
-		HRESULT res = DoDragDrop(idobj, idsrc, DROPEFFECT_COPY, &dndout);
-		if (FAILED(res)) {
-			g_warning("Oops! Something is wrong with OLE2 DnD..");
-		}
-
-		idobj->Release();   // Not sure if we really need this. However, it doesn't hurt either.
-		idsrc->Release();
-	}
-
-	return true;
-}
-#else
 gint Npc_chooser::drag_motion(
     GtkWidget *widget,      // The view window.
     GdkEventMotion *event,
@@ -531,7 +486,6 @@ gint Npc_chooser::drag_motion(
 		                    U7_TARGET_NPCID, reinterpret_cast<GdkEvent *>(event));
 	return true;
 }
-#endif
 
 /*
  *  Handle a mouse button-press event.
@@ -560,14 +514,6 @@ gint Npc_chooser::mouse_press(
 		if (info[i].box.has_point(absx, absy)) {
 			// Found the box?
 			// Indicate we can drag.
-#ifdef _WIN32
-// Here, we have to override GTK+'s Drag and Drop, which is non-OLE and
-// usually stucks outside the program window. I think it's because
-// the dragged shape only receives mouse motion events when the new mouse pointer
-// position is *still* inside the shape. So if you move the mouse too fast,
-// we are stuck.
-			win32_button = true;
-#endif
 			new_selected = i;
 			break;
 		} else if (info[i].box.y - voffset >= config_height)
@@ -687,15 +633,10 @@ void Npc_chooser::drag_data_get(
 	int npcnum = chooser->info[chooser->selected].npcnum;
 	int len = Store_u7_npcid(buf, npcnum);
 	cout << "Setting selection data (" << npcnum << ')' << endl;
-#ifdef _WIN32
-	auto *wdata = reinterpret_cast<windragdata *>(seldata);
-	wdata->assign(info, len, buf);
-#else
 	// Set data.
 	gtk_selection_data_set(seldata,
 	                       gtk_selection_data_get_target(seldata),
 	                       8, buf, len);
-#endif
 }
 
 /*
@@ -1120,14 +1061,8 @@ Npc_chooser::Npc_chooser(
 	// Mouse motion.
 	g_signal_connect(G_OBJECT(draw), "drag-begin",
 	                 G_CALLBACK(drag_begin), this);
-#ifdef _WIN32
-	// required to override GTK+ Drag and Drop
-	g_signal_connect(G_OBJECT(draw), "motion-notify-event",
-	                 G_CALLBACK(win32_drag_motion), this);
-#else
 	g_signal_connect(G_OBJECT(draw), "motion-notify-event",
 	                 G_CALLBACK(drag_motion), this);
-#endif
 	g_signal_connect(G_OBJECT(draw), "drag-data-get",
 	                 G_CALLBACK(drag_data_get), this);
 	gtk_container_add(GTK_CONTAINER(frame), draw);

--- a/mapedit/npclst.h
+++ b/mapedit/npclst.h
@@ -160,13 +160,8 @@ public:
 	static void frame_changed(GtkAdjustment *adj, gpointer data);
 	static void all_frames_toggled(GtkToggleButton *btn,
 	                               gpointer user_data);
-#ifdef _WIN32
-	static gint win32_drag_motion(GtkWidget *widget, GdkEventMotion *event,
-	                              gpointer data);
-#else
 	static gint drag_motion(GtkWidget *widget, GdkEventMotion *event,
 	                        gpointer data);
-#endif
 };
 
 #endif

--- a/mapedit/objedit.cc
+++ b/mapedit/objedit.cc
@@ -112,18 +112,6 @@ C_EXPORT gboolean on_obj_pos_changed(
 	return TRUE;
 }
 
-#ifdef _WIN32
-
-void ExultStudio::Obj_shape_dropped(int shape, int frame, int x, int y, void *data) {
-	cout << "Dropped a shape: " << shape << "," << frame << " " << data << endl;
-	ignore_unused_variable_warning(x, y);
-	auto *studio = static_cast<ExultStudio *>(data);
-	Shape_single::on_shape_dropped(U7_SHAPE_SHAPES, shape, frame, studio->obj_single);
-}
-
-#endif
-
-
 /*
  *  Open the object-editing window.
  */
@@ -132,13 +120,7 @@ void ExultStudio::open_obj_window(
     unsigned char *data,        // Serialized object.
     int datalen
 ) {
-#ifdef _WIN32
-	bool first_time = false;
-#endif
 	if (!objwin) {          // First time?
-#ifdef _WIN32
-		first_time = true;
-#endif
 		objwin = get_widget("obj_window");
 		// Note: vgafile can't be null here.
 		if (palbuf) {
@@ -158,12 +140,6 @@ void ExultStudio::open_obj_window(
 	if (!init_obj_window(data, datalen))
 		return;
 	gtk_widget_show(objwin);
-#ifdef _WIN32
-	if (first_time || !objdnd)
-		Windnd::CreateStudioDropDest(objdnd, objhwnd,
-		                             ExultStudio::Obj_shape_dropped,
-		                             nullptr, nullptr, this);
-#endif
 }
 
 /*
@@ -174,9 +150,6 @@ void ExultStudio::close_obj_window(
 ) {
 	if (objwin) {
 		gtk_widget_hide(objwin);
-#ifdef _WIN32
-		Windnd::DestroyStudioDropDest(objdnd, objhwnd);
-#endif
 	}
 }
 

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -267,7 +267,6 @@ gulong Shape_draw::enable_drop(
     void *udata         // Passed to callback.
 ) {
 	gtk_widget_realize(draw);//???????
-#ifndef _WIN32
 	drop_callback = callback;
 	drop_user_data = udata;
 	GtkTargetEntry tents[3];
@@ -285,10 +284,6 @@ gulong Shape_draw::enable_drop(
 
 	return g_signal_connect(G_OBJECT(draw), "drag-data-received",
 	                        G_CALLBACK(drag_data_received), this);
-#else
-	ignore_unused_variable_warning(callback, udata);
-	return 0;
-#endif
 }
 
 /*

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -244,8 +244,8 @@ void Shape_draw::drag_data_received(
 	     << "'" << endl;
 	if (draw->drop_callback &&
 	        (gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_SHAPEID_NAME, 0) ||
-	         gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_GENERIC_NAME_X11, 0) ||
-	         gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_GENERIC_NAME_MACOSX, 0)) &&
+	         gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_DROPFILE_NAME_MIME, 0) ||
+	         gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_DROPFILE_NAME_MACOSX, 0)) &&
 	        Is_u7_shapeid(gtk_selection_data_get_data(seldata)) &&
 	        gtk_selection_data_get_format(seldata) == 8 &&
 	        gtk_selection_data_get_length(seldata) > 0) {
@@ -271,8 +271,8 @@ gulong Shape_draw::enable_drop(
 	drop_user_data = udata;
 	GtkTargetEntry tents[3];
 	tents[0].target = const_cast<char *>(U7_TARGET_SHAPEID_NAME);
-	tents[1].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_X11);
-	tents[2].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_MACOSX);
+	tents[1].target = const_cast<char *>(U7_TARGET_DROPFILE_NAME_MIME);
+	tents[2].target = const_cast<char *>(U7_TARGET_DROPFILE_NAME_MACOSX);
 	tents[0].flags = 0;
 	tents[1].flags = 0;
 	tents[2].flags = 0;
@@ -337,8 +337,8 @@ void Shape_draw::start_drag(
 	dragging = true;
 	GtkTargetEntry tents[3];// Set up for dragging.
 	tents[0].target = const_cast<char *>(target);
-	tents[1].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_X11);
-	tents[2].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_MACOSX);
+	tents[1].target = const_cast<char *>(U7_TARGET_DROPFILE_NAME_MIME);
+	tents[2].target = const_cast<char *>(U7_TARGET_DROPFILE_NAME_MACOSX);
 	tents[0].flags = 0;
 	tents[1].flags = 0;
 	tents[2].flags = 0;

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -41,12 +41,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "u7drag.h"
 #include "utils.h"
 
-#ifdef _WIN32
-#	include "windrag.h"
-
-#	include <windows.h>
-#endif
-
 #include <glib.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -540,46 +534,6 @@ gint Shape_chooser::expose(
  *  Handle a mouse drag event.
  */
 
-#ifdef _WIN32
-
-static bool win32_button = false;
-
-gint Shape_chooser::win32_drag_motion(
-    GtkWidget *widget,      // The view window.
-    GdkEventMotion *event,
-    gpointer data           // ->Shape_chooser.
-) {
-	ignore_unused_variable_warning(widget, event);
-	if (win32_button) {
-		win32_button = false;
-
-		// prepare the dragged data
-		windragdata wdata;
-
-		// This call allows us to recycle the data transfer initialization code.
-		//  It's clumsy, but far easier to maintain.
-		drag_data_get(nullptr, nullptr, reinterpret_cast<GtkSelectionData *>(&wdata),
-		              U7_TARGET_SHAPEID, 0, data);
-
-		POINT pnt;
-		GetCursorPos(&pnt);
-
-		LPDROPSOURCE idsrc = new Windropsource(nullptr, pnt.x, pnt.y);
-		LPDATAOBJECT idobj = new Winstudioobj(wdata);
-		DWORD dndout;
-
-		HRESULT res = DoDragDrop(idobj, idsrc, DROPEFFECT_COPY, &dndout);
-		if (FAILED(res)) {
-			g_warning("Oops! Something is wrong with OLE2 DnD..");
-		}
-
-		idobj->Release();   // Not sure if we really need this. However, it doesn't hurt either.
-		idsrc->Release();
-	}
-
-	return true;
-}
-#else
 gint Shape_chooser::drag_motion(
     GtkWidget *widget,      // The view window.
     GdkEventMotion *event,
@@ -592,7 +546,6 @@ gint Shape_chooser::drag_motion(
 		                    U7_TARGET_SHAPEID, reinterpret_cast<GdkEvent *>(event));
 	return true;
 }
-#endif
 
 /*
  *  Handle a mouse button-press event.
@@ -621,14 +574,6 @@ gint Shape_chooser::mouse_press(
 		if (info[i].box.distance(absx, absy) <= 2) {
 			// Found the box?
 			// Indicate we can drag.
-#ifdef _WIN32
-// Here, we have to override GTK+'s Drag and Drop, which is non-OLE and
-// usually stucks outside the program window. I think it's because
-// the dragged shape only receives mouse motion events when the new mouse pointer
-// position is *still* inside the shape. So if you move the mouse too fast,
-// we are stuck.
-			win32_button = true;
-#endif
 			new_selected = i;
 			break;
 		} else if (info[i].box.y - voffset >= config_height)
@@ -1759,15 +1704,10 @@ void Shape_chooser::drag_data_get(
 	                           shinfo.framenum);
 	cout << "Setting selection data (" << shinfo.shapenum <<
 	     '/' << shinfo.framenum << ')' << endl;
-#ifdef _WIN32
-	auto *wdata = reinterpret_cast<windragdata *>(seldata);
-	wdata->assign(info, len, buf);
-#else
 	// Set data.
 	gtk_selection_data_set(seldata,
 	                       gtk_selection_data_get_target(seldata),
 	                       8, buf, len);
-#endif
 }
 
 /*
@@ -2343,14 +2283,8 @@ Shape_chooser::Shape_chooser(
 	// Mouse motion.
 	g_signal_connect(G_OBJECT(draw), "drag-begin",
 	                 G_CALLBACK(drag_begin), this);
-#ifdef _WIN32
-// required to override GTK+ Drag and Drop
-	g_signal_connect(G_OBJECT(draw), "motion-notify-event",
-	                 G_CALLBACK(win32_drag_motion), this);
-#else
 	g_signal_connect(G_OBJECT(draw), "motion-notify-event",
 	                 G_CALLBACK(drag_motion), this);
-#endif
 	g_signal_connect(G_OBJECT(draw), "drag-data-get",
 	                 G_CALLBACK(drag_data_get), this);
 	gtk_container_add(GTK_CONTAINER(frame), draw);

--- a/mapedit/shapelst.h
+++ b/mapedit/shapelst.h
@@ -190,13 +190,8 @@ public:
 	static void frame_changed(GtkAdjustment *adj, gpointer data);
 	static void all_frames_toggled(GtkToggleButton *btn,
 	                               gpointer user_data);
-#ifdef _WIN32
-	static gint win32_drag_motion(GtkWidget *widget, GdkEventMotion *event,
-	                              gpointer data);
-#else
 	static gint drag_motion(GtkWidget *widget, GdkEventMotion *event,
 	                        gpointer data);
-#endif
 	// Menu items:
 	static void on_shapes_popup_info_activate(
 	    GtkMenuItem *item, gpointer udata);

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -46,9 +46,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #ifdef _WIN32
 #	include "servewin32.h"
-
-#	include <ole2.h>
-#	include <windows.h>
 #else
 #	include <sys/socket.h>
 #	include <sys/un.h>
@@ -817,9 +814,6 @@ ExultStudio::ExultStudio(int argc, char **argv): glade_path(nullptr),
 	config->value("config/estudio/image_editor", iedit, "gimp");
 	image_editor = g_strdup(iedit.c_str());
 	config->set("config/estudio/image_editor", iedit, true);
-#ifdef _WIN32
-	OleInitialize(nullptr);
-#endif
 	// Init. 'Mode' menu, since Glade
 	//   doesn't seem to do it right.
 	GSList *group = nullptr;
@@ -835,9 +829,6 @@ ExultStudio::ExultStudio(int argc, char **argv): glade_path(nullptr),
 }
 
 ExultStudio::~ExultStudio() {
-#ifdef _WIN32
-	OleUninitialize();
-#endif
 	// Store main window size.
 	int w = w_at_close;
 	int h = h_at_close;

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -550,6 +550,10 @@ ExultStudio::ExultStudio(int argc, char **argv): glade_path(nullptr),
 	ucbrowsewin(nullptr), gameinfowin(nullptr),
 	game_type(BLACK_GATE), expansion(false), sibeta(false), curr_game(-1), curr_mod(-1),
 	server_socket(-1), server_input_tag(-1), waiting_for_server(nullptr) {
+#ifdef _WIN32
+	// Enable the GTK+ 3 OLE Drag and Drop
+	g_setenv("GDK_WIN32_USE_EXPERIMENTAL_OLE2_DND", "1", 0);
+#endif
 	// Initialize the various subsystems
 	self = this;
 	gtk_init(&argc, &argv);

--- a/mapedit/studio.h
+++ b/mapedit/studio.h
@@ -92,13 +92,9 @@ using Msg_callback = void (*)(Exult_server::Msg_type id,
                               const unsigned char *data, int datalen, void *client);
 
 #ifndef _WIN32
-#define C_EXPORT extern "C"
+#	define C_EXPORT extern "C"
 #else
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
-#define C_EXPORT extern "C" __declspec(dllexport)
+#	define C_EXPORT extern "C" __declspec(dllexport)
 #endif
 
 class ExultStudio {

--- a/mapedit/studio.h
+++ b/mapedit/studio.h
@@ -98,7 +98,6 @@ using Msg_callback = void (*)(Exult_server::Msg_type id,
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
-#include "windrag.h"
 #define C_EXPORT extern "C" __declspec(dllexport)
 #endif
 
@@ -185,19 +184,6 @@ private:
 	int curr_game;  // Which game is loaded
 	int curr_mod;   // Which mod is loaded, or -1 for none
 	std::string game_encoding;  // Character set for current game/mod.
-	// For Win32 DND
-#ifdef _WIN32
-	HWND            egghwnd;
-	Windnd          *eggdnd;
-	HWND            npchwnd;
-	Windnd          *npcdnd;
-	HWND            objhwnd;
-	Windnd          *objdnd;
-	HWND            conthwnd;
-	Windnd          *contdnd;
-	HWND            shphwnd;
-	Windnd          *shpdnd;
-#endif
 	// Server data.
 	int         server_socket;
 	gint            server_input_tag;
@@ -305,18 +291,12 @@ public:
 	int init_obj_window(unsigned char *data, int datalen);
 	int save_obj_window();
 	void rotate_obj();
-#ifdef _WIN32
-	static void Obj_shape_dropped(int shape, int frame, int x, int y, void *data);
-#endif
 	// Containers:
 	void open_cont_window(unsigned char *data, int datalen);
 	void close_cont_window();
 	int init_cont_window(unsigned char *data, int datalen);
 	int save_cont_window();
 	void rotate_cont();
-#ifdef _WIN32
-	static void Cont_shape_dropped(int shape, int frame, int x, int y, void *data);
-#endif
 	// Barges:
 	void open_barge_window(unsigned char *data = nullptr, int datalen = 0);
 	void close_barge_window();
@@ -327,9 +307,6 @@ public:
 	void close_egg_window();
 	int init_egg_window(unsigned char *data, int datalen);
 	int save_egg_window();
-#ifdef _WIN32
-	static void Egg_monster_dropped(int shape, int frame, int x, int y, void *data);
-#endif
 	// NPC's:
 	void open_npc_window(unsigned char *data = nullptr, int datalen = 0);
 	void close_npc_window();
@@ -338,10 +315,6 @@ public:
 	int save_npc_window();
 	void update_npc(); // updates the npc browser if it is open
 	static void schedule_btn_clicked(GtkWidget *btn, gpointer data);
-#ifdef _WIN32
-	static void Npc_shape_dropped(int shape, int frame, int x, int y, void *data);
-	static void Npc_face_dropped(int shape, int frame, int x, int y, void *data);
-#endif
 	// Shapes:
 	GdkPixbuf *shape_image(     // The GdkPixbuf should be g_object_unrefed.
 	    Vga_file *shpfile, int shnum, int frnum, bool transparent);

--- a/shapes/u7drag.h
+++ b/shapes/u7drag.h
@@ -30,8 +30,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //	  Prefix = 18 : 8 file:/// + 9 U7CHUNKID + 1 terminating null
 #define U7DND_DATA_LENGTH(n) (18 + ((n)*7))
 //	Generic FILE_MIME Target
-#define U7_TARGET_GENERIC_NAME_X11    "text/uri-list"
-#define U7_TARGET_GENERIC_NAME_MACOSX "public.file-url"
+#define U7_TARGET_DROPFILE_NAME_MIME   "text/uri-list"
+#define U7_TARGET_DROPFILE_NAME_MACOSX "public.file-url"
 
 //	Target information for dragging a shape:
 #define U7_TARGET_SHAPEID_NAME "U7SHAPEID"

--- a/shapes/u7drag.h
+++ b/shapes/u7drag.h
@@ -89,11 +89,9 @@ using Move_shape_handler_fun = void (*)(int shape, int frame, int x, int y,
                                         int prevx, int prevy, bool show);
 using Move_combo_handler_fun = void (*)(int xtiles, int ytiles, int tiles_right,
                                         int tiles_below, int x, int y, int prevx, int prevy, bool show);
-using Drop_shape_handler_fun = void (*)(int shape, int frame, int x, int y,
-                                        void *data);
-using Drop_chunk_handler_fun = void (*)(int chunk, int x, int y, void *data);
-using Drop_npc_handler_fun = void (*)(int npc, int x, int y, void *data);
-using Drop_combo_handler_fun = void (*)(int cnt, U7_combo_data *combo,
-                                        int x, int y, void *data);
+using Drop_shape_handler_fun = void (*)(int shape, int frame, int x, int y);
+using Drop_chunk_handler_fun = void (*)(int chunk, int x, int y);
+using Drop_npc_handler_fun = void (*)(int npc, int x, int y);
+using Drop_combo_handler_fun = void (*)(int cnt, U7_combo_data *combo, int x, int y);
 
 #endif

--- a/windrag.cc
+++ b/windrag.cc
@@ -14,33 +14,12 @@
 #include "u7drag.h"
 #include "ignore_unused_variable_warning.h"
 
-static UINT CF_EXULT = RegisterClipboardFormat("ExultData");
+static UINT CF_EXULT = RegisterClipboardFormat(U7_TARGET_GENERIC_NAME_X11);
 
 // Just in case
 #ifndef DECLSPEC_NOTHROW
 #define DECLSPEC_NOTHROW
 #endif
-
-// Statics
-
-void Windnd::CreateStudioDropDest(Windnd  *&windnd, HWND &hWnd,
-                                  Drop_shape_handler_fun shapefun,
-                                  Drop_chunk_handler_fun cfun,
-                                  Drop_shape_handler_fun facefun,
-                                  void *udata) {
-	hWnd = GetActiveWindow();
-	windnd = new Windnd(hWnd, shapefun, cfun, facefun, udata);
-	if (FAILED(RegisterDragDrop(hWnd, windnd))) {
-		std::cout << "Something's wrong with OLE2 ..." << std::endl;
-	}
-}
-
-void Windnd::DestroyStudioDropDest(Windnd  *&windnd, HWND &hWnd) {
-	RevokeDragDrop(hWnd);
-	delete windnd;
-	windnd = nullptr;
-	hWnd = nullptr;
-}
 
 // IDropTarget implementation
 
@@ -52,20 +31,10 @@ Windnd::Windnd(
     Drop_chunk_handler_fun cfun,
     Drop_npc_handler_fun npcfun,
     Drop_combo_handler_fun combfun
-) : gamewin(hgwnd), udata(nullptr), move_shape_handler(movefun),
+) : gamewin(hgwnd), move_shape_handler(movefun),
 	move_combo_handler(movecmbfun), shape_handler(shapefun),
-	chunk_handler(cfun), npc_handler(npcfun), face_handler(nullptr),
+	chunk_handler(cfun), npc_handler(npcfun),
 	combo_handler(combfun), drag_id(-1) {
-	std::memset(&data, 0, sizeof(data));
-	m_cRef = 1;
-}
-
-Windnd::Windnd(HWND hgwnd, Drop_shape_handler_fun shapefun,
-               Drop_chunk_handler_fun cfun, Drop_shape_handler_fun ffun, void *d
-              )
-	: gamewin(hgwnd), udata(d), move_shape_handler(nullptr), move_combo_handler(nullptr),
-	  shape_handler(shapefun), chunk_handler(cfun),
-	  face_handler(ffun), combo_handler(nullptr), drag_id(-1) {
 	std::memset(&data, 0, sizeof(data));
 	m_cRef = 1;
 }
@@ -117,32 +86,24 @@ Windnd::DragEnter(IDataObject *pDataObject,
 
 	STGMEDIUM med;
 	pDataObject->GetData(&fetc, &med);
-	windragdata wdd(static_cast<unsigned char *>(GlobalLock(med.hGlobal)));
+	const unsigned char *dragdata = static_cast<unsigned char *>(GlobalLock(med.hGlobal));
+
+	if (Is_u7_shapeid(dragdata)) {
+		drag_id = U7_TARGET_SHAPEID;
+		Get_u7_shapeid(dragdata, data.shape.file, data.shape.shape, data.shape.frame);
+	} else if (Is_u7_chunkid(dragdata)) {
+		drag_id = U7_TARGET_CHUNKID;
+		Get_u7_chunkid(dragdata, data.chunk.chunknum);
+	} else if (Is_u7_comboid(dragdata)) {
+		drag_id = U7_TARGET_COMBOID;
+		Get_u7_comboid(dragdata, data.combo.xtiles, data.combo.ytiles, data.combo.right, data.combo.below, data.combo.cnt, data.combo.combo);
+	} else if (Is_u7_npcid(dragdata)) {
+		drag_id = U7_TARGET_NPCID;
+		Get_u7_npcid(dragdata, data.npc.npcnum);
+	}
+
 	GlobalUnlock(med.hGlobal);
 	ReleaseStgMedium(&med);
-
-	drag_id = wdd.get_id();
-	switch (drag_id) {
-
-	case U7_TARGET_SHAPEID:
-		Get_u7_shapeid(wdd.get_data(), data.shape.file, data.shape.shape, data.shape.frame);
-		break;
-
-	case U7_TARGET_CHUNKID:
-		Get_u7_chunkid(wdd.get_data(), data.chunk.chunknum);
-		break;
-
-	case U7_TARGET_COMBOID:
-		Get_u7_comboid(wdd.get_data(), data.combo.xtiles, data.combo.ytiles, data.combo.right, data.combo.below, data.combo.cnt, data.combo.combo);
-		break;
-
-	case U7_TARGET_NPCID:
-		Get_u7_npcid(wdd.get_data(), data.npc.npcnum);
-		break;
-
-	default:
-		break;
-	}
 
 	prevx = -1;
 	prevy = -1;
@@ -223,47 +184,48 @@ Windnd::Drop(IDataObject *pDataObject,
 	fetc.dwAspect = DVASPECT_CONTENT;
 	fetc.lindex = -1;
 	fetc.tymed = TYMED_HGLOBAL;
-	STGMEDIUM med;
 
+	STGMEDIUM med;
 	pDataObject->GetData(&fetc, &med);
-	windragdata wdd(static_cast<unsigned char *>(GlobalLock(med.hGlobal)));
-	GlobalUnlock(med.hGlobal);
-	ReleaseStgMedium(&med);
+	const unsigned char *dragdata = static_cast<unsigned char *>(GlobalLock(med.hGlobal));
 
 	POINT pnt = { pt.x, pt.y};
 	ScreenToClient(gamewin, &pnt);
 
-	int id = wdd.get_id();
-
-	if (id == U7_TARGET_SHAPEID) {
+	if (Is_u7_shapeid(dragdata)) {
 		int file;
 		int shape;
 		int frame;
-		Get_u7_shapeid(wdd.get_data(), file, shape, frame);
+		Get_u7_shapeid(dragdata, file, shape, frame);
+		std::cerr << "(Exult) Dropping SHAPE at " << pt.x << " " << pt.y << " for " << file << " " << shape << " " << frame << std::endl;
 		if (file == U7_SHAPE_SHAPES) {
-			if (shape_handler) (*shape_handler)(shape, frame, pnt.x, pnt.y, udata);
-		} else if (file == U7_SHAPE_FACES) {
-			if (face_handler) (*face_handler)(shape, frame, pnt.x, pnt.y, udata);
+			if (shape_handler) (*shape_handler)(shape, frame, pnt.x, pnt.y);
 		}
-	} else if (id == U7_TARGET_NPCID) {
+	} else if (Is_u7_npcid(dragdata)) {
 		int npcnum;
-		Get_u7_npcid(wdd.get_data(), npcnum);
-		if (npc_handler) (*npc_handler)(npcnum, pnt.x, pnt.y, nullptr);
-	} else if (id == U7_TARGET_CHUNKID) {
+		Get_u7_npcid(dragdata, npcnum);
+		std::cerr << "(Exult) Dropping NPC at " << pt.x << " " << pt.y << " for " << npcnum << std::endl;
+		if (npc_handler) (*npc_handler)(npcnum, pnt.x, pnt.y);
+	} else if (Is_u7_chunkid(dragdata)) {
 		int chunknum;
-		Get_u7_chunkid(wdd.get_data(), chunknum);
-		if (chunk_handler) (*chunk_handler)(chunknum, pnt.x, pnt.y, udata);
-	} else if (id == U7_TARGET_COMBOID) {
+		Get_u7_chunkid(dragdata, chunknum);
+		std::cerr << "(Exult) Dropping CHUNK at " << pt.x << " " << pt.y << " for " << chunknum << std::endl;
+		if (chunk_handler) (*chunk_handler)(chunknum, pnt.x, pnt.y);
+	} else if (Is_u7_comboid(dragdata)) {
 		int xtiles;
 		int ytiles;
 		int right;
 		int below;
 		int cnt;
 		U7_combo_data *combo;
-		Get_u7_comboid(wdd.get_data(), xtiles, ytiles, right, below, cnt, combo);
-		if (combo_handler) (*combo_handler)(cnt, combo, pnt.x, pnt.y, udata);
+		Get_u7_comboid(dragdata, xtiles, ytiles, right, below, cnt, combo);
+		std::cerr << "(Exult) Dropping COMBO at " << pt.x << " " << pt.y << " for " << xtiles << " " << ytiles << " " << right << " " << below << " " << cnt << std::endl;
+		if (combo_handler) (*combo_handler)(cnt, combo, pnt.x, pnt.y);
 		delete combo;
 	}
+
+	GlobalUnlock(med.hGlobal);
+	ReleaseStgMedium(&med);
 
 	return S_OK;
 }
@@ -277,246 +239,6 @@ bool Windnd::is_valid(IDataObject *pDataObject) {
 	fetc.tymed = TYMED_HGLOBAL;
 
 	return SUCCEEDED(pDataObject->QueryGetData(&fetc));
-}
-
-// IDropSource implementation
-
-Windropsource::Windropsource(HBITMAP pdrag_bitmap, int x0, int y0)
-	: drag_bitmap(pdrag_bitmap) {
-	ignore_unused_variable_warning(x0, y0);
-	m_cRef = 1;
-	drag_shape = nullptr;
-}
-
-Windropsource::~Windropsource() {
-	DestroyWindow(drag_shape);
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Windropsource::QueryInterface(REFIID iid, void **ppvObject) {
-	*ppvObject = nullptr;
-	if (IID_IUnknown == iid || IID_IDropSource == iid)
-		*ppvObject = this;
-	if (nullptr == *ppvObject)
-		return E_NOINTERFACE;
-	static_cast<LPUNKNOWN>(*ppvObject)->AddRef();
-	return NOERROR;
-}
-
-STDMETHODIMP_(ULONG) DECLSPEC_NOTHROW
-Windropsource::AddRef() {
-	m_cRef = m_cRef + 1;
-
-	return m_cRef;
-}
-
-STDMETHODIMP_(ULONG) DECLSPEC_NOTHROW
-Windropsource::Release() {
-	if (0 != --m_cRef)
-		return m_cRef;
-	delete this;
-	return 0;
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Windropsource::QueryContinueDrag(
-    BOOL fEscapePressed,
-    DWORD grfKeyState
-) {
-	if (fEscapePressed)
-		return DRAGDROP_S_CANCEL;
-	else if (!(grfKeyState & MK_LBUTTON))
-		return DRAGDROP_S_DROP;
-	else
-		return NOERROR;
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Windropsource::GiveFeedback(
-    DWORD dwEffect
-) {
-	ignore_unused_variable_warning(dwEffect);
-	return DRAGDROP_S_USEDEFAULTCURSORS;
-}
-
-// IDataObject implementation
-
-Winstudioobj::Winstudioobj(const windragdata& pdata)
-	: data(pdata) {
-	m_cRef = 1;
-	drag_image = nullptr;
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Winstudioobj::QueryInterface(REFIID iid, void **ppvObject) {
-	*ppvObject = nullptr;
-	if (IID_IUnknown == iid || IID_IDataObject == iid)
-		*ppvObject = this;
-	if (nullptr == *ppvObject)
-		return E_NOINTERFACE;
-	static_cast<LPUNKNOWN>(*ppvObject)->AddRef();
-	return NOERROR;
-}
-
-STDMETHODIMP_(ULONG) DECLSPEC_NOTHROW
-Winstudioobj::AddRef() {
-	return ++m_cRef;
-}
-
-STDMETHODIMP_(ULONG) DECLSPEC_NOTHROW
-Winstudioobj::Release() {
-	if (0 != --m_cRef)
-		return m_cRef;
-	delete this;
-	return 0;
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Winstudioobj::GetData(
-    FORMATETC *pFormatetc,
-    STGMEDIUM *pmedium
-) {
-	std::cout << "In GetData" << std::endl;
-
-	HGLOBAL hText;
-	unsigned char *ldata;
-
-	pmedium->tymed = 0;
-	pmedium->pUnkForRelease = nullptr;
-	pmedium->hGlobal = nullptr;
-
-	// This method is called by the drag-drop target to obtain the data
-	// that is being dragged.
-	if (pFormatetc->cfFormat == CF_EXULT &&
-	        pFormatetc->dwAspect == DVASPECT_CONTENT &&
-	        pFormatetc->tymed == TYMED_HGLOBAL) {
-		hText = GlobalAlloc(GMEM_SHARE | GMEM_ZEROINIT, 8 + data.get_size());
-		if (!hText)
-			return E_OUTOFMEMORY;
-
-		// This provides us with a pointer to the allocated memory
-		ldata = static_cast<unsigned char *>(GlobalLock(hText));
-		data.serialize(ldata);
-		GlobalUnlock(hText);
-
-		pmedium->tymed = TYMED_HGLOBAL;
-		pmedium->hGlobal = hText;
-
-		return S_OK;
-	}
-
-	return DATA_E_FORMATETC;
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Winstudioobj::GetDataHere(
-    FORMATETC *pFormatetc,
-    STGMEDIUM *pmedium
-) {
-	ignore_unused_variable_warning(pFormatetc, pmedium);
-	return DATA_E_FORMATETC;
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Winstudioobj::QueryGetData(
-    FORMATETC *pFormatetc
-) {
-	// This method is called by the drop target to check whether the source
-	// provides data is a format that the target accepts.
-	if (pFormatetc->cfFormat == CF_EXULT
-	        && pFormatetc->dwAspect == DVASPECT_CONTENT
-	        && pFormatetc->tymed & TYMED_HGLOBAL)
-		return S_OK;
-	else return S_FALSE;
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Winstudioobj::GetCanonicalFormatEtc(
-    FORMATETC *pFormatetcIn,
-    FORMATETC *pFormatetcOut
-) {
-	ignore_unused_variable_warning(pFormatetcIn);
-	pFormatetcOut->ptd = nullptr;
-	return E_NOTIMPL;
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Winstudioobj::SetData(
-    FORMATETC *pFormatetc,
-    STGMEDIUM *pmedium,
-    BOOL fRelease
-) {
-	ignore_unused_variable_warning(pFormatetc, pmedium, fRelease);
-	return E_NOTIMPL;
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Winstudioobj::EnumFormatEtc(
-    DWORD dwDirection,
-    IEnumFORMATETC **ppenumFormatetc
-) {
-	SCODE sc = S_OK;
-
-	if (dwDirection == DATADIR_GET) {
-		std::cout << "EnumFmt" << std::endl;
-		ignore_unused_variable_warning(*ppenumFormatetc);
-		// I was too lazy to implement still another OLE2 interface just for something
-		//  we don't even use. This function is supposed to be called by a drop target
-		//  to find out if it can accept the provided data type. I suppose with
-		//  E_NOTIMPL, other drop targets don't care about Exult data.
-		/*
-		FORMATETC fmtetc;
-		fmtetc.cfFormat = CF_EXULT;
-		fmtetc.dwAspect = DVASPECT_CONTENT;
-		fmtetc.tymed = TYMED_HGLOBAL;
-		fmtetc.ptd = nullptr;
-		fmtetc.lindex = -1;
-
-		*ppenumFormatetc = OleStdEnumFmtEtc_Create(1, &fmtetc);
-		if (*ppenumFormatetc == nullptr)
-		sc = E_OUTOFMEMORY;*/
-		sc = E_NOTIMPL;
-
-	} else if (dwDirection == DATADIR_SET) {
-		// A data transfer object that is used to transfer data
-		//    (either via the clipboard or drag/drop does NOT
-		//    accept SetData on ANY format.
-		sc = E_NOTIMPL;
-		goto error;
-	} else {
-		sc = E_INVALIDARG;
-		goto error;
-	}
-
-error:
-	return sc;
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Winstudioobj::DAdvise(
-    FORMATETC *pFormatetc,
-    DWORD advf,
-    IAdviseSink *pAdvSink,
-    DWORD *pdwConnection
-) {
-	ignore_unused_variable_warning(pFormatetc, advf, pAdvSink, pdwConnection);
-	return OLE_E_ADVISENOTSUPPORTED;
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Winstudioobj::DUnadvise(
-    DWORD dwConnection
-) {
-	ignore_unused_variable_warning(dwConnection);
-	return OLE_E_ADVISENOTSUPPORTED;
-}
-
-STDMETHODIMP DECLSPEC_NOTHROW
-Winstudioobj::EnumDAdvise(
-    IEnumSTATDATA **ppenumAdvise
-) {
-	ignore_unused_variable_warning(*ppenumAdvise);
-	return OLE_E_ADVISENOTSUPPORTED;
 }
 
 #endif

--- a/windrag.cc
+++ b/windrag.cc
@@ -14,7 +14,7 @@
 #include "u7drag.h"
 #include "ignore_unused_variable_warning.h"
 
-static UINT CF_EXULT = RegisterClipboardFormat(U7_TARGET_GENERIC_NAME_X11);
+static UINT CF_EXULT = RegisterClipboardFormat(U7_TARGET_DROPFILE_NAME_MIME);
 
 // Just in case
 #ifndef DECLSPEC_NOTHROW

--- a/windrag.h
+++ b/windrag.h
@@ -17,50 +17,6 @@
 #include <ole2.h>
 #include "utils.h"
 
-// A useful structure for Winstudioobj
-class windragdata {
-	std::vector<unsigned char> data;
-	sint32 id;
-public:
-
-	inline unsigned char *get_data() {
-		return data.data();
-	}
-
-	inline int get_id() const {
-		return id;
-	}
-
-	inline size_t get_size() const {
-		return data.size();
-	}
-
-	// Default constructor
-	inline windragdata() = default;
-
-	// Read from buffer
-	explicit inline windragdata(const unsigned char *buf) {
-		id = Read4(buf);
-		size_t size = Read4(buf);
-		data.assign(buf, buf + size);
-	}
-
-	inline windragdata(sint32 i, uint32 s, const unsigned char *d)
-		: data(d, d + s), id(i) {
-	}
-
-	inline void serialize(unsigned char *buf) {
-		Write4(buf, id);
-		Write4(buf, data.size());
-		std::memcpy(buf, data.data(), data.size());
-	}
-
-	inline void assign(sint32 i, uint32 s, const unsigned char *d) {
-		id = i;
-		data.assign(d, d + s);
-	}
-};
-
 /*
  * The 'IDropTarget' implementation
  */
@@ -70,14 +26,11 @@ private:
 
 	std::atomic<DWORD> m_cRef;
 
-	void *udata;
-
 	Move_shape_handler_fun move_shape_handler;
 	Move_combo_handler_fun move_combo_handler;
 	Drop_shape_handler_fun shape_handler;
 	Drop_chunk_handler_fun chunk_handler;
 	Drop_npc_handler_fun npc_handler;
-	Drop_shape_handler_fun face_handler;
 	Drop_combo_handler_fun combo_handler;
 
 	// Used for when dragging the mouse over the exult window
@@ -105,8 +58,6 @@ public:
 	Windnd(HWND hgwnd, Move_shape_handler_fun, Move_combo_handler_fun,
 	       Drop_shape_handler_fun, Drop_chunk_handler_fun,
 	       Drop_npc_handler_fun npcfun, Drop_combo_handler_fun);
-	Windnd(HWND hgwnd, Drop_shape_handler_fun shapefun,
-	       Drop_chunk_handler_fun cfun, Drop_shape_handler_fun ffun, void *d);
 
 	STDMETHOD(QueryInterface)(REFIID iid, void **ppvObject) override;
 	STDMETHOD_(ULONG, AddRef)() override;
@@ -126,90 +77,6 @@ public:
 	                DWORD *pdwEffect) override;
 
 	bool is_valid(IDataObject *pDataObject);
-
-	static void CreateStudioDropDest(Windnd  *&windnd, HWND &hWnd,
-	                                 Drop_shape_handler_fun shapefun,
-	                                 Drop_chunk_handler_fun cfun,
-	                                 Drop_shape_handler_fun facefun,
-	                                 void *udata);
-
-	static void DestroyStudioDropDest(Windnd  *&windnd, HWND &hWnd);
-};
-
-/*
- * The IDropSource implementation
- */
-
-class FAR Windropsource final :  public IDropSource {
-private:
-	std::atomic<DWORD> m_cRef;
-
-	HWND drag_shape;
-	HBITMAP drag_bitmap;
-	int shw, shh;
-	~Windropsource();
-
-public:
-	Windropsource(HBITMAP pdrag_bitmap, int x0, int y0);
-
-	STDMETHOD(QueryInterface)(REFIID iid, void **ppvObject) override;
-	STDMETHOD_(ULONG, AddRef)() override;
-	STDMETHOD_(ULONG, Release)() override;
-
-	STDMETHOD(QueryContinueDrag)(BOOL fEscapePressed, DWORD grfKeyState) override;
-	STDMETHOD(GiveFeedback)(DWORD dwEffect) override;
-
-};
-
-/*
- * The IDataObject implementation
- */
-class FAR Winstudioobj final :  public IDataObject {
-private:
-	std::atomic<DWORD> m_cRef;
-
-	HBITMAP drag_image;
-
-	windragdata data;
-	~Winstudioobj() = default;
-
-public:
-	Winstudioobj(const windragdata& pdata);
-
-	STDMETHOD(QueryInterface)(REFIID iid, void **ppvObject) override;
-	STDMETHOD_(ULONG, AddRef)() override;
-	STDMETHOD_(ULONG, Release)() override;
-
-	STDMETHOD(GetData)(FORMATETC *pFormatetc, STGMEDIUM *pmedium) override;
-	STDMETHOD(GetDataHere)(FORMATETC *pFormatetc, STGMEDIUM *pmedium) override;
-	STDMETHOD(QueryGetData)(
-	    FORMATETC *pFormatetc
-	) override;
-	STDMETHOD(GetCanonicalFormatEtc)(
-	    FORMATETC *pFormatetcIn,
-	    FORMATETC *pFormatetcOut
-	) override;
-	STDMETHOD(SetData)(
-	    FORMATETC *pFormatetc,
-	    STGMEDIUM *pmedium,
-	    BOOL fRelease
-	) override;
-	STDMETHOD(EnumFormatEtc)(
-	    DWORD dwDirection,
-	    IEnumFORMATETC **ppenumFormatetc
-	) override;
-	STDMETHOD(DAdvise)(
-	    FORMATETC *pFormatetc,
-	    DWORD advf,
-	    IAdviseSink *pAdvSink,
-	    DWORD *pdwConnection
-	) override;
-	STDMETHOD(DUnadvise)(
-	    DWORD dwConnection
-	) override;
-	STDMETHOD(EnumDAdvise)(
-	    IEnumSTATDATA **ppenumAdvise
-	) override;
 };
 
 #ifdef __GNUC__


### PR DESCRIPTION
This is a proposal for a rework of the Drag and Drop code in Exult and Studio under Windows, as discussed in Issue #71.

### Rationale

In Windows, when the Drag and Drop from Studio to Exult was created, SDL for Exult and GTK+ for Studio only supported receiving WM_DROPFILES messages, and GTK+ supported sending/receiving Drag and Drop messages but only from/to the windows of the current GTK+ application. In other words, there were no way to post a Drag and Drop message from Studio to Exult.

Under Windows, Exult _and_ Studio have their own specialized Drag and Drop code paths to overcome this lack of a working Drag and Drop protocol. This code is in `windrag.h` and `windrag.cc`. Whereas Exult displays a single window acting as an entire Drag and Drop receiver, Studio has many windows and many Drag and Drop sender / receiver widgets in them. As a result, the Exult receiver part as rather simple, the Studio part is complex, and very few GtkDrawingAreas of Studio can act as Drag and Drop receivers, many less than under Linux or MacOS. This is compounded today with the new Shapes and Paperdoll GtkDrawingAreas of Studio, all of which can act as Drag and Drop receivers under Linux and MacOS, but none under Windows.

GTK+ 3 provides an alternate full power cross application OLE2 Drag and Drop, although it is considered «Experimental» and is enabled with an environment variable `GDK_WIN32_USE_EXPERIMENTAL_OLE2_DND`. This Drag and Drop code becomes default in GTK 4. _I have not been able to catch defects in this code_.

### Proposal

- Studio exploits fully the OLE2 Drag and Drop of GTK+ 3, sending Drags to itself and to Studio, receiving Drops from itself.
- Exult keeps a proprietary code for receiving OLE2 Drops from Studio, this is a much simplified and slightly altered `windrag.cc`.
- There are only little signature changes in `exult.cc`, and no other change in Exult.
- All _WIN32 special paths for Drag and Drop in Studio are removed, including references to `windrag.h`.
- Studio in `studio.cc` enables the OLE2 Drag and Drop of GTK+ 3.

### Status

- Exult and Studio compile and run under Linux without change
- Exult and Studio compile and run under Windows, with Drag and Drop from Studio to Studio enabled in all GtkDrawingAreas, with Drag and Drop from Studio to Exult working with the DragOver messages correctly interpreted : Under Windows only, Exult draws the green grid to help a precise positioning of the Dropped object.

Since the OLE2 Drag and Drop is considered experimental in GTK+ 3, I would like this proposal to be strongly tested.

Dragon Baroque, March 27, 2021