### PR TITLE
Fix savegame corruption when save_compression == 0

### DIFF
--- a/files/Flex.h
+++ b/files/Flex.h
@@ -139,7 +139,7 @@ public:
 	}
 	void write_name(const std::string& fullname) {
 		std::string name = base_name(fullname);
-		name.resize(8+1+3, 0);	// DOS filename
+		name.resize(8+1+3+1, 0);	// DOS filename
 		dout.write(name);
 	}
 	void write_object(const File_spec &spec) {


### PR DESCRIPTION
Here is a fix for savegame corruption when not using zip compression.
The size of "filename" field in the flex file should be 13 bytes, but currently Exult only writes 12 bytes.