### PR TITLE
Fix CLang warnings in Usecode Compiler

### DIFF
--- a/usecode/compiler/uclex.ll
+++ b/usecode/compiler/uclex.ll
@@ -2,7 +2,9 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#if !defined(__llvm__) && !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wredundant-tags"
+#endif
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif  // __GNUC__
@@ -249,7 +251,9 @@ char *Handle_string
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#if !defined(__llvm__) && !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wredundant-tags"
+#endif
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #if !defined(__llvm__) && !defined(__clang__)

--- a/usecode/compiler/ucparse.yy
+++ b/usecode/compiler/ucparse.yy
@@ -101,7 +101,9 @@ struct Member_selector
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wcast-qual"
+#if !defined(__llvm__) && !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wredundant-tags"
+#endif
 #endif  // __GNUC__
 
 %}


### PR DESCRIPTION
  Commit 1 of 1 :
    usecode/compiler/uclex.ll + ucparse.yy
      CLang does not support -Wredundant-tags