### PR TITLE
Transfer obsolete monster flags from monster.dat to shape_info.txt

### DIFF
--- a/mapedit/combo.cc
+++ b/mapedit/combo.cc
@@ -251,7 +251,9 @@ Combo::Combo(
 	starttx(c_num_tiles), startty(c_num_tiles),
 	tilefoot(0, 0, 0, 0) {
 	// Read info. the first time.
-	shapes_file->read_info(ExultStudio::get_instance()->get_game_type(), true);
+	ExultStudio *es = ExultStudio::get_instance();
+	if (shapes_file->read_info(es->get_game_type(), true))
+		es->set_shapeinfo_modified();
 }
 
 /*

--- a/mapedit/contedit.cc
+++ b/mapedit/contedit.cc
@@ -272,7 +272,8 @@ void ExultStudio::rotate_cont(
 		return;
 	auto *shfile = static_cast<Shapes_vga_file *>(vgafile->get_ifile());
 	// Make sure data's been read in.
-	shfile->read_info(game_type, true);
+	if (shfile->read_info(game_type, true))
+		set_shapeinfo_modified();
 	const Shape_info &info = shfile->get_info(shnum);
 	frnum = info.get_rotated_frame(frnum, 1);
 	set_spin("cont_frame", frnum);

--- a/mapedit/objedit.cc
+++ b/mapedit/objedit.cc
@@ -246,7 +246,8 @@ void ExultStudio::rotate_obj(
 		return;
 	auto *shfile = static_cast<Shapes_vga_file *>(vgafile->get_ifile());
 	// Make sure data's been read in.
-	shfile->read_info(game_type, true);
+	if (shfile->read_info(game_type, true))
+		set_shapeinfo_modified();
 	const Shape_info &info = shfile->get_info(shnum);
 	frnum = info.get_rotated_frame(frnum, 1);
 	set_spin("obj_frame", frnum);

--- a/mapedit/shapegroup.cc
+++ b/mapedit/shapegroup.cc
@@ -63,7 +63,8 @@ Shape_group::Shape_group(
 	auto *vgafile = static_cast<Shapes_vga_file *>(
 	                    es->get_vgafile()->get_ifile());
 	// Read info. the first time.
-	vgafile->read_info(es->get_game_type(), true);
+	if (vgafile->read_info(es->get_game_type(), true))
+		es->set_shapeinfo_modified();
 	int i;
 	int cnt = vgafile->get_num_shapes();
 	bool modified = file->modified;

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -790,7 +790,8 @@ void Shape_chooser::edit_shape_info(
 	const char *name = nullptr;
 	if (shapes_file) {
 		// Read info. the first time.
-		shapes_file->read_info(studio->get_game_type(), true);
+		if (shapes_file->read_info(studio->get_game_type(), true))
+			studio->set_shapeinfo_modified();
 		if (!shapes_file->has_info(shnum))
 			shapes_file->set_info(shnum, Shape_info());
 		info = &shapes_file->get_info(shnum);
@@ -2106,7 +2107,8 @@ void Shape_chooser::search(
 		return;         // Empty.
 	// Read info if not read.
 	ExultStudio *studio = ExultStudio::get_instance();
-	shapes_file->read_info(studio->get_game_type(), true);
+	if (shapes_file->read_info(studio->get_game_type(), true))
+		studio->set_shapeinfo_modified();
 	// Start with selection, or top.
 	int start = selected >= 0 ? selected : static_cast<int>(rows[row0].index0);
 	int i;
@@ -2406,7 +2408,8 @@ void Shape_chooser::update_statusbar(
 				g_snprintf(buf + len, sizeof(buf) - len,
 				           ":  '%s'", nm);
 			}
-			shapes_file->read_info(studio->get_game_type(), true);
+			if (shapes_file->read_info(studio->get_game_type(), true))
+				studio->set_shapeinfo_modified();
 			int frnum = info[selected].framenum;
 			const Shape_info &inf = shapes_file->get_info(shapenum);
 			const Frame_name_info *nminf;

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -755,7 +755,7 @@ ExultStudio::ExultStudio(int argc, char **argv): glade_path(nullptr),
 	cout << "Looking for CSS at '" << path << "'... ";
 	if (U7exists(path)) {
 		cout << "loading." << endl;
-		if(!gtk_css_provider_load_from_path(css_provider, path, &error)) {
+		if (!gtk_css_provider_load_from_path(css_provider, path, &error)) {
 			cerr << "Couldn't load css file: " << error->message << endl;
 			cerr << "ExultStudio proceeds without it. "
 			     << "You can fix it and reload it in 'File > Reload > Style CSS'" << endl;
@@ -2538,7 +2538,7 @@ C_EXPORT gboolean on_prefs_window_delete_event(
 void ExultStudio::reload_css(
 ) {
 	GError *error = nullptr;
-	if(!gtk_css_provider_load_from_path(css_provider, css_path, &error)) {
+	if (!gtk_css_provider_load_from_path(css_provider, css_path, &error)) {
 		cerr << "Couldn't reload the CSS file: " << error->message << endl;
 		prompt("Failed to reload the CSS file.\n"
 		       "ExultStudio proceeds without it. You can fix it and Reload it.", "OK");

--- a/shapes/shapevga.h
+++ b/shapes/shapevga.h
@@ -55,7 +55,8 @@ public:
 	// Read additional data files.
 	void reload_info(Exult_Game game);
 	void fix_old_shape_info(Exult_Game game);
-	void read_info(Exult_Game game, bool editing = false);
+	// Returns true when some Shape data have been migrated.
+	bool read_info(Exult_Game game, bool editing = false);
 	void write_info(Exult_Game game);   // Write them back out.
 	Shape *new_shape(int shapenum) override;
 	Shape_info &get_info(int shapenum) {


### PR DESCRIPTION
Proposal to solve issue #122.

At the end of `Shapes_vga_file::read_info`, scan the Shapes that are monsters and which hold the obsolete monster flags can_teleport, can_summon, can_be_invisible.
Set these flags into shape_info.txt Actor info - seen in the Studio Shape Editor as NPC Flags, and 
Remove these flags from Monster info in monster.dat.

For each such Shape, produce under Exult or under Exult Studio on cerr/stderr a message like 
`Shape 1298 is a monster that can teleport, teleport flag moved from Monster info ( monster.dat ) to Actor info ( shape_info.txt ) as NPC flags.`
Real example taken from Glimmerscape Mod from SourceForge. Shape 1298 is the Wisp.

Missing : set modified flag which would cause a warning at Studio exit from a needed Save. At this point, Save All rewrites correctly the fixed flags, but no warning notifies the user of a pending needed Save on Studio exit.