### PR TITLE
Install script changes for game mods

### DIFF
--- a/content/bg/Makefile.mingw
+++ b/content/bg/Makefile.mingw
@@ -27,7 +27,7 @@ CLEANFILES = \
 all: usecode
 
 install: all
-	mkdir $(bgdir)
+	mkdir -p $(bgdir)
 	cp lbjoin.cfg $(bgdir)/lbjoin.cfg
 	mkdir -p $(bgdir)/lbjoin/
 	cp usecode $(bgdir)/lbjoin/usecode

--- a/content/bgkeyring/Makefile.am
+++ b/content/bgkeyring/Makefile.am
@@ -167,9 +167,9 @@ PAPERDOL_VGA_OBJECTS = \
 	src/graphics/paperdol.in	\
 	src/graphics/paperdol/Female_Paperdoll.shp	\
 	src/graphics/paperdol/FlyingCarpet.shp	\
-	src/graphics/paperdol/Laurianna_Paperdoll.shp	\
 	src/graphics/paperdol/LB_Crown_Paperdoll.shp	\
 	src/graphics/paperdol/LB_Sceptre_Paperdoll.shp	\
+	src/graphics/paperdol/Laurianna_Paperdoll.shp	\
 	src/graphics/paperdol/Male_Paperdoll.shp	\
 	src/graphics/paperdol/Mariah_Paperdoll.shp	\
 	src/graphics/paperdol/Spell_Amulet_Paperdoll.shp	\
@@ -216,11 +216,11 @@ SHAPES_VGA_OBJECTS = \
 	src/graphics/shapes/Julias_Hammer.shp	\
 	src/graphics/shapes/Keyring.shp	\
 	src/graphics/shapes/Kitchen_Items.shp	\
-	src/graphics/shapes/Laurianna.shp	\
-	src/graphics/shapes/Laurianna.shp	\
 	src/graphics/shapes/LB_Amulet.shp	\
 	src/graphics/shapes/LB_Crown.shp	\
 	src/graphics/shapes/LB_Sceptre.shp	\
+	src/graphics/shapes/Laurianna.shp	\
+	src/graphics/shapes/Laurianna.shp	\
 	src/graphics/shapes/Lord_British.shp	\
 	src/graphics/shapes/Magic_Gem.shp	\
 	src/graphics/shapes/Mariah.shp	\

--- a/content/bgkeyring/Makefile.mingw
+++ b/content/bgkeyring/Makefile.mingw
@@ -175,9 +175,9 @@ PAPERDOL_VGA_OBJECTS = \
 	src/graphics/paperdol.in	\
 	src/graphics/paperdol/Female_Paperdoll.shp	\
 	src/graphics/paperdol/FlyingCarpet.shp	\
-	src/graphics/paperdol/Laurianna_Paperdoll.shp	\
 	src/graphics/paperdol/LB_Crown_Paperdoll.shp	\
 	src/graphics/paperdol/LB_Sceptre_Paperdoll.shp	\
+	src/graphics/paperdol/Laurianna_Paperdoll.shp	\
 	src/graphics/paperdol/Male_Paperdoll.shp	\
 	src/graphics/paperdol/Mariah_Paperdoll.shp	\
 	src/graphics/paperdol/Spell_Amulet_Paperdoll.shp	\
@@ -224,11 +224,11 @@ SHAPES_VGA_OBJECTS = \
 	src/graphics/shapes/Julias_Hammer.shp	\
 	src/graphics/shapes/Keyring.shp	\
 	src/graphics/shapes/Kitchen_Items.shp	\
-	src/graphics/shapes/Laurianna.shp	\
-	src/graphics/shapes/Laurianna.shp	\
 	src/graphics/shapes/LB_Amulet.shp	\
 	src/graphics/shapes/LB_Crown.shp	\
 	src/graphics/shapes/LB_Sceptre.shp	\
+	src/graphics/shapes/Laurianna.shp	\
+	src/graphics/shapes/Laurianna.shp	\
 	src/graphics/shapes/Lord_British.shp	\
 	src/graphics/shapes/Magic_Gem.shp	\
 	src/graphics/shapes/Mariah.shp	\
@@ -272,7 +272,7 @@ CLEANFILES = \
 all: data/usecode data/faces.vga data/gumps.vga data/mainshp.flx data/paperdol.vga data/shapes.vga
 
 install: all
-	mkdir $(bgkeyringdir)
+	mkdir -p $(bgkeyringdir)
 	cp Keyring.cfg $(bgkeyringdir)/Keyring.cfg
 	mkdir -p $(bgkeyringdir)/Keyring/data
 	cp data/usecode $(bgkeyringdir)/Keyring/data/usecode

