### PR TITLE
Use U7 file I/O for unzip

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,12 @@ EXULTSOURCES =	\
 	exultmenu.cc	\
 	exultmenu.h	\
 	exult_constants.h	\
+	files/sdlrwopsstreambuf.cc \
+	files/sdlrwopsstreambuf.h \
+	files/sdlrwopsistream.cc \
+	files/sdlrwopsistream.h \
+	files/sdlrwopsostream.cc \
+	files/sdlrwopsostream.h \
 	fnames.h	\
 	frameseq.h	\
 	game.cc		\

--- a/Makefile.common
+++ b/Makefile.common
@@ -13,6 +13,9 @@ MAIN_OBJS:=actions.o \
 	effects.o \
 	exult.o \
 	exultmenu.o \
+	files/sdlrwopsstreambuf.o \
+	files/sdlrwopsistream.o \
+	files/sdlrwopsostream.o \
 	game.o \
 	gameclk.o \
 	gamedat.o \

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -42,7 +42,7 @@ AC_DEFUN([EXULT_CHECK_SDL],[
 
   REQ_MAJOR=2
   REQ_MINOR=0
-  REQ_PATCHLEVEL=6
+  REQ_PATCHLEVEL=10
   REQ_VERSION=$REQ_MAJOR.$REQ_MINOR.$REQ_PATCHLEVEL
 
   AC_MSG_CHECKING([for SDL - version >= $REQ_VERSION])
@@ -69,7 +69,7 @@ AC_DEFUN([EXULT_CHECK_SDL],[
 
   if test x$exult_sdlok = xyes ; then
 
-    if test ! \( \( $sdl_major_version -gt $REQ_MAJOR \) -o \( \( $sdl_major_version -eq $REQ_MAJOR \) -a \( \( $sdl_minor_version -gt $REQ_MINOR \) -o \( \( $sdl_minor_version -eq $REQ_MINOR \) -a \( $sdl_patchlevel -gt $REQ_PATCHLEVEL \) \) \) \) \); then
+    if test ! \( \( $sdl_major_version -gt $REQ_MAJOR \) -o \( \( $sdl_major_version -eq $REQ_MAJOR \) -a \( \( $sdl_minor_version -gt $REQ_MINOR \) -o \( \( $sdl_minor_version -eq $REQ_MINOR \) -a \( $sdl_patchlevel -ge $REQ_PATCHLEVEL \) \) \) \) \); then
       exult_sdlok="no, version < $REQ_VERSION found"
     else
       AC_COMPILE_IFELSE([AC_LANG_SOURCE([[

--- a/audio/midi_drivers/MT32EmuMidiDriver.cpp
+++ b/audio/midi_drivers/MT32EmuMidiDriver.cpp
@@ -94,15 +94,15 @@ int MT32EmuMidiDriver::open() {
 		FileStream part1;
 		FileStream part2;
 		if (openROMFile(part1, "MT32A.BIN", false) && openROMFile(part2, "MT32B.BIN", false)) {
-			std::ofstream out;
-			if (U7open(out, "<SAVEHOME>/data/MT32_CONTROL.ROM", false)) {
+			auto pOut = U7open_out("<SAVEHOME>/data/MT32_CONTROL.ROM", false);
+			if (pOut) {
+				auto& out = *pOut;
 				const Bit8u *data1 = part1.getData();
 				const Bit8u *data2 = part2.getData();
 				for (size_t ii = 0; ii < std::min(part1.getSize(), part2.getSize()); ii++) {
 					out.put(static_cast<char>(data1[ii]));
 					out.put(static_cast<char>(data2[ii]));
 				}
-				out.close();
 				controlROMImage = getROM(controlROMFile, "MT32_CONTROL.ROM");
 			}
 		}

--- a/conf/Configuration.cc
+++ b/conf/Configuration.cc
@@ -216,13 +216,14 @@ bool Configuration::read_abs_config_file(const string &input_filename, const str
 
 	is_file = true; // set to file, even if file not found
 
-	std::ifstream ifile;
+	std::unique_ptr<std::istream> pIfile;
 	try {
-		U7open(ifile, filename.c_str(), true);
+		pIfile = U7open_in(filename.c_str(), true);
 	} catch (exult_exception &) {
 		// configuration file not found
 		return false;
 	}
+	auto& ifile = *pIfile;
 
 	if (ifile.fail())
 		return false;
@@ -235,8 +236,6 @@ bool Configuration::read_abs_config_file(const string &input_filename, const str
 		sbuf += line + "\n";
 		getline(ifile, line);
 	}
-
-	ifile.close();
 
 	CTRACE("Configuration::read_config_file - file read");
 
@@ -260,18 +259,18 @@ void Configuration::write_back() {
 	if (!is_file)
 		return; // Don't write back if not from a file
 
-	std::ofstream ofile;
+	std::unique_ptr<std::ostream> pOfile;
 	try {
-		U7open(ofile, filename.c_str(), true);
+		pOfile = U7open_out(filename.c_str(), true);
 	} catch (const file_open_exception &) {
 		perror("Failed to write configuration file");
 		return;
 	}
+	auto& ofile = *pOfile;
 	if (ofile.fail()) {
 		perror("Failed to write configuration file");
 	}
 	ofile << dump() << endl;
-	ofile.close();
 }
 
 

--- a/exult.cc
+++ b/exult.cc
@@ -74,6 +74,8 @@
 #include "keys.h"
 #include "mouse.h"
 #include "ucmachine.h"
+#include "sdlrwopsistream.h"
+#include "sdlrwopsostream.h"
 #include "utils.h"
 #include "version.h"
 #include "u7drag.h"
@@ -267,6 +269,21 @@ int main(
 	bool    showversion = false;
 	int     result;
 	Args    parameters;
+
+	// Use SDL_RWops for file I/O in the main game engine for better
+	// cross-platform support.  Standalone utilities continue to default
+	// to the default std::fstream-based file I/O to avoid taking an SDL
+	// dependency.
+	U7set_istream_factory(
+		[](const char* s, std::ios_base::openmode mode) {
+			return std::make_unique<SdlRwopsIstream>(s, mode);
+		}
+	);
+	U7set_ostream_factory(
+		[](const char* s, std::ios_base::openmode mode) {
+			return std::make_unique<SdlRwopsOstream>(s, mode);
+		}
+	);
 
 	// Declare everything from the commandline that we're interested in.
 	parameters.declare("-h", &needhelp, true);

--- a/files/sdlrwopsistream.cc
+++ b/files/sdlrwopsistream.cc
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2021-2022  The Exult Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#include "sdlrwopsistream.h"
+
+SdlRwopsIstream::SdlRwopsIstream() : std::istream(&m_streambuf)
+{
+}
+
+SdlRwopsIstream::SdlRwopsIstream(const char* s, std::ios_base::openmode mode) : std::istream(&m_streambuf)
+{
+    if (m_streambuf.open(s, mode | std::ios_base::in) == nullptr)
+        setstate(std::ios_base::failbit);
+}
+
+SdlRwopsStreambuf* SdlRwopsIstream::rdbuf() const
+{
+    return const_cast<SdlRwopsStreambuf*>(&m_streambuf);
+}
+
+bool SdlRwopsIstream::is_open() const
+{
+    return m_streambuf.is_open();
+}
+
+void SdlRwopsIstream::open(const char* s, std::ios_base::openmode mode)
+{
+    if (m_streambuf.open(s, mode | std::ios_base::in))
+        clear();
+    else
+        setstate(std::ios_base::failbit);
+}
+
+void
+SdlRwopsIstream::close()
+{
+    if (!m_streambuf.close())
+        setstate(std::ios_base::failbit);
+}

--- a/files/sdlrwopsistream.h
+++ b/files/sdlrwopsistream.h
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (C) 2021-2022  The Exult Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#ifndef SDLRWOPSISTREAM_H_
+#define SDLRWOPSISTREAM_H_
+
+#include "sdlrwopsstreambuf.h"
+#include <istream>
+
+class SdlRwopsIstream
+    : public std::istream
+{
+public:
+    typedef typename traits_type::int_type int_type;
+    typedef typename traits_type::pos_type pos_type;
+    typedef typename traits_type::off_type off_type;
+
+    SdlRwopsIstream();
+    explicit SdlRwopsIstream(const char* s, std::ios_base::openmode mode = std::ios_base::in);
+
+    SdlRwopsStreambuf* rdbuf() const;
+    bool is_open() const;
+    void open(const char* s, std::ios_base::openmode mode = std::ios_base::in);
+    void close();
+
+private:
+    SdlRwopsStreambuf m_streambuf;
+};
+
+#endif //SDLRWOPSISTREAM_H_

--- a/files/sdlrwopsostream.cc
+++ b/files/sdlrwopsostream.cc
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2021-2022  The Exult Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#include "sdlrwopsostream.h"
+
+SdlRwopsOstream::SdlRwopsOstream() : std::ostream(&m_streambuf)
+{
+}
+
+SdlRwopsOstream::SdlRwopsOstream(const char* s, std::ios_base::openmode mode) : std::ostream(&m_streambuf) {
+    if (m_streambuf.open(s, mode | std::ios_base::out) == nullptr)
+        setstate(std::ios_base::failbit);
+}
+
+SdlRwopsStreambuf* SdlRwopsOstream::rdbuf() const
+{
+    return const_cast<SdlRwopsStreambuf*>(&m_streambuf);
+}
+
+bool SdlRwopsOstream::is_open() const
+{
+    return m_streambuf.is_open();
+}
+
+void SdlRwopsOstream::open(const char* s, std::ios_base::openmode mode)
+{
+    if (m_streambuf.open(s, mode | std::ios_base::out))
+        clear();
+    else
+        setstate(std::ios_base::failbit);
+}
+
+void SdlRwopsOstream::close()
+{
+    if (m_streambuf.close() == nullptr)
+        setstate(std::ios_base::failbit);
+}

--- a/files/sdlrwopsostream.h
+++ b/files/sdlrwopsostream.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2021-2022  The Exult Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#ifndef SDLRWOPSOSTREAM_H_
+#define SDLRWOPSOSTREAM_H_
+
+#include "sdlrwopsstreambuf.h"
+#include <ostream>
+
+class SdlRwopsOstream : public std::ostream
+{
+public:
+    typedef typename traits_type::int_type int_type;
+    typedef typename traits_type::pos_type pos_type;
+    typedef typename traits_type::off_type off_type;
+
+    SdlRwopsOstream();
+    explicit SdlRwopsOstream(const char* s, std::ios_base::openmode mode = std::ios_base::out);
+
+    SdlRwopsStreambuf* rdbuf() const;
+    bool is_open() const;
+    void open(const char* s, std::ios_base::openmode mode = std::ios_base::out);
+    void close();
+
+private:
+    SdlRwopsStreambuf m_streambuf;
+};
+
+#endif //SDLRWOPSOSTREAM_H_

--- a/files/sdlrwopsstreambuf.cc
+++ b/files/sdlrwopsstreambuf.cc
@@ -1,0 +1,281 @@
+/*
+ *  Copyright (C) 2021-2022  The Exult Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#include "sdlrwopsstreambuf.h"
+
+#include <SDL.h>
+
+#include <cstring>
+#include <memory>
+
+// Partly derived from libc++'s basic_filebuf
+// https://github.com/llvm-mirror/libcxx/blob/master/include/fstream
+//   Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//   See https://llvm.org/LICENSE.txt for license information.
+//   SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+static constexpr auto NO_OPENMODE = static_cast<std::ios_base::openmode>(0);
+
+SdlRwopsStreambuf::SdlRwopsStreambuf()
+		: m_context(nullptr), m_openMode(NO_OPENMODE),
+		  m_currentMode(NO_OPENMODE) {
+	setg(nullptr, nullptr, nullptr);
+	setp(nullptr, nullptr);
+}
+
+SdlRwopsStreambuf::~SdlRwopsStreambuf() {
+	try {
+		close();
+	} catch (...) {
+	}
+}
+
+bool SdlRwopsStreambuf::is_open() const {
+	return m_context;
+}
+
+SdlRwopsStreambuf*
+		SdlRwopsStreambuf::open(const char* s, std::ios_base::openmode mode) {
+	if (m_context) {
+		return nullptr;
+	}
+
+	const char* mdstr   = nullptr;
+	int         modeval = mode & ~std::ios_base::ate;
+	switch (modeval) {
+	case std::ios_base::out:
+	case std::ios_base::out | std::ios_base::trunc:
+		mdstr = "w";
+		break;
+	case std::ios_base::out | std::ios_base::app:
+	case std::ios_base::app:
+		mdstr = "a";
+		break;
+	case std::ios_base::in:
+		mdstr = "r";
+		break;
+	case std::ios_base::in | std::ios_base::out:
+		mdstr = "r+";
+		break;
+	case std::ios_base::in | std::ios_base::out | std::ios_base::trunc:
+		mdstr = "w+";
+		break;
+	case std::ios_base::in | std::ios_base::out | std::ios_base::app:
+	case std::ios_base::in | std::ios_base::app:
+		mdstr = "a+";
+		break;
+	case std::ios_base::out | std::ios_base::binary:
+	case std::ios_base::out | std::ios_base::trunc | std::ios_base::binary:
+		mdstr = "wb";
+		break;
+	case std::ios_base::out | std::ios_base::app | std::ios_base::binary:
+	case std::ios_base::app | std::ios_base::binary:
+		mdstr = "ab";
+		break;
+	case std::ios_base::in | std::ios_base::binary:
+		mdstr = "rb";
+		break;
+	case std::ios_base::in | std::ios_base::out | std::ios_base::binary:
+		mdstr = "r+b";
+		break;
+	case std::ios_base::in | std::ios_base::out | std::ios_base::trunc
+			| std::ios_base::binary:
+		mdstr = "w+b";
+		break;
+	case std::ios_base::in | std::ios_base::out | std::ios_base::app
+			| std::ios_base::binary:
+	case std::ios_base::in | std::ios_base::app | std::ios_base::binary:
+		mdstr = "a+b";
+		break;
+	default:
+		return nullptr;
+	}
+
+	m_context = SDL_RWFromFile(s, mdstr);
+	if (!m_context) {
+		return nullptr;
+	}
+	m_openMode = mode;
+	if (mode & std::ios_base::ate) {
+		if (SDL_RWseek(m_context, 0, RW_SEEK_END) == -1) {
+			SDL_RWclose(m_context);
+			m_context = nullptr;
+			return nullptr;
+		}
+	}
+	return this;
+}
+
+SdlRwopsStreambuf* SdlRwopsStreambuf::close() {
+	if (!m_context) {
+		return nullptr;
+	}
+
+	std::unique_ptr<SDL_RWops, int (*)(SDL_RWops*)> h(m_context, SDL_RWclose);
+	auto                                            rt = this;
+	if (sync())
+		rt = nullptr;
+	if (SDL_RWclose(h.release()))
+		rt = nullptr;
+	m_context = nullptr;
+	setg(nullptr, nullptr, nullptr);
+	setp(nullptr, nullptr);
+
+	return rt;
+}
+
+typename SdlRwopsStreambuf::int_type SdlRwopsStreambuf::underflow() {
+	if (!m_context)
+		return traits_type::eof();
+
+	bool initial = false;
+	if (!(m_currentMode & std::ios_base::in)) {
+		setp(nullptr, nullptr);
+		setg(m_buffer, m_buffer + sizeof(m_buffer),
+			 m_buffer + sizeof(m_buffer));
+		m_currentMode = std::ios_base::in;
+		initial       = true;
+	}
+
+	char_type buf1;
+	if (gptr() == nullptr)
+		setg(&buf1, &buf1 + 1, &buf1 + 1);
+	const std::size_t unget_sz
+			= initial ? 0 : std::min<std::size_t>((egptr() - eback()) / 2, 4);
+	int_type c = traits_type::eof();
+	if (gptr() == egptr()) {
+		std::memmove(eback(), egptr() - unget_sz, unget_sz * sizeof(char_type));
+		std::size_t nmemb = egptr() - eback() - unget_sz;
+		nmemb             = SDL_RWread(m_context, eback() + unget_sz, 1, nmemb);
+		if (nmemb != 0) {
+			setg(eback(), eback() + unget_sz, eback() + unget_sz + nmemb);
+			c = traits_type::to_int_type(*gptr());
+		}
+	} else
+		c = traits_type::to_int_type(*gptr());
+	if (eback() == &buf1)
+		setg(nullptr, nullptr, nullptr);
+	return c;
+}
+
+typename SdlRwopsStreambuf::int_type SdlRwopsStreambuf::pbackfail(int_type c) {
+	if (m_context && eback() < gptr()) {
+		if (traits_type::eq_int_type(c, traits_type::eof())) {
+			gbump(-1);
+			return traits_type::not_eof(c);
+		}
+		if ((m_openMode & std::ios_base::out)
+			|| traits_type::eq(traits_type::to_char_type(c), gptr()[-1])) {
+			gbump(-1);
+			*gptr() = traits_type::to_char_type(c);
+			return c;
+		}
+	}
+	return traits_type::eof();
+}
+
+typename SdlRwopsStreambuf::int_type SdlRwopsStreambuf::overflow(int_type c) {
+	if (!m_context)
+		return traits_type::eof();
+
+	if (!(m_currentMode & std::ios_base::out)) {
+		setg(nullptr, nullptr, nullptr);
+		setp(nullptr, nullptr);
+		m_currentMode = std::ios_base::out;
+	}
+
+	char_type  buf1;
+	char_type* pb_save  = pbase();
+	char_type* epb_save = epptr();
+	if (!traits_type::eq_int_type(c, traits_type::eof())) {
+		if (pptr() == nullptr)
+			setp(&buf1, &buf1 + 1);
+		*pptr() = traits_type::to_char_type(c);
+		pbump(1);
+	}
+	if (pptr() != pbase()) {
+		std::size_t nmemb = static_cast<std::size_t>(pptr() - pbase());
+		if (SDL_RWwrite(m_context, pbase(), sizeof(char_type), nmemb) != nmemb)
+			return traits_type::eof();
+		setp(pb_save, epb_save);
+	}
+	return traits_type::not_eof(c);
+}
+
+typename SdlRwopsStreambuf::pos_type SdlRwopsStreambuf::seekoff(
+		off_type off, std::ios_base::seekdir dir, std::ios_base::openmode) {
+	int width = 1;
+	if (!m_context || sync())
+		return pos_type(off_type(-1));
+	int whence;
+	switch (dir) {
+	case std::ios_base::beg:
+		whence = RW_SEEK_SET;
+		break;
+	case std::ios_base::cur:
+		whence = RW_SEEK_CUR;
+		break;
+	case std::ios_base::end:
+		whence = RW_SEEK_END;
+		break;
+	default:
+		return pos_type(off_type(-1));
+	}
+	if (SDL_RWseek(m_context, width * off, whence) == -1)
+		return pos_type(off_type(-1));
+	pos_type r = SDL_RWtell(m_context);
+	return r;
+}
+
+typename SdlRwopsStreambuf::pos_type
+		SdlRwopsStreambuf::seekpos(pos_type sp, std::ios_base::openmode) {
+	if (!m_context || sync())
+		return pos_type(off_type(-1));
+	if (SDL_RWseek(m_context, sp, RW_SEEK_SET) == -1)
+		return pos_type(off_type(-1));
+	return sp;
+}
+
+int
+SdlRwopsStreambuf::sync()
+{
+    if (!m_context)
+        return 0;
+
+    if (m_currentMode & std::ios_base::out)
+    {
+        if (pptr() != pbase())
+            if (overflow() == traits_type::eof())
+                return -1;
+        //Would be calling SDL_RWflush() here if it existed.
+        //Consider closing and re-opening the file to simulate a flush.
+        if (SDL_RWOPS_STDFILE == m_context->type) {
+            fflush(m_context->hidden.stdio.fp);
+        }
+    }
+    else if (m_currentMode & std::ios_base::in)
+    {
+        off_type c;
+        c = egptr() - gptr();
+        if (SDL_RWseek(m_context, -c, RW_SEEK_CUR) == -1)
+            return -1;
+        setg(nullptr, nullptr, nullptr);
+        m_currentMode = NO_OPENMODE;
+    }
+    return 0;
+}

--- a/files/sdlrwopsstreambuf.h
+++ b/files/sdlrwopsstreambuf.h
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (C) 2021-2022  The Exult Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#ifndef SDLRWOPSSTREAMBUF_H_
+#define SDLRWOPSSTREAMBUF_H_
+
+#include <streambuf>
+
+// Partly derived from libc++'s basic_filebuf
+// https://github.com/llvm-mirror/libcxx/blob/master/include/fstream
+//   Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//   See https://llvm.org/LICENSE.txt for license information.
+//   SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+class SdlRwopsStreambuf : public std::streambuf {
+public:
+	SdlRwopsStreambuf();
+	virtual ~SdlRwopsStreambuf();
+	bool               is_open() const;
+	SdlRwopsStreambuf* open(const char* s, std::ios_base::openmode mode);
+	SdlRwopsStreambuf* close();
+
+protected:
+	int_type underflow() override;
+	int_type pbackfail(int_type c = traits_type::eof()) override;
+	int_type overflow(int_type c = traits_type::eof()) override;
+	pos_type
+			seekoff(off_type off, std::ios_base::seekdir dir,
+					std::ios_base::openmode which
+					= std::ios_base::in | std::ios_base::out) override;
+	pos_type
+			seekpos(pos_type                sp,
+					std::ios_base::openmode which
+					= std::ios_base::in | std::ios_base::out) override;
+	int     sync() override;
+
+private:
+	char                    m_buffer[8];
+	struct SDL_RWops*       m_context;
+	std::ios_base::openmode m_openMode;
+	std::ios_base::openmode m_currentMode;
+};
+
+#endif    // SDLRWOPSSTREAMBUF_H_

--- a/files/utils.cc
+++ b/files/utils.cc
@@ -67,11 +67,6 @@ static void switch_slashes(string &name);
 static bool base_to_uppercase(string &str, int count);
 
 
-// Wrap a few functions
-inline int stat(const std::string &file_name, struct stat *buf) {
-	return stat(file_name.c_str(), buf);
-}
-
 // Global factories for instantiating file streams
 static U7IstreamFactory istream_factory = [](const char* s, std::ios_base::openmode mode) {
 	return std::make_unique<std::ifstream>(s, mode);
@@ -380,12 +375,19 @@ void U7remove(
 	DeleteFile(lpszT);
 #else
 
-	struct stat sbuf;
-
 	int uppercasecount = 0;
 	do {
-		bool exists = (stat(name, &sbuf) == 0);
-		if (exists) {
+		std::unique_ptr<std::istream> in;
+		try {
+			if (istream_factory) {
+				in = istream_factory(name.c_str(), std::ios_base::in);
+			} else {
+				in = std::make_unique<std::ifstream>(name.c_str(), std::ios_base::in);
+			}
+		} catch (std::exception &)
+		{}
+		if (in && in->good() && !in->fail()) {
+			in.reset();
 			std::remove(name.c_str());
 		}
 	} while (base_to_uppercase(name, ++uppercasecount));
@@ -429,17 +431,10 @@ std::unique_ptr<std::istream> U7open_static(
 bool U7exists(
     const char *fname         // May be converted to upper-case.
 ) {
-	string name = get_system_path(fname);
-	struct stat sbuf;
-
-	int uppercasecount = 0;
-	do {
-		bool exists = (stat(name, &sbuf) == 0);
-		if (exists)
-			return true; // found it!
-	} while (base_to_uppercase(name, ++uppercasecount));
-
-	// file not found
+	try {
+	    return U7open_in(fname) != nullptr;
+	} catch (std::exception &)
+	{}
 	return false;
 }
 

--- a/files/utils.h
+++ b/files/utils.h
@@ -22,11 +22,13 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include <functional>
 #include <iostream>
 #include <string>
 #include <cstring>
 #include <iosfwd>
 #include <limits>
+#include <memory>
 #include <dirent.h>
 
 #include "common_types.h"
@@ -401,19 +403,24 @@ inline size_t get_file_size(std::istream& in) {
 	return len;
 }
 
-bool U7open(
-    std::ifstream &in,          // Input stream to open.
-    const char *fname,          // May be converted to upper-case.
-    bool is_text = false            // Should the file be opened in text mode
-);
-bool U7open(
-    std::ofstream &out,         // Output stream to open.
+// Sets factories for creating istreams/ostreams.  Intended to be called once during initialization before using
+// any U7open...() calls and is not guaranteed to be thread-safe.
+using U7IstreamFactory = std::function<std::unique_ptr<std::istream>(const char* s, std::ios_base::openmode mode)>;
+using U7OstreamFactory = std::function<std::unique_ptr<std::ostream>(const char* s, std::ios_base::openmode mode)>;
+void U7set_istream_factory(U7IstreamFactory factory);
+void U7set_ostream_factory(U7OstreamFactory factory);
+
+std::unique_ptr<std::istream> U7open_in(
     const char *fname,          // May be converted to upper-case.
     bool is_text = false            // Should the file be opened in text mode
 );
 
-bool U7open_static(
-    std::ifstream &in,      // Input stream to open.
+std::unique_ptr<std::ostream> U7open_out(
+    const char *fname,          // May be converted to upper-case.
+    bool is_text = false            // Should the file be opened in text mode
+);
+
+std::unique_ptr<std::istream> U7open_static(
     const char *fname,      // May be converted to upper-case.
     bool is_text            // Should file be opened in text mode
 );

--- a/gamemap.cc
+++ b/gamemap.cc
@@ -76,7 +76,7 @@ using std::vector;
 using std::pair;
 
 vector<Chunk_terrain *> *Game_map::chunk_terrains = nullptr;
-std::ifstream *Game_map::chunks = nullptr;
+std::unique_ptr<std::istream> Game_map::chunks;
 bool Game_map::v2_chunks = false;
 bool Game_map::read_all_terrain = false;
 bool Game_map::chunk_terrains_modified = false;
@@ -141,7 +141,6 @@ Game_map::Game_map(
 Game_map::~Game_map(
 ) {
 	clear();            // Delete all objects, chunks.
-	delete chunks;
 }
 
 /*
@@ -150,25 +149,25 @@ Game_map::~Game_map(
 
 void Game_map::init_chunks(
 ) {
-	delete chunks;
-	chunks = new ifstream;
 	int num_chunk_terrains;
 	bool patch_exists = is_system_path_defined("<PATCH>");
 	if (patch_exists && U7exists(PATCH_U7CHUNKS))
-		U7open(*chunks, PATCH_U7CHUNKS);
+		chunks = U7open_in(PATCH_U7CHUNKS);
 	else try {
-			U7open(*chunks, U7CHUNKS);
+			chunks = U7open_in(U7CHUNKS);
 		} catch (const file_exception &) {
 			if (!Game::is_editing() ||  // Ok if map-editing.
 			        !patch_exists)  // But only if patch exists.
 				throw;
-			ofstream ochunks;   // Create one in 'patch'.
-			U7open(ochunks, PATCH_U7CHUNKS);
+			auto pOchunks = U7open_out(PATCH_U7CHUNKS);   // Create one in 'patch'.
+			if (!pOchunks)
+				throw file_write_exception(PATCH_U7CHUNKS);
+			auto& ochunks = *pOchunks;
 			ochunks.write(v2hdr, sizeof(v2hdr));
 			unsigned char buf[16 * 16 * 3]{};
 			ochunks.write(reinterpret_cast<char *>(buf), sizeof(buf));
-			ochunks.close();
-			U7open(*chunks, PATCH_U7CHUNKS);
+			pOchunks.reset();
+			chunks = U7open_in(PATCH_U7CHUNKS);
 		}
 	char v2buf[V2_CHUNK_HDR_SIZE];  // Check for V2.
 	chunks->read(v2buf, sizeof(v2buf));
@@ -201,19 +200,22 @@ void Game_map::init(
 	if (num == 0)
 		init_chunks();
 	map_modified = false;
-	std::ifstream u7map;        // Read in map.
+	std::unique_ptr<std::istream> pU7map;        // Read in map.
 	bool nomap = false;
 	if (is_system_path_defined("<PATCH>") &&
 	        U7exists(get_mapped_name(PATCH_U7MAP, fname)))
-		U7open(u7map, fname);
+		pU7map = U7open_in(fname);
 	else try {
-			U7open(u7map, get_mapped_name(U7MAP, fname));
+			pU7map = U7open_in(get_mapped_name(U7MAP, fname));
 		} catch (const file_exception & /*f*/) {
 			if (!Game::is_editing())    // Ok if map-editing.
 				cerr << "Map file '" << fname << "' not found." <<
 				     endl;
 			nomap = true;
 		}
+	if (!pU7map)
+		nomap = true;
+	auto& u7map = *pU7map;
 	for (int schunk = 0; schunk < c_num_schunks * c_num_schunks; schunk++) {
 		// Read in the chunk #'s.
 		unsigned char buf[16 * 16 * 2];
@@ -229,7 +231,6 @@ void Game_map::init(
 			for (int cx = 0; cx < 16; cx++)
 				terrain_map[scx + cx][scy + cy] = Read2(mapdata);
 	}
-	u7map.close();
 	// Clear object lists, flags.
 	for (auto& row : objects) {
 		for (auto& obj : row) {
@@ -257,8 +258,7 @@ void Game_map::clear_chunks(
 		delete chunk_terrains;
 		chunk_terrains = nullptr;
 	}
-	delete chunks;          // Close 'u7chunks'.
-	chunks = nullptr;
+	chunks.reset();		 // Close 'u7chunks'.
 	read_all_terrain = false;
 }
 
@@ -443,9 +443,12 @@ void Game_map::write_chunk_terrains(
 			break;
 	if (i < cnt) {          // Got to update.
 		get_all_terrain();  // IMPORTANT:  Get all in memory.
-		ofstream ochunks;   // Open file for chunks data.
+		// Open file for chunks data.
 		// This truncates the file.
-		U7open(ochunks, PATCH_U7CHUNKS);
+		auto pOchunks = U7open_out(PATCH_U7CHUNKS);
+		if (!pOchunks) 
+			throw file_write_exception(U7CHUNKS);
+		auto& ochunks = *pOchunks;
 		v2_chunks = New_shapes();
 		int nbytes = v2_chunks ? 3 : 2;
 		if (v2_chunks)
@@ -466,7 +469,6 @@ void Game_map::write_chunk_terrains(
 		}
 		if (!ochunks.good())
 			throw file_write_exception(U7CHUNKS);
-		ochunks.close();
 	}
 	chunk_terrains_modified = false;
 }
@@ -489,8 +491,11 @@ void Game_map::write_static(
 			write_ifix_objects(schunk);
 	if (chunk_terrains_modified)
 		write_chunk_terrains();
-	std::ofstream u7map;        // Write out map.
-	U7open(u7map, get_mapped_name(PATCH_U7MAP, fname));
+	// Write out map.
+	auto pU7map = U7open_out(get_mapped_name(PATCH_U7MAP, fname));
+	if (!pU7map)
+		throw file_write_exception(U7MAP);
+	auto& u7map = *pU7map;
 	for (schunk = 0; schunk < c_num_schunks * c_num_schunks; schunk++) {
 		int scy = 16 * (schunk / 12); // Get abs. chunk coords.
 		int scx = 16 * (schunk % 12);
@@ -504,7 +509,6 @@ void Game_map::write_static(
 	}
 	if (!u7map.good())
 		throw file_write_exception(U7MAP);
-	u7map.close();
 	map_modified = false;
 }
 
@@ -722,9 +726,9 @@ void Game_map::write_ireg(
 		if (schunk_cache[schunk] && schunk_cache_sizes[schunk] >= 0) {
 			// It's loaded in a memory buffer
 			char fname[128];        // Set up name.
-			ofstream ireg_stream;
-			U7open(ireg_stream, get_schunk_file_name(U7IREG, schunk, fname));
-			ireg_stream.write(schunk_cache[schunk], schunk_cache_sizes[schunk]);
+			auto ireg_stream = U7open_out(get_schunk_file_name(U7IREG, schunk, fname));
+			if (ireg_stream)
+				ireg_stream->write(schunk_cache[schunk], schunk_cache_sizes[schunk]);
 		} else if (schunk_read[schunk]) {
 			// It's active
 			write_ireg_objects(schunk);

--- a/gamemap.h
+++ b/gamemap.h
@@ -58,7 +58,7 @@ class Game_map {
 	int num;            // Map #.  Index in gwin->maps.
 	// Flat chunk areas:
 	static std::vector<Chunk_terrain *> *chunk_terrains;
-	static std::ifstream *chunks;   // "u7chunks" file.
+	static std::unique_ptr<std::istream> chunks;   // "u7chunks" file.
 	static bool v2_chunks;      // True if 3 bytes/entry.
 	static bool read_all_terrain;   // True if we've read them all.
 	static bool chunk_terrains_modified;

--- a/gamemgr/bggame.cc
+++ b/gamemgr/bggame.cc
@@ -2022,9 +2022,7 @@ void BG_Game::show_credits() {
 	                     menushapes.extract_shape(0x14)
 	                    );
 	if (credits.run(gwin)) { // Watched through the entire sequence?
-		std::ofstream quotesflg;
-		U7open(quotesflg, "<SAVEGAME>/quotes.flg");
-		quotesflg.close();
+		U7open_out("<SAVEGAME>/quotes.flg");
 	}
 }
 

--- a/gamemgr/sigame.cc
+++ b/gamemgr/sigame.cc
@@ -1255,9 +1255,7 @@ void SI_Game::show_credits() {
 	                     menushapes.extract_shape(0x14)
 	                    );
 	if (credits.run(gwin)) { // Watched through the entire sequence?
-		std::ofstream quotesflg;
-		U7open(quotesflg, "<SAVEGAME>/quotes.flg");
-		quotesflg.close();
+		U7open_out("<SAVEGAME>/quotes.flg");
 	}
 }
 

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -1270,26 +1270,29 @@ bool Game_window::init_gamedat(bool create) {
 			Game::set_new_game();
 			restore_gamedat(INITGAME);
 		}
-		ofstream out;
 		// Editing, and no IDENTITY?
 		if (Game::is_editing() && !U7exists(IDENTITY)) {
-			U7open(out, IDENTITY);
+			auto pOut = U7open_out(IDENTITY);
+			if (!pOut)
+				return false;
+			auto& out = *pOut;
 			out << Game::get_gametitle() << endl;
-			out.close();
 		}
 
 		// log version of exult that was used to start this game
-		U7open(out, GNEWGAMEVER);
-		getVersionInfo(out);
-		out.close();
+		auto out = U7open_out(GNEWGAMEVER);
+		if (out)
+			getVersionInfo(*out);
 	}
 	//++++Maybe just test for IDENTITY+++:
 	else if ((U7exists(U7NBUF_DAT) || !U7exists(NPC_DAT)) &&
 	         !Game::is_editing()) {
 		return false;
 	} else {
-		ifstream identity_file;
-		U7open(identity_file, IDENTITY);
+		auto pIdentity_file = U7open_in(IDENTITY);
+		if (!pIdentity_file)
+		    return false;
+		auto& identity_file = *pIdentity_file;
 		char gamedat_identity[256];
 		identity_file.read(gamedat_identity, 256);
 		char *ptr = gamedat_identity;
@@ -1506,10 +1509,11 @@ void Game_window::reload_usecode(
 ) {
 	// Get custom usecode functions.
 	if (is_system_path_defined("<PATCH>") && U7exists(PATCH_USECODE)) {
-		ifstream file;
-		U7open(file, PATCH_USECODE);
+		auto pFile = U7open_in(PATCH_USECODE);
+		if (!pFile)
+			return;
+		auto& file = *pFile;
 		usecode->read_usecode(file, true);
-		file.close();
 	}
 }
 

--- a/keys.cc
+++ b/keys.cc
@@ -771,9 +771,10 @@ void KeyBinder::ParseLine(char *line) {
 }
 
 void KeyBinder::LoadFromFileInternal(const char *filename) {
-	ifstream keyfile;
-
-	U7open(keyfile, filename, true);
+	auto pKeyfile = U7open_in(filename, true);
+	if (!pKeyfile)
+		return;
+	auto& keyfile = *pKeyfile;
 	char temp[1024]; // 1024 should be long enough
 	while (!keyfile.eof()) {
 		keyfile.getline(temp, 1024);
@@ -784,7 +785,6 @@ void KeyBinder::LoadFromFileInternal(const char *filename) {
 		}
 		ParseLine(temp);
 	}
-	keyfile.close();
 }
 
 void KeyBinder::LoadFromFile(const char *filename) {

--- a/mapedit/shapefile.h
+++ b/mapedit/shapefile.h
@@ -27,7 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "ignore_unused_variable_warning.h"
 
-#include <fstream>
+#include <istream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -82,7 +82,7 @@ public:
 	// Call for main browser.
 	virtual Object_browser *get_browser(Shape_file_info *vgafile,
 	                                    unsigned char *palbuf);
-	virtual std::ifstream *get_file() {
+	virtual std::istream *get_file() {
 		return nullptr;
 	}
 	virtual Flex *get_flex() {
@@ -124,16 +124,16 @@ public:
  *  Chunks file:
  */
 class Chunks_file_info : public Shape_file_info {
-	std::ifstream *file;        // For 'chunks'; ifile is nullptr.
+	std::unique_ptr<std::istream> file;        // For 'chunks'; ifile is nullptr.
 public:
 	// We will own file.
 	Chunks_file_info(const char *bnm, const char *pnm,
-	                 std::ifstream *f, Shape_group_file *g)
-		: Shape_file_info(bnm, pnm, g), file(f)
+	                 std::unique_ptr<std::istream> f, Shape_group_file *g)
+		: Shape_file_info(bnm, pnm, g), file(std::move(f))
 	{  }
 	~Chunks_file_info() override;
-	std::ifstream *get_file() override {
-		return file;
+	std::istream *get_file() override {
+		return file.get();
 	}
 	Object_browser *create_browser(Shape_file_info *vgafile,
 	                               unsigned char *palbuf,

--- a/mapedit/ucbrowse.cc
+++ b/mapedit/ucbrowse.cc
@@ -312,8 +312,12 @@ void Usecode_browser::setup_list(
 ) {
 	ExultStudio *studio = ExultStudio::get_instance();
 	const char *ucfile = studio->get_text_entry("usecodes_file");
-	ifstream in;
-	U7open(in, ucfile);
+	auto pIn = U7open_in(ucfile);
+	if (!pIn) {
+		EStudio::Alert("Error opening '%s'.", ucfile);
+		return;
+	}
+	auto& in = *pIn;
 	Usecode_symbol_table symtbl;
 	if (!in.good()) {
 		EStudio::Alert("Error reading '%s'.", ucfile);

--- a/shapes/items.cc
+++ b/shapes/items.cc
@@ -308,14 +308,11 @@ void Setup_text(bool si, bool expansion, bool sibeta) {
 	bool is_patch = is_system_path_defined("<PATCH>");
 	// Always read from exultmsg.txt
 	// TODO: allow multilingual exultmsg.txt files.
-	istream *exultmsg;
+	std::unique_ptr<istream> exultmsg;
 	if (is_patch && U7exists(PATCH_EXULTMSG)) {
-		auto *exultmsgfile = new ifstream();
-		exultmsg = exultmsgfile;
-		U7open(*exultmsgfile, PATCH_EXULTMSG, true);
+		exultmsg = U7open_in(PATCH_EXULTMSG, true);
 	} else {
-		auto *exultmsgbuf = new stringstream();
-		exultmsg = exultmsgbuf;
+		auto exultmsgbuf = std::make_unique<stringstream>();
 		const char *msgs = BUNDLE_CHECK(BUNDLE_EXULT_FLX, EXULT_FLX);
 		U7object txtobj(msgs, EXULT_FLX_EXULTMSG_TXT);
 		size_t len;
@@ -323,26 +320,33 @@ void Setup_text(bool si, bool expansion, bool sibeta) {
 		if (txt && len > 0) {
 			exultmsgbuf->str(string(reinterpret_cast<char*>(txt.get()), len));
 		}
+		exultmsg = std::move(exultmsgbuf);
 	}
 
 	// Exult new-style messages?
 	if (is_patch && U7exists(PATCH_TEXTMSGS)) {
-		ifstream txtfile;
-		U7open(txtfile, PATCH_TEXTMSGS, true);
+		auto pTxtfile = U7open_in(PATCH_TEXTMSGS, true);
+		if (!pTxtfile)
+			return;
+		auto& txtfile = *pTxtfile;
 		Setup_text(txtfile, *exultmsg);
 	} else if (U7exists(TEXTMSGS)) {
-		ifstream txtfile;
-		U7open(txtfile, TEXTMSGS, true);
+		auto pTxtfile = U7open_in(TEXTMSGS, true);
+		if (!pTxtfile)
+			return;
+		auto& txtfile = *pTxtfile;
 		Setup_text(txtfile, *exultmsg);
 	} else {
-		ifstream textflx;
+		std::unique_ptr<istream> pTextflx;
 		if (is_patch && U7exists(PATCH_TEXT))
-			U7open(textflx, PATCH_TEXT);
+			pTextflx = U7open_in(PATCH_TEXT);
 		else
-			U7open(textflx, TEXT_FLX);
+			pTextflx = U7open_in(TEXT_FLX);
+		if (!pTextflx)
+			return;
+		auto& textflx = *pTextflx;
 		Setup_item_names(textflx, *exultmsg, si, expansion, sibeta);
 	}
-	delete exultmsg;
 }
 
 /*
@@ -368,13 +372,13 @@ void Free_text(
 
 void Write_text_file(
 ) {
-	ofstream out;
-
-	U7open(out, PATCH_TEXTMSGS, true);  // (It's a text file.)
+	auto pOut = U7open_out(PATCH_TEXTMSGS, true);  // (It's a text file.)
+	if (!pOut)
+		return;
+	auto& out = *pOut;
 	out << "Exult " << VERSION << " text message file." <<
 	    "  Written by ExultStudio." << endl;
 	Write_msg_file_section(out, SHAPES_SECT, item_names);
 	Write_msg_file_section(out, MSGS_SECT, text_msgs);
 	Write_msg_file_section(out, MISC_SECT, misc_names);
-	out.close();
 }

--- a/shapes/miscinf.cc
+++ b/shapes/miscinf.cc
@@ -385,11 +385,12 @@ void Shapeinfo_lookup::Read_data_file(
 	} else {
 		try {
 			snprintf(buf, 50, "<STATIC>/%s.txt", fname);
-			ifstream in;
-			U7open(in, buf, false);
+			auto pIn = U7open_in(buf, false);
+			if (!pIn)
+				throw file_open_exception(buf);
+			auto& in = *pIn;
 			static_version = Read_text_msg_file_sections(in,
 			                 static_strings, sections, numsections);
-			in.close();
 		} catch (std::exception const&) {
 			if (!Game::is_editing()) {
 				throw;
@@ -400,11 +401,12 @@ void Shapeinfo_lookup::Read_data_file(
 	patch_strings.resize(numsections);
 	snprintf(buf, 50, "<PATCH>/%s.txt", fname);
 	if (U7exists(buf)) {
-		ifstream in;
-		U7open(in, buf, false);
+		auto pIn = U7open_in(buf, false);
+		if (!pIn)
+			throw file_open_exception(buf);
+		auto& in = *pIn;
 		patch_version = Read_text_msg_file_sections(in, patch_strings,
 		                sections, numsections);
-		in.close();
 	}
 
 	for (size_t i = 0; i < static_strings.size(); i++) {

--- a/shapes/shapewrite.cc
+++ b/shapes/shapewrite.cc
@@ -252,30 +252,38 @@ void Shapes_vga_file::write_info(
 
 	// ShapeDims
 	// Starts at 0x96'th shape.
-	ofstream shpdims;
-	U7open(shpdims, PATCH_SHPDIMS);
+	auto pShpdims = U7open_out(PATCH_SHPDIMS);
+	if (!pShpdims)
+		return;
+	auto& shpdims = *pShpdims;
 	for (size_t i = c_first_obj_shape; i < num_shapes; i++) {
 		shpdims.put(info[i].shpdims[0]);
 		shpdims.put(info[i].shpdims[1]);
 	}
 
 	// WGTVOL
-	ofstream wgtvol;
-	U7open(wgtvol, PATCH_WGTVOL);
+	auto pWgtvol = U7open_out(PATCH_WGTVOL);
+	if (!pWgtvol)
+		return;
+	auto& wgtvol = *pWgtvol;
 	for (size_t i = 0; i < num_shapes; i++) {
 		wgtvol.put(info[i].weight);
 		wgtvol.put(info[i].volume);
 	}
 
 	// TFA
-	ofstream tfa;
-	U7open(tfa, PATCH_TFA);
+	auto pTfa = U7open_out(PATCH_TFA);
+	if (!pTfa)
+		return;
+	auto& tfa = *pTfa;
 	for (size_t i = 0; i < num_shapes; i++)
 		tfa.write(reinterpret_cast<char *>(&info[i].tfa[0]), 3);
 
 	// Write data about drawing the weapon in an actor's hand
-	ofstream wihh;
-	U7open(wihh, PATCH_WIHH);
+	auto pWihh = U7open_out(PATCH_WIHH);
+	if (!pWihh)
+		return;
+	auto& wihh = *pWihh;
 	size_t cnt = 0;            // Keep track of actual entries.
 	for (size_t i = 0; i < num_shapes; i++)
 		if (info[i].weapon_offsets == nullptr)
@@ -286,10 +294,12 @@ void Shapes_vga_file::write_info(
 		if (info[i].weapon_offsets)
 			// There are two bytes per frame: 64 total
 			wihh.write(reinterpret_cast<char *>(info[i].weapon_offsets), 64);
-	wihh.close();
 
-	ofstream occ;          // Write occlude.dat.
-	U7open(occ, PATCH_OCCLUDE);
+	// Write occlude.dat.
+	auto pOcc = U7open_out(PATCH_OCCLUDE);
+	if (!pOcc)
+		return;
+	auto& occ = *pOcc;
 	unsigned char occbits[c_occsize];   // c_max_shapes bit flags.
 	// +++++This could be rewritten better!
 	memset(&occbits[0], 0, sizeof(occbits));
@@ -305,8 +315,11 @@ void Shapes_vga_file::write_info(
 	}
 	occ.write(reinterpret_cast<char *>(occbits), sizeof(occbits));
 
-	ofstream mfile;         // Now get monster info.
-	U7open(mfile, PATCH_EQUIP); // Write 'equip.dat'.
+	// Now get monster info.
+	auto pMfile = U7open_out(PATCH_EQUIP); // Write 'equip.dat'.
+	if (!pMfile)
+		return;
+	auto& mfile = *pMfile;
 	cnt = Monster_info::get_equip_cnt();
 	Write_count(mfile, cnt);    // Exult extension.
 	for (size_t i = 0; i < cnt; i++) {
@@ -320,7 +333,6 @@ void Shapes_vga_file::write_info(
 			Write2(mfile, 0);
 		}
 	}
-	mfile.close();
 
 	Functor_multidata_writer < Shape_info,
 	                         Class_writer_functor < Armor_info, Shape_info,

--- a/tools/ipack.cc
+++ b/tools/ipack.cc
@@ -803,19 +803,23 @@ int main(
 	char *imagename = nullptr;
 	char *palname = nullptr;
 	Shape_specs specs;      // Shape specs. stored here.
-	ifstream specin;
+	std::unique_ptr<std::istream> pSpecin;
 	try {
-		U7open(specin, scriptname, true);
+		pSpecin = U7open_in(scriptname, true);
 	} catch (exult_exception &e) {
 		cerr << e.what() << endl;
 		exit(1);
 	}
+	if (!pSpecin) {
+		cerr << "Failed to open " << scriptname << endl;
+		exit(1);
+	}
+	auto& specin = *pSpecin;
 	Read_script(specin, imagename, palname, specs);
 	if (!imagename) {
 		cerr << "No archive name (i.e., 'shapes.vga') given" << endl;
 		exit(1);
 	}
-	specin.close();
 	switch (argv[1][1]) {   // Which function?
 	case 'c':           // Create.
 		try {

--- a/tools/textpack.cc
+++ b/tools/textpack.cc
@@ -142,13 +142,18 @@ int main(
 	switch (argv[1][1]) {   // Which function?
 	case 'c':           // Create Flex.
 		if (argc >= 4) {    // Text filename given?
-			ifstream in;    // Open as text.
+			std::unique_ptr<std::istream> pIn;    // Open as text.
 			try {
-				U7open(in, argv[3], true);
+				pIn = U7open_in(argv[3], true);
 			} catch (exult_exception &e) {
 				cerr << e.what() << endl;
 				exit(1);
 			}
+			if (!pIn) {
+				cerr << "Failed to open " << argv[3] << endl;
+				exit(1);
+			}
+			auto& in = *pIn;
 			if (Read_text_msg_file(in, strings) == -1)
 				exit(1);
 		} else          // Default to stdin.
@@ -169,13 +174,18 @@ int main(
 			exit(1);
 		}
 		if (argc >= 4) {    // Text file given?
-			ofstream out;
+			std::unique_ptr<std::ostream> pOut;
 			try {
-				U7open(out, argv[3],  true);
+				pOut = U7open_out(argv[3],  true);
 			} catch (exult_exception &e) {
 				cerr << e.what() << endl;
 				exit(1);
 			}
+			if (!pOut) {
+				cerr << "Failed to open " << argv[3] << endl;
+				exit(1);
+			}
+			auto& out = *pOut;
 			Write_text(out, strings);
 		} else
 			Write_text(cout, strings);

--- a/tools/u7voice2syx.cc
+++ b/tools/u7voice2syx.cc
@@ -282,8 +282,11 @@ int main(int argc, char *argv[]) {
 				throw exult_exception("File size didn't match timbre count. Wont convert.");
 
 			std::cout << "Opening " << outname << " for writing..." << std::endl;
-			std::ofstream sysex_file;
-			U7open(sysex_file, outname, false);
+			auto pSysex_file = U7open_out(outname, false);
+			if (!pSysex_file) {
+				throw exult_exception(std::string("Failed to open ") + outname);
+			}
+			auto& sysex_file = *pSysex_file;
 
 			//
 			// All Dev Reset
@@ -425,9 +428,6 @@ int main(int argc, char *argv[]) {
 
 			// Write the 'real' Display
 			sysex_file.write(sysex_buffer, num_to_write);
-
-			// Close the file
-			sysex_file.close();
 
 		} catch (exult_exception &e) {
 			std::cerr << "Something went wrong: " << e.what() << std::endl;

--- a/usecode/intrinsics.cc
+++ b/usecode/intrinsics.cc
@@ -2344,9 +2344,7 @@ USECODE_INTRINSIC(run_endgame) {
 	game->end_game(parms[0].get_int_value() != 0);
 	// If successful enable menu entry and play credits afterwards
 	if (parms[0].get_int_value() != 0) {
-		std::ofstream endgameflg;
-		U7open(endgameflg, "<SAVEGAME>/endgame.flg");
-		endgameflg.close();
+		U7open_out("<SAVEGAME>/endgame.flg");
 		game->show_credits();
 	}
 	quitting_time = QUIT_TIME_YES;

--- a/usecode/keyring.cc
+++ b/usecode/keyring.cc
@@ -31,36 +31,36 @@ using std::ifstream;
 using std::ofstream;
 
 void Keyring::read() {
-	ifstream in;
+	std::unique_ptr<std::istream> pIn;
 
 	// clear keyring first
 	keys.clear();
 
 	try {
-		U7open(in, KEYRINGDAT);
+		pIn = U7open_in(KEYRINGDAT);
 	} catch (exult_exception &/*e*/) {
 		// maybe an old savegame, just leave the keyring empty
 		return;
 	}
+	if (!pIn)
+		return;
+	auto& in = *pIn;
 
 	do {
 		int val = Read2(in);
 		if (in.good())
 			addkey(val);
 	} while (in.good());
-
-	in.close();
 }
 
 void Keyring::write() {
-	ofstream out;
-
-	U7open(out, KEYRINGDAT);
+	auto pOut = U7open_out(KEYRINGDAT);
+	if (!pOut)
+		throw file_open_exception(KEYRINGDAT);
+	auto& out = *pOut;
 
 	for (int key : keys)
 		Write2(out, key);
-
-	out.close();
 }
 
 void Keyring::clear() {

--- a/usecode/ucxt/include/ucdata.h
+++ b/usecode/ucxt/include/ucdata.h
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <fstream>
 #include <iostream>
+#include <memory>
 
 #include "ucfunc.h"
 
@@ -54,6 +55,7 @@ public:
 	}
 
 	bool fail() const {
+		auto& _file = *_pFile;
 		return _file.fail();
 	}
 
@@ -71,13 +73,15 @@ private:
 
 	void file_open(const std::string &filename);
 	void file_seek_start() {
+		auto& _file = *_pFile;
 		_file.seekg(0, std::ios::beg);
 	}
 	void file_seek_end() {
+		auto& _file = *_pFile;
 		_file.seekg(0, std::ios::end);
 	}
 
-	std::ifstream _file;
+	std::unique_ptr<std::istream> _pFile;
 
 	std::string _output_redirect;
 	std::string _input_usecode_file;

--- a/usecode/ucxt/include/ucfunc.h
+++ b/usecode/ucxt/include/ucfunc.h
@@ -288,9 +288,9 @@ public:
 	static std::map<unsigned int, std::string> FlagMap;
 };
 
-void readbin_U7UCFunc(std::ifstream &f, UCFunc &ucf, const UCOptions &options,
+void readbin_U7UCFunc(std::istream &f, UCFunc &ucf, const UCOptions &options,
                       Usecode_symbol_table *symtbl);
-void readbin_U8UCFunc(std::ifstream &f, UCFunc &ucf);
+void readbin_U8UCFunc(std::istream &f, UCFunc &ucf);
 
 std::ostream &tab_indent(const unsigned int indent, std::ostream &o);
 #endif

--- a/usecode/ucxt/src/ucfunc.cc
+++ b/usecode/ucxt/src/ucfunc.cc
@@ -1131,7 +1131,7 @@ string demunge_ocstring(UCFunc &ucf, const FuncMap &funcmap, const string &asmst
 }
 
 void readbin_U7UCFunc(
-    ifstream &f,
+    std::istream &f,
     UCFunc &ucf,
     const UCOptions &options,
     Usecode_symbol_table *symtbl
@@ -1349,7 +1349,7 @@ void readbin_U7UCFunc(
 	}
 }
 
-void readbin_U8UCFunc(ifstream &f, UCFunc &ucf) {
+void readbin_U8UCFunc(std::istream &f, UCFunc &ucf) {
 	ignore_unused_variable_warning(f, ucf);
 }
 

--- a/usecode/ucxt/src/ucxt.cc
+++ b/usecode/ucxt/src/ucxt.cc
@@ -100,10 +100,14 @@ int main(int argc, char **argv) {
 	// done because for some reason it started crashing upon piping or redirection to file... wierd.
 	// yes, it's a hack to fix an eldritch bug I could't find... it seems appropriate
 	// FIXME: Problem nolonger exists. Probably should put some 'nice' code in it's place.
-	std::ofstream outputstream;
 	std::streambuf *coutbuf = nullptr;
 	if (!uc.output_redirect().empty()) {
-		U7open(outputstream, uc.output_redirect().c_str(), false);
+		auto pOutputstream = U7open_out(uc.output_redirect().c_str(), false);
+		if (!pOutputstream) {
+			cout << "error. failed to open " << uc.output_redirect() << " for writing. exiting." << endl;
+			exit(1);
+		}
+		auto& outputstream = *pOutputstream;
 		if (outputstream.fail()) {
 			cout << "error. failed to open " << uc.output_redirect() << " for writing. exiting." << endl;
 			exit(1);


### PR DESCRIPTION
The unzip code is hard-coded to to directly access the filesystem, which ends up bypassing the logic in in U7 file I/O for game folders and handling nonstandard directory structures and filesystems.  This patch modifies the unzip code to use the U7 file I/O abstraction.