### PR TITLE
Detect SDL with SDL_main

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,8 +21,13 @@ SUBDIRS =  files conf data shapes imagewin pathfinder \
 	mapedit desktop docs $(MODSDIR)
 
 bin_PROGRAMS = exult
+if SDL_MAIN_NEEDED
+exult_SOURCES = sdl_main.cc
+else
+exult_SOURCES =
+endif
 
-exult_SOURCES =	\
+exult_SOURCES +=	\
 	actions.cc	\
 	actions.h	\
 	actorio.cc	\

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -90,6 +90,8 @@ AC_DEFUN([EXULT_CHECK_SDL],[
   if test "x$exult_sdlok" = xyes; then
     LIBS="$LIBS $SDL_LIBS"
 
+    dnl as normal executable...
+
     AC_LINK_IFELSE([AC_LANG_SOURCE([[
     #include "SDL.h"
 
@@ -97,13 +99,40 @@ AC_DEFUN([EXULT_CHECK_SDL],[
       SDL_Init(0);
       return 0;
     }
-    ]])],sdllinkok=yes,sdllinkok=no)
+    ]])],sdllinkok=exe,sdllinkok=no)
+
+    if test x$sdllinkok = xno; then
+
+      dnl as library with SDL_main...
+
+      AC_LINK_IFELSE([AC_LANG_SOURCE([[
+      #include "SDL.h"
+
+      int main(int argc, char* argv[]) {
+        SDL_Init(0);
+        return 0;
+      }
+      #undef main
+      int main(int argc, char * argv[]) {
+        return SDL_main(argc, argv);
+      }
+      ]])],sdllinkok=lib,sdllinkok=no)      
+
+      AM_CONDITIONAL(SDL_MAIN_NEEDED, true)
+    else
+      AM_CONDITIONAL(SDL_MAIN_NEEDED, false)
+    fi
+
     if test x$sdllinkok = xno; then
       exult_sdlok=no
     fi
   fi
 
-  AC_MSG_RESULT($exult_sdlok)
+  if test x$sdllinkok = xlib; then
+    AC_MSG_RESULT($exult_sdlok (SDL_MAIN_NEEDED))
+  else
+    AC_MSG_RESULT($exult_sdlok)
+  fi
 
   LDFLAGS="$exult_backupldflags"
   CPPFLAGS="$exult_backupcppflags"

--- a/sdl_main.cc
+++ b/sdl_main.cc
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2021-2022  The Exult Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#include <SDL_main.h>
+
+#undef main
+
+int main(
+    int argc,
+    char *argv[]
+) {
+	return SDL_main(argc, argv);
+}


### PR DESCRIPTION
On Android, SDL replaces the `main()` symbol with `SDL_main()`, which results in a link error if we try to link an executable.  This is actually a more generic concept in SDL that is turned on by default in android builds.  This patch adds support for detecting when a platform enables `SDL_main()` and adds a wrapper with a real `main()` to call it when building an executable.