### PR TITLE
Only match top-level exult in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,7 @@ data/exult_iphone.flx
 data/exult_iphone_flx.h
 data/exult_si.flx
 data/exult_si_flx.h
-exult
+/exult
 files/rwregress
 mapedit/exult_studio
 mapedit/u7shp


### PR DESCRIPTION
The Android app will end up organizing java souces in a directory structure that includes a folder named 'exult'.  The current .gitignore causes any folder named 'exult' to be ignored.  This patch changes to only ignoring files/folders named 'exult' at the top level to avoid interfering with android sources.