### PR TITLE
Add option to build Exult as a library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,14 +20,7 @@ SUBDIRS =  files conf data shapes imagewin pathfinder \
 	gamemgr flic usecode tools audio gumps objs server \
 	mapedit desktop docs $(MODSDIR)
 
-bin_PROGRAMS = exult
-if SDL_MAIN_NEEDED
-exult_SOURCES = sdl_main.cc
-else
-exult_SOURCES =
-endif
-
-exult_SOURCES +=	\
+EXULTSOURCES =	\
 	actions.cc	\
 	actions.h	\
 	actorio.cc	\
@@ -137,12 +130,35 @@ EXULTLIBS = \
 	files/sha1/libsha1.la \
 	files/zip/libminizip.la
 
-exult_LDADD = \
-	$(EXULTLIBS) $(PNG_LIBS) \
+EXULTLIBADD = \
+	$(EXULTLIBS) $(PNG_LIBS) $(FREETYPE2_LIBS) \
 	$(SDL_LIBS) $(SYSLIBS) $(x_libraries) $(ICON_FILE) \
 	$(ZLIB_LIBS) $(VORBIS_LIBS) $(VORBISFILE_LIBS) $(OGG_LIBS) $(MT32EMU_LIBS) $(FLUIDSYNTH_LIBS) $(ALSA_LIBS)
 
-exult_DEPENDENCIES = $(ICON_FILE) $(EXULTLIBS)
+EXULTDEPENDENCIES = $(ICON_FILE) $(EXULTLIBS)
+
+# If we've been asked to build exult as a library...
+if BUILD_LIBEXULT
+lib_LTLIBRARIES = libexult.la
+libexult_la_SOURCES = $(EXULTSOURCES)
+libexult_la_LIBADD = $(EXULTLIBADD)
+libexult_la_DEPENDENCIES = $(EXULTDEPENDENCIES)
+libexult_la_LDFLAGS=-release $(PACKAGE_VERSION)
+
+# Otherwise we must be building an executable
+else # !BUILD_LIBEXULT
+bin_PROGRAMS = exult
+exult_SOURCES = $(EXULTSOURCES)
+exult_LDADD = $(EXULTLIBADD)
+exult_DEPENDENCIES = $(EXULTDEPENDENCIES)
+if SDL_MAIN_NEEDED
+exult_SOURCES += sdl_main.cc
+endif
+
+# Workaround for automake issue with using the same sources for both a library and an executable.
+# See https://www.gnu.org/software/automake/manual/html_node/Objects-created-both-with-libtool-and-without.html
+exult_CPPFLAGS = $(AM_CPPFLAGS)
+endif
 
 EXTRA_DIST = 	\
 	autogen.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -244,6 +244,17 @@ else
 fi
 
 # ---------------------------------------------------------------------
+# Build Exult as a library?
+# ---------------------------------------------------------------------
+
+AC_ARG_ENABLE(libexult, AS_HELP_STRING([--enable-libexult], [Build Exult as a library @<:@default no@:>@]),,enable_libexult=no)
+if test x$enable_libexult = xno; then
+	AM_CONDITIONAL(BUILD_LIBEXULT, false)
+else
+	AM_CONDITIONAL(BUILD_LIBEXULT, true)
+fi
+
+# ---------------------------------------------------------------------
 # Statically link libraries?
 # ---------------------------------------------------------------------
 

--- a/macosx/macosx.am
+++ b/macosx/macosx.am
@@ -38,9 +38,12 @@ if WITH_OSX_CODE_SIGNATURE
 	codesign --options runtime --timestamp -f -s "$(OSX_CODE_SIGNATURE)" $(studio_name)/Contents/Resources/lib/gdk-pixbuf-2.0/2.10.0/loaders/*.so
 endif
 
+# Don't try to build/install the MacOS bundle if we are building libexult
+if !BUILD_LIBEXULT
 install-exec-local: bundle
 	mkdir -p $(DESTDIR)/Applications/
 	cp -r $(bundle_name) $(DESTDIR)/Applications/
+endif
 
 osxdmg: bundle
 	mkdir -p Exult-snapshot


### PR DESCRIPTION
The existing build structure always tries to build exult as an executable.  This ends up causing link errors when building for android.  This patch introduces a configure option to build the entire exult codebase into a library instead of an executable.  This will enable android builds to opt out of the executable while still building the library which the app will load at runtime.  This configure option is disabled by default, so builds on other platforms will still generate a monolithic executable like they always have.