### PR TITLE
Fix Gimp Plugin compilation on Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1000,8 +1000,8 @@ if test x$enable_gimp_plugin = xyes; then
 		AC_MSG_RESULT([no, not building GIMP plugin])
 	else
 		AC_MSG_CHECKING([for GIMP version])
-		gimp_version=`$GIMPTOOL --version | awk 'BEGIN { FS = "."; } { print $1 * 1000 + $2*100+$3;}'`
-		if test "$gimp_version" -ge 2800; then
+		gimp_version=`$GIMPTOOL --version | awk 'BEGIN { FS = "."; } { print $1 * 10000 + $2 * 100 + $3;}'`
+		if test "$gimp_version" -ge 20800; then
 			AC_MSG_RESULT([found >= 2.8.0])
 			AC_SUBST(GIMPTOOL)
 			AM_CONDITIONAL(GIMP_PLUGIN, true)

--- a/mapedit/u7shp.cc
+++ b/mapedit/u7shp.cc
@@ -31,25 +31,19 @@
 #	pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #	if !defined(__llvm__) && !defined(__clang__)
+#		pragma GCC diagnostic ignored "-Wpedantic"
 #		pragma GCC diagnostic ignored "-Wuseless-cast"
 #	else
+#		pragma GCC diagnostic ignored "-Wc99-extensions"
 #		pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #	endif
 #endif    // __GNUC__
-#ifdef USE_STRICT_GTK
-#	define GTK_DISABLE_SINGLE_INCLUDES
-#	define GSEAL_ENABLE
-#	define GNOME_DISABLE_DEPRECATED
-#	define GTK_DISABLE_DEPRECATED
-#	define GDK_DISABLE_DEPRECATED
-#endif    // USE_STRICT_GTK
 #include <gtk/gtk.h>
+#include <libgimp/gimp.h>
+#include <libgimp/gimpui.h>
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif  // __GNUC__
-
-#include <libgimp/gimp.h>
-#include <libgimp/gimpui.h>
 
 /* Declare some local functions.
  */


### PR DESCRIPTION
  Commit 1 of 1
    configure.ac
      Handle Gimp Ver.Rel.Mod where Rel >= 10
    mapedit/u7shp.cc
      Move gimp.h and gimpui.h under the warning deactivate frame
      Add 2 new warning deactivates
      Do no enable the GTK .. Deprecated checks