### PR TITLE
Fix ogg/vorbis stuttering on Android

### DIFF
--- a/audio/AudioMixer.cc
+++ b/audio/AudioMixer.cc
@@ -85,9 +85,10 @@ id_counter(0), device(nullptr)
 	desired.callback = sdlAudioCallback;
 	desired.userdata = this;
 
-	// Set update rate to 20 Hz, or there abouts. This should be more then adequate for everyone
+	// Set update rate to 5 Hz, or there abouts. This should be more than adequate for everyone
+	// Note: setting this to 1 Hz (/1) causes Exult to hang on MacOS.
 	desired.samples=1;
-	while(desired.samples<=desired.freq/30) desired.samples<<=1;
+	while(desired.samples<=desired.freq/5) desired.samples<<=1;
 
 	// Open SDL Audio (even though we may not need it)
 	SDL_InitSubSystem(SDL_INIT_AUDIO);


### PR DESCRIPTION
The existing 20Hz buffering for ogg/vorbis playback isn't sufficient on android.  It results in stuttering when using digital music on both an emulated android device on a laptop and on two native android devices.  Increasing to 5Hz buffering.

Note: This value was chosen based on empirical testing on a Kindle Fire tablet.  6Hz and above resulted in stuttering with digital music enabled.