### PR TITLE
Document VideoModeOK() return value

### DIFF
--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -174,6 +174,8 @@ protected:
 	struct SDL_Window *screen_window;
 	struct SDL_Renderer *screen_renderer;
 	struct SDL_Texture *screen_texture;
+        // Returns 0 on failure, else highest bpp for resolution
+        // TODO: bpp and flags are currently ignored; fix or remove
 	static int VideoModeOK(int width, int height, int bpp, Uint32 flags);
 	void UpdateRect(SDL_Surface *surf, int x, int y, int w, int h);
 


### PR DESCRIPTION
There was no documentation for the `VideoModeOK()` method, and some of the calling code appears to be using it incorrectly.  This patch simply adds some documentation for the return value of the function.