### PR TITLE
Fix crash when restarting game on Android

### DIFF
--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -480,6 +480,14 @@ void Image_window::static_init() {
 Image_window::~Image_window() {
 	free_surface();
 	delete ibuf;
+
+	// Clean up the SDL window.  Not particularly important for standalone
+	// executable builds, but on android, if the app remains in memory after
+	// exiting the game and you try to restart the game, the previous run's
+	// window will still be allocated if we don't clean it up here and the
+	// subsequent attempt to call SDL_CreateWindow() will crash.
+	SDL_DestroyWindow(screen_window);
+	screen_window = nullptr;
 }
 
 /*


### PR DESCRIPTION
This probably doesn't matter for standalone executables that fully terminate the process when the game exits, but on Android, the game is loaded as a shared library and it is not reliably unloaded when the game exits.  In cases where the library is kept in memory, a subsequent attempt to start the game will find the previous run's `SDL_Window` still allocated, and if we don't clean it up here, the subsequent attempt to call `SDL_CreateWindow()` will crash.