### PR TITLE
Use SDL_Joystick API for Android virtual dpad

### DIFF
--- a/android/lib/include/TouchUI_Android.h
+++ b/android/lib/include/TouchUI_Android.h
@@ -45,7 +45,7 @@ private:
 	jmethodID               m_hideGameControlsMethod;
 	jmethodID               m_showButtonControlsMethod;
 	jmethodID               m_hideButtonControlsMethod;
-	SDL_GameController*     m_gameController;
+	SDL_Joystick*           m_joystick;
 	jmethodID               m_promptForNameMethod;
 };
 

--- a/android/lib/src/TouchUI_Android.cc
+++ b/android/lib/src/TouchUI_Android.cc
@@ -55,9 +55,8 @@ TouchUI_Android* TouchUI_Android::getInstance() {
 }
 
 void TouchUI_Android::setVirtualJoystick(Sint16 x, Sint16 y) {
-	auto joystick = SDL_GameControllerGetJoystick(m_gameController);
-	SDL_JoystickSetVirtualAxis(joystick, SDL_CONTROLLER_AXIS_LEFTX, x);
-	SDL_JoystickSetVirtualAxis(joystick, SDL_CONTROLLER_AXIS_LEFTY, y);
+	SDL_JoystickSetVirtualAxis(m_joystick, SDL_CONTROLLER_AXIS_LEFTX, x);
+	SDL_JoystickSetVirtualAxis(m_joystick, SDL_CONTROLLER_AXIS_LEFTY, y);
 }
 
 void TouchUI_Android::sendEscapeKeypress() {
@@ -96,9 +95,9 @@ TouchUI_Android::TouchUI_Android() {
 		std::cerr << "SDL_JoystickAttachVirtual failed: " << SDL_GetError()
 				  << std::endl;
 	} else {
-		m_gameController = SDL_GameControllerOpen(joystickDeviceIndex);
-		if (!m_gameController) {
-			std::cerr << "SDL_GameControllerOpen failed for virtual joystick: "
+		m_joystick = SDL_JoystickOpen(joystickDeviceIndex);
+		if (!m_joystick) {
+			std::cerr << "SDL_JoystickOpen failed for virtual joystick: "
 					  << SDL_GetError() << std::endl;
 			SDL_JoystickDetachVirtual(joystickDeviceIndex);
 		}
@@ -106,16 +105,13 @@ TouchUI_Android::TouchUI_Android() {
 }
 
 TouchUI_Android::~TouchUI_Android() {
-	if (m_gameController) {
-		if (m_gameController) {
-			const SDL_JoystickID joystickId = SDL_JoystickInstanceID(
-					SDL_GameControllerGetJoystick(m_gameController));
-			SDL_GameControllerClose(m_gameController);
-			for (int i = 0, n = SDL_NumJoysticks(); i < n; ++i) {
-				if (SDL_JoystickGetDeviceInstanceID(i) == joystickId) {
-					SDL_JoystickDetachVirtual(i);
-					break;
-				}
+	if (m_joystick) {
+		const auto joystickId = SDL_JoystickInstanceID(m_joystick);
+		SDL_JoystickClose(m_joystick);
+		for (int i = 0, n = SDL_NumJoysticks(); i < n; ++i) {
+			if (SDL_JoystickGetDeviceInstanceID(i) == joystickId) {
+				SDL_JoystickDetachVirtual(i);
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
The current code for the Android dpad creates a virtual joystick with `SDL_JoystickAttachVirtual()` and then opens it with `SDL_GameControllerOpen()` for all subsequent interaction.  In practice, it only gets used as a joystick and does not have a hat or buttons, so it is more efficient to open it with `SDL_JoystickOpen()`.  In addition, [this commit](https://github.com/libsdl-org/SDL/commit/1a17ab30e17f22c390caa1403f32dfac03532dff#diff-da9344d94c66b8c702a45e7649f412039f08bba83bd82de33f5c80ea9c8c39d5R488-R491) introduces code that causes `SDL_GameControllerOpen()` to fail for virtual joysticks, but `SDL_JoystickOpen()` continues to work fine.  SDL will have a fix for [this issue](https://github.com/libsdl-org/SDL/issues/5662) in v2.0.24, but in the mean time, `SDL_JoystickOpen()` is the only option for v2.0.22, and is more efficient in any case.