### PR TITLE
Add dependencies framework and Ogg dependency

### DIFF
--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -10,4 +10,5 @@ add_subdirectory("dependencies")
 find_library( log-lib log )
 
 target_link_libraries( exult-android-wrapper
-                       ${log-lib} )
+                       ${log-lib}
+                       ogg )

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -5,6 +5,8 @@ add_library( exult-android-wrapper
              SHARED
              exult_android_main.cc )
 
+add_subdirectory("dependencies")
+
 find_library( log-lib log )
 
 target_link_libraries( exult-android-wrapper

--- a/android/app/src/main/cpp/dependencies/CMakeLists.txt
+++ b/android/app/src/main/cpp/dependencies/CMakeLists.txt
@@ -39,3 +39,4 @@ ProcessorCount(NCPU)
 
 # Pull in dependencies
 include(ExternalProject)
+add_subdirectory("ogg")

--- a/android/app/src/main/cpp/dependencies/CMakeLists.txt
+++ b/android/app/src/main/cpp/dependencies/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Common install directory for dependencies.
+set(DEPENDENCIES_INSTALL_DIR "${CMAKE_BINARY_DIR}/dependencies/install")
+
+# Map LLVM triple to the NDK's toolchain prefix triple.
+if(${ANDROID_LLVM_TRIPLE} STREQUAL armv7-none-linux-androideabi${ANDROID_NATIVE_API_LEVEL})
+    set(TRIPLE armv7a-linux-androideabi${ANDROID_NATIVE_API_LEVEL})
+elseif(${ANDROID_LLVM_TRIPLE} STREQUAL aarch64-none-linux-android${ANDROID_NATIVE_API_LEVEL})
+    set(TRIPLE aarch64-linux-android${ANDROID_NATIVE_API_LEVEL})
+elseif(${ANDROID_LLVM_TRIPLE} STREQUAL i686-none-linux-android${ANDROID_NATIVE_API_LEVEL})
+    set(TRIPLE i686-linux-android${ANDROID_NATIVE_API_LEVEL})
+elseif(${ANDROID_LLVM_TRIPLE} STREQUAL x86_64-none-linux-android${ANDROID_NATIVE_API_LEVEL})
+    set(TRIPLE x86_64-linux-android${ANDROID_NATIVE_API_LEVEL})
+else()
+    set(TRIPLE ${ANDROID_LLVM_TRIPLE})
+endif()
+
+# Build up linker flags to find libraries at build and runtime.
+foreach(IMPLICIT_LINK_DIRECTORY ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES})
+  set(LDFLAGS "${LDFLAGS} -L${IMPLICIT_LINK_DIRECTORY} -Wl,-rpath,${IMPLICIT_LINK_DIRECTORY}")
+endforeach()
+
+# Construct a shell script that sets autotools-friendly environment variables for the NDK build.
+set(ENVFILE "${CMAKE_CURRENT_BINARY_DIR}/env.sh")
+file(WRITE ${ENVFILE} "#!/bin/sh\n")
+file(APPEND ${ENVFILE} "export CC=${ANDROID_TOOLCHAIN_ROOT}/bin/${TRIPLE}-clang\n")
+file(APPEND ${ENVFILE} "export CXX=${ANDROID_TOOLCHAIN_ROOT}/bin/${TRIPLE}-clang++\n")
+file(APPEND ${ENVFILE} "export AR=${ANDROID_TOOLCHAIN_ROOT}/bin/llvm-ar\n")
+file(APPEND ${ENVFILE} "export RANLIB=${ANDROID_TOOLCHAIN_ROOT}/bin/llvm-ranlib\n")
+file(APPEND ${ENVFILE} "export PKG_CONFIG_PATH=${DEPENDENCIES_INSTALL_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH\n")
+file(APPEND ${ENVFILE} "export LDFLAGS=\"${ANDROID_LINKER_FLAGS} ${LDFLAGS}\"\n")
+
+string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE)
+file(APPEND ${ENVFILE} "export CFLAGS=\"${CMAKE_C_FLAGS_${BUILD_TYPE}}\"\n")
+file(APPEND ${ENVFILE} "export CXXFLAGS=\"${CMAKE_CXX_FLAGS_${BUILD_TYPE}}\"\n")
+
+# Get the CPU count to use for parallel builds
+include(ProcessorCount)
+ProcessorCount(NCPU)
+
+# Pull in dependencies
+include(ExternalProject)

--- a/android/app/src/main/cpp/dependencies/build_dependency.cmake
+++ b/android/app/src/main/cpp/dependencies/build_dependency.cmake
@@ -1,0 +1,33 @@
+# Construct the CMake script
+configure_file(CMakeLists.txt.in ${CMAKE_CURRENT_BINARY_DIR}/CMakeLists.txt @ONLY)
+
+# Generate
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM} .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+if (result)
+  message(FATAL_ERROR "CMake generate failed for ${DEPENDENCY}: ${result}")
+endif()
+
+# Build
+execute_process(
+  COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+if (result)
+  message(FATAL_ERROR "CMake build failed for ${DEPENDENCY}: ${result}")
+endif()
+
+# Define a target with the headers and library
+add_library(${DEPENDENCY} SHARED IMPORTED GLOBAL)
+set_target_properties(
+  ${DEPENDENCY} PROPERTIES
+  IMPORTED_LOCATION ${DEPENDENCIES_INSTALL_DIR}/lib/lib${DEPENDENCY}.so
+)
+set_target_properties(
+  ${DEPENDENCY} PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${DEPENDENCIES_INSTALL_DIR}/include
+)

--- a/android/app/src/main/cpp/dependencies/ogg/CMakeLists.txt
+++ b/android/app/src/main/cpp/dependencies/ogg/CMakeLists.txt
@@ -1,0 +1,2 @@
+set(DEPENDENCY ogg)
+include(../build_dependency.cmake)

--- a/android/app/src/main/cpp/dependencies/ogg/CMakeLists.txt.in
+++ b/android/app/src/main/cpp/dependencies/ogg/CMakeLists.txt.in
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION @CMAKE_MINIMUM_REQUIRED_VERSION@)
+project(@DEPENDENCY@)
+
+include(ExternalProject)
+
+ExternalProject_Add(
+  @DEPENDENCY@
+  GIT_REPOSITORY    https://github.com/xiph/ogg.git
+  GIT_TAG           v1.3.5
+  INSTALL_DIR       @DEPENDENCIES_INSTALL_DIR@
+  CONFIGURE_COMMAND <SOURCE_DIR>/autogen.sh
+  COMMAND           . @ENVFILE@ && <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --host=@ANDROID_LLVM_TRIPLE@
+  BUILD_COMMAND     make -j@NCPU@
+)


### PR DESCRIPTION
First patch adds the dependency framework, and the second adds the Ogg dependency to show how the framework is used:
- Add cmake scripts to support pulling in and building NDK-level dependency libraries for Exult.
- Download and build the Ogg library with the NDK toolchain.

Other dependencies to follow after these are merged.