### PR TITLE
Use exit() to terminate NDK code

### DIFF
--- a/android/app/src/main/cpp/exult_android_main.cc
+++ b/android/app/src/main/cpp/exult_android_main.cc
@@ -36,5 +36,7 @@ ExultAndroid_main(int argc, char* argv[]) {
 	std::cout.rdbuf(ndk_cout);
 	std::cerr.rdbuf(ndk_cerr);
 
-	return 0;
+	// note: `exit(0)` rather than `return 0` to ensure proper cleanup of resources
+	//	 between runs.
+	exit(0);
 }


### PR DESCRIPTION
Simply returning from the NDK entrypoint function does not clean up global resources since the process has not terminated, which can cause problems with Exult as it assumes the entire engine terminates upon return from `main()`.  Calling `exit()` ensures full cleanup so that the Android version behaves more like a standard process exiting.  The need for this surfaced when debugging problems with enabling scalers on Android.  They work the first time the app launches, but fail on subsequent runs.  With this patch applied, scalers work consistently on every run.  This patch is a workaround which is technically masking real bugs with proper resource cleanup in the code, but as the entire Exult codebase is written to assume complete cleanup upon return from main, there may be many small problems to chase down and it seems safer to use `exit()` to ensure consistent behavior.