--- a/content/islefaq/Makefile.mingw
+++ b/content/islefaq/Makefile.mingw
@@ -39,7 +39,7 @@ CLEANFILES = \
 all: patch/usecode patch/faces.vga patch/shapes.vga
 
 install: all
-	mkdir $(islefaqdir)
+	mkdir -p $(islefaqdir)
 	cp islefaq.cfg $(islefaqdir)/islefaq.cfg
 	mkdir -p $(islefaqdir)/islefaq/patch
 	cp patch/usecode $(islefaqdir)/islefaq/patch/usecode

--- a/content/makefile_builder.sh
+++ b/content/makefile_builder.sh
@@ -245,7 +245,7 @@ $datafiles_mingw"
 	fi
 
 	# Rules for MinGW 'make install' and 'make uninstall'.
-	echo -e "$targets_mingw${n}\ninstall: all${n}\tmkdir \$(${moddir}dir)${n}\tcp $(basename "$cfgfile") \$(${moddir}dir)/$(basename "$cfgfile")${n}$datafiles_mingw${n}\nuninstall:${n}\trm -f \$(${moddir}dir)/$(basename "$cfgfile")${n}\trm -rf $destdir_mingw${n}" >> "$modmakefile_mingw"
+	echo -e "$targets_mingw${n}\ninstall: all${n}\tmkdir -p \$(${moddir}dir)${n}\tcp $(basename "$cfgfile") \$(${moddir}dir)/$(basename "$cfgfile")${n}$datafiles_mingw${n}\nuninstall:${n}\trm -f \$(${moddir}dir)/$(basename "$cfgfile")${n}\trm -rf $destdir_mingw${n}" >> "$modmakefile_mingw"
 
 	# Output rule to build expack, if needed.
 	if [[ "$buildexpack" == "yes" ]]; then

--- a/content/si/Makefile.mingw
+++ b/content/si/Makefile.mingw
@@ -27,7 +27,7 @@ CLEANFILES = \
 all: usecode
 
 install: all
-	mkdir $(sidir)
+	mkdir -p $(sidir)
 	cp curecantra.cfg $(sidir)/curecantra.cfg
 	mkdir -p $(sidir)/curecantra/
 	cp usecode $(sidir)/curecantra/usecode

--- a/content/sifixes/Makefile.am
+++ b/content/sifixes/Makefile.am
@@ -91,6 +91,7 @@ SHAPES_VGA_OBJECTS = \
 
 SPRITES_VGA_OBJECTS = \
 	src/graphics/sprites.in	\
+	src/graphics/sprites/map_en.shp	\
 	src/graphics/sprites/sprite_07_teleport_here.shp	
 
 sifixesdir = $(datadir)/exult/silverseed/mods

--- a/content/sifixes/Makefile.mingw
+++ b/content/sifixes/Makefile.mingw
@@ -99,6 +99,7 @@ SHAPES_VGA_OBJECTS = \
 
 SPRITES_VGA_OBJECTS = \
 	src/graphics/sprites.in	\
+	src/graphics/sprites/map_en.shp	\
 	src/graphics/sprites/sprite_07_teleport_here.shp	
 
 CLEANFILES = \
@@ -117,7 +118,7 @@ CLEANFILES = \
 all: data/usecode data/gumps.vga data/mainshp.flx data/paperdol.vga data/shapes.vga data/sprites.vga
 
 install: all
-	mkdir $(sifixesdir)
+	mkdir -p $(sifixesdir)
 	cp sifixes.cfg $(sifixesdir)/sifixes.cfg
 	mkdir -p $(sifixesdir)/sifixes/data
 	cp data/usecode $(sifixesdir)/sifixes/data/usecode


### PR DESCRIPTION
The various Makefile.mingw to install the game mods ( si, sifixes, gb, bgkeyring ) all use 
`mkdir forgeofvirtue/mods` or `mkdir silverseed/mods`.

Replace those by `mkdir -p ...` to ensure that one may install all mods.

1. Actually changed only into `makefile_builder.sh`,
2. Then regenerated all Makefile.sh and Makefile.mingw using `LC_ALL=C ./makefile_builder.sh`.

Even with LC_ALL=C, the produced Makefiles change the place of `Laurianna.shp` and `Laurianna_Paperdoll.shp`.
Sorry about that.
On the other hand it looks like `map_en.shp` was missing fron `sifixes`.
I don't know whether that is serious.