### PR TITLE
Add vertical status bars

### DIFF
--- a/gumps/Face_stats.cc
+++ b/gumps/Face_stats.cc
@@ -392,7 +392,6 @@ void Face_stats::create_buttons() {
 		width = - PORTRAIT_WIDTH;
 	}
 	else if (mode == 3) {
-
 		// if large black bars we dont want potraits floating in space so put them next to the game window
 		if (black_bar_width > (PORTRAIT_WIDTH *2)) posx = black_bar_width - PORTRAIT_WIDTH - 5;
 		// center potrait in blank space
@@ -401,7 +400,8 @@ void Face_stats::create_buttons() {
 		posy = PORTRAIT_HEIGHT;
 		width = 0;
 		height = PORTRAIT_HEIGHT;
-		y = 0;
+		// center potraits in Y, mainly to avoid conflicting with other on screeen controls
+		y = gamey/2 - (PORTRAIT_HEIGHT*4)/2;
 		vertical = true;
 	}
 
@@ -412,12 +412,9 @@ void Face_stats::create_buttons() {
 	party[0] = new Portrait_button(this, posx, posy, gwin->get_main_actor());
 
 	for (i = 0; i < party_size; i++) {
-		// if vertical display first 4 on left and last 4 on right
-		// I chose this over squishing them in tightly
+		// if vertical display first 4 on left and last 4 on right 
 		if (vertical && i == 3) {
-			// if large black bars we dont want potraits floating in space so put them next to the game window
 			if (black_bar_width > (PORTRAIT_WIDTH *2)) posx = gamex + 5;
-			// center potrait in blank space
 			else if (black_bar_width > PORTRAIT_WIDTH) posx = black_bar_width + gamex - black_bar_width/2 - PORTRAIT_WIDTH/2;
 			else posx = black_bar_width + gamex - PORTRAIT_WIDTH;
 			posy = 0;
@@ -426,11 +423,8 @@ void Face_stats::create_buttons() {
 		Actor *act = gwin->get_npc(npc_nums[i + 1]);
 		assert(act != nullptr);
 		// Show faces if in SI, or if paperdolls are allowed
-		if (sman->can_use_paperdolls() ||
-		        // Otherwise, show faces also if the character
-		        // has paperdoll information
-		        act->get_info().get_npc_paperdoll()) {
-		
+		// Otherwise, show faces also if the character has paperdoll information
+		if (sman->can_use_paperdolls() || act->get_info().get_npc_paperdoll()) {
 			posx += width;
 			posy += height;
 			party[i + 1] = new Portrait_button(this, posx, posy, gwin->get_npc(npc_nums[i + 1]));
@@ -452,7 +446,6 @@ bool Face_stats::has_point(int x, int y) const {
 	for (auto *act : party)
 		if (act && act->on_button(x, y))
 			return true;
-
 	return false;
 }
 

--- a/gumps/Face_stats.cc
+++ b/gumps/Face_stats.cc
@@ -351,35 +351,35 @@ void Face_stats::delete_buttons() {
 }
 
 void Face_stats::create_buttons() {
-	int i;
-	int posx = 0;
-	int posy = 0;
-	int width = PORTRAIT_WIDTH;
-	int black_bar_width = 0;
-	int height = 0;
-	bool vertical = false;
+	int  i;
+	int  posx            = 0;
+	int  posy            = 0;
+	int  width           = PORTRAIT_WIDTH;
+	int  black_bar_width = 0;
+	int  height          = 0;
+	bool vertical        = false;
 
-	resx = gwin->get_win()->get_full_width();
-	resy = gwin->get_win()->get_full_height();
-	gamex = gwin->get_game_width();
-	gamey = gwin->get_game_height();
-	x = 0;
-	y = gwin->get_win()->get_end_y();
-	black_bar_width = (resx - gamex)/2;
+	resx            = gwin->get_win()->get_full_width();
+	resy            = gwin->get_win()->get_full_height();
+	gamex           = gwin->get_game_width();
+	gamey           = gwin->get_game_height();
+	x               = 0;
+	y               = gwin->get_win()->get_end_y();
+	black_bar_width = (resx - gamex) / 2;
 
 	party_size = partyman->get_count();
 
 	int num_to_paint = 0;
 
 	for (i = 0; i < party_size; i++) {
-		int num = partyman->get_member(i);
-		Actor *act = gwin->get_npc(num);
+		int    num = partyman->get_member(i);
+		Actor* act = gwin->get_npc(num);
 		assert(act != nullptr);
 		// Show faces if in SI, or if paperdolls are allowed
 		if (sman->can_use_paperdolls() ||
-		        // Otherwise, show faces also if the character
-		        // has paperdoll information
-		        act->get_info().get_npc_paperdoll())
+			// Otherwise, show faces also if the character
+			// has paperdoll information
+			act->get_info().get_npc_paperdoll())
 			++num_to_paint;
 	}
 
@@ -388,20 +388,22 @@ void Face_stats::create_buttons() {
 	else if (mode == 1)
 		posx = (resx - (num_to_paint + 1) * PORTRAIT_WIDTH) / 2;
 	else if (mode == 2) {
-		posx = resx - PORTRAIT_WIDTH;
-		width = - PORTRAIT_WIDTH;
-	}
-	else if (mode == 3) {
+		posx  = resx - PORTRAIT_WIDTH;
+		width = -PORTRAIT_WIDTH;
+	} else if (mode == 3) {
 		// if large black bars we dont want potraits floating in space so put them next to the game window
-		if (black_bar_width > (PORTRAIT_WIDTH *2)) posx = black_bar_width - PORTRAIT_WIDTH - 5;
+		if (black_bar_width > (PORTRAIT_WIDTH * 2))
+			posx = black_bar_width - PORTRAIT_WIDTH - 5;
 		// center potrait in blank space
-		else if (black_bar_width > PORTRAIT_WIDTH) posx = black_bar_width/2 - PORTRAIT_WIDTH/2;
-		else posx = 0;
-		posy = PORTRAIT_HEIGHT;
-		width = 0;
+		else if (black_bar_width > PORTRAIT_WIDTH)
+			posx = black_bar_width / 2 - PORTRAIT_WIDTH / 2;
+		else
+			posx = 0;
+		posy   = PORTRAIT_HEIGHT;
+		width  = 0;
 		height = PORTRAIT_HEIGHT;
 		// center potraits in Y, mainly to avoid conflicting with other on screeen controls
-		y = gamey/2 - (PORTRAIT_HEIGHT*4)/2;
+		y        = gamey / 2 - (PORTRAIT_HEIGHT * 4) / 2;
 		vertical = true;
 	}
 
@@ -412,15 +414,18 @@ void Face_stats::create_buttons() {
 	party[0] = new Portrait_button(this, posx, posy, gwin->get_main_actor());
 
 	for (i = 0; i < party_size; i++) {
-		// if vertical display first 4 on left and last 4 on right 
+		// if vertical display first 4 on left and last 4 on right
 		if (vertical && i == 3) {
-			if (black_bar_width > (PORTRAIT_WIDTH *2)) posx = gamex + 5;
-			else if (black_bar_width > PORTRAIT_WIDTH) posx = black_bar_width + gamex - black_bar_width/2 - PORTRAIT_WIDTH/2;
-			else posx = black_bar_width + gamex - PORTRAIT_WIDTH;
+			if (black_bar_width > (PORTRAIT_WIDTH * 2))
+				posx = gamex + 5;
+			else if (black_bar_width > PORTRAIT_WIDTH)
+				posx = black_bar_width + gamex - black_bar_width / 2 - PORTRAIT_WIDTH / 2;
+			else
+				posx = black_bar_width + gamex - PORTRAIT_WIDTH;
 			posy = 0;
 		}
 		npc_nums[i + 1] = partyman->get_member(i);
-		Actor *act = gwin->get_npc(npc_nums[i + 1]);
+		Actor* act      = gwin->get_npc(npc_nums[i + 1]);
 		assert(act != nullptr);
 		// Show faces if in SI, or if paperdolls are allowed
 		// Otherwise, show faces also if the character has paperdoll information
@@ -438,7 +443,7 @@ void Face_stats::create_buttons() {
 	for (i = 0; i < 8; i++)
 		if (party[i]) {
 			TileRect r = party[i]->get_rect();
-			region = region.add(r);
+			region     = region.add(r);
 		}
 }
 

--- a/gumps/Face_stats.cc
+++ b/gumps/Face_stats.cc
@@ -366,7 +366,6 @@ void Face_stats::create_buttons() {
 	x = 0;
 	y = gwin->get_win()->get_end_y();
 	black_bar_width = (resx - gamex)/2;
-	std::cout << "Black Bar Width: " << black_bar_width << std::endl;
 
 	party_size = partyman->get_count();
 
@@ -393,8 +392,11 @@ void Face_stats::create_buttons() {
 		width = - PORTRAIT_WIDTH;
 	}
 	else if (mode == 3) {
+
+		// if large black bars we dont want potraits floating in space so put them next to the game window
+		if (black_bar_width > (PORTRAIT_WIDTH *2)) posx = black_bar_width - PORTRAIT_WIDTH - 5;
 		// center potrait in blank space
-		if (black_bar_width > PORTRAIT_WIDTH) posx = black_bar_width/2 - PORTRAIT_WIDTH/2;
+		else if (black_bar_width > PORTRAIT_WIDTH) posx = black_bar_width/2 - PORTRAIT_WIDTH/2;
 		else posx = 0;
 		posy = PORTRAIT_HEIGHT;
 		width = 0;
@@ -413,7 +415,10 @@ void Face_stats::create_buttons() {
 		// if vertical display first 4 on left and last 4 on right
 		// I chose this over squishing them in tightly
 		if (vertical && i == 3) {
-			if (black_bar_width > PORTRAIT_WIDTH) posx = black_bar_width + gamex - black_bar_width/2 - PORTRAIT_WIDTH/2;
+			// if large black bars we dont want potraits floating in space so put them next to the game window
+			if (black_bar_width > (PORTRAIT_WIDTH *2)) posx = gamex + 5;
+			// center potrait in blank space
+			else if (black_bar_width > PORTRAIT_WIDTH) posx = black_bar_width + gamex - black_bar_width/2 - PORTRAIT_WIDTH/2;
 			else posx = black_bar_width + gamex - PORTRAIT_WIDTH;
 			posy = 0;
 		}
@@ -429,7 +434,6 @@ void Face_stats::create_buttons() {
 			posx += width;
 			posy += height;
 			party[i + 1] = new Portrait_button(this, posx, posy, gwin->get_npc(npc_nums[i + 1]));
-			std::cout << "ResX:" << resx << "  Portrait Position: " << i+1 << " - " << posx << "," << posy << std::endl;
 		} else {
 			party[i + 1] = nullptr;
 		}

--- a/gumps/GameplayOptions_gump.cc
+++ b/gumps/GameplayOptions_gump.cc
@@ -78,7 +78,8 @@ void GameplayOptions_gump::cancel() {
 }
 
 void GameplayOptions_gump::build_buttons() {
-	std::vector<std::string> stats = {"Disabled", "Left", "Middle", "Right"};
+	//Status Bar Positions
+	std::vector<std::string> stats = {"Disabled", "Left", "Middle", "Right", "Vertical"};
 	buttons[id_facestats] = std::make_unique<GameplayTextToggle>(this, &GameplayOptions_gump::toggle_facestats,
 	        std::move(stats), facestats, colx[3], rowy[0], 59);
 


### PR DESCRIPTION
Added vertical status bars so it can be used when on a widescreen monitor(or windowed) to make use of the empty space on the left and right of the game window if using original game area.

Decided to put them in two groups of 4 as to not need to squish them all on one side which could be done without overlap but looks awful.

Typical use case(how it looks @ 1920x1080 or 2560x1440(16:9))
![Vertical_Typical_Border](https://user-images.githubusercontent.com/3213678/149418372-8c4227dc-159e-451d-bddf-7d116ce81ef9.png)

New Option in Gameplay
![Vertical_New Menu Option](https://user-images.githubusercontent.com/3213678/149418435-ca406771-9fbd-49bb-8075-8ac07ed4ef3c.png)

Will center potraits up to double potrait width...
![Vertical_Borders Double Portrait](https://user-images.githubusercontent.com/3213678/149418567-6d36b616-b335-498f-801a-65d853a9ccb0.png)

When you have really large black bars...
![Vertical_Large_Border](https://user-images.githubusercontent.com/3213678/149418470-a9abb76a-e82a-4b1f-8acf-90e63c02cf6c.png)

Two more to show nothing is broken...
![Vertical_No Border](https://user-images.githubusercontent.com/3213678/149418520-0780df06-5aed-4696-87e0-43e9823d7464.png)
![Vertical_Borders not full width of Portrait](https://user-images.githubusercontent.com/3213678/149418524-38c5b01e-3b52-49c7-bc77-d7cf7138ffd8.png)

