### PR TITLE
Fix out-of-tree autogen

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# Move to autogen.sh's directory
+srcdir=`dirname $0`
+test -n "$srcdir" && cd "$srcdir"
+
 DIE=0
 
 # Check for availability

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Move to autogen.sh's directory
-srcdir=`dirname $0`
+srcdir=$(dirname $0)
 test -n "$srcdir" && cd "$srcdir"
 
 DIE=0


### PR DESCRIPTION
The existing `autogen.sh` assumes it is being run from the source directory.  This causes problems if the build is being managed by a tool which is running from another directory.  This patch modifies the script to change to the source directory before rerunning autotools.