### PR TITLE
Studio clean_vector

### DIFF
--- a/shapes/data_utils.h
+++ b/shapes/data_utils.h
@@ -88,7 +88,7 @@ template <typename T>
 void clean_vector(std::vector<T> &vec) {
 	vec.erase(std::remove_if(vec.begin(), vec.end(),
 		[](T& elem) {
-			return elem.is_invalid() || !elem.have_static();
+			return elem.is_invalid() && !elem.have_static();
 		}
 		), vec.end());
 }


### PR DESCRIPTION
For lost changes in Shape Editor :
On a Shape object without Frame Names, create Frame Names with the Shape Editor, Add, OK, the Frame Names are lost on the Shape Editor exit.
On a Shape object created by a patch, with Frame Names, or on a Shape Object given Frame Names by a patch, alter the Frame Names with the Shape Editor, Add, OK, the Shape loses all its Frame Names at Shape Editor exit.

Same with Frame Flags, Frame HPs, Frame Usecode, Object Paperdoll, Brightness and Warmth.

Reason : the clean_vector function called by all clean_invalid_.. functions has its removal test wrong.

Should fix Issue #121 

Sincerely
Dragon-Baroque