### PR TITLE
Exult silent clang sdl fix

### DIFF
--- a/audio/midi_drivers/timidity/timidity.cpp
+++ b/audio/midi_drivers/timidity/timidity.cpp
@@ -90,8 +90,11 @@ static int read_config_file(const char *name)
 		w.clear();
 		w.push_back(strtok(tmp, " \t\r\n\240"));
 		if (!w[0] || (*w[0]=='#')) continue;
-		while (w.back() && w.size() < MAXWORDS)
-			w.push_back(strtok(nullptr," \t\r\n\240"));
+		while (w.size() < MAXWORDS) {
+			char *token = strtok(nullptr," \t\r\n\240");
+			if (token && token[0] != '#') w.push_back(token);
+			else break;
+		}
 		if (!strcmp(w[0], "dir"))
 		{
 			if (w.size() < 2)
@@ -335,7 +338,10 @@ int Timidity_Init_Simple(int rate, int samples, sint32 encoding)
 	/* see if the pentagram config file specifies an alternate timidity.cfg */
 	config->value("config/audio/midi/timiditycfg", configfile, CONFIG_FILE);
 
-	if (read_config_file(configfile.c_str())<0) {
+	if (( read_config_file(configfile.c_str()) < 0) &&
+	    ((!is_system_path_defined("<BUNDLE>")) ||
+	     (read_config_file(get_system_path("<BUNDLE>/" CONFIG_FILE).c_str()) < 0)) &&
+	    ( read_config_file(get_system_path("<DATA>/"   CONFIG_FILE).c_str()) < 0) ) {
 		return -1;
 	}
 

--- a/audio/midi_drivers/timidity/timidity.h
+++ b/audio/midi_drivers/timidity/timidity.h
@@ -176,7 +176,7 @@ extern void Timidity_GenerateSamples(void *stream, int samples);
 #include <machine/endian.h>
 #endif
 
-#ifdef linux
+#ifdef __linux__
 /*
  * Byte order is defined in <bytesex.h> as __BYTE_ORDER, that need to
  * be checked against __LITTLE_ENDIAN and __BIG_ENDIAN defined in <endian.h>
@@ -193,7 +193,7 @@ extern void Timidity_GenerateSamples(void *stream, int samples);
 # else
 # error No byte sex defined
 # endif
-#endif /* linux */
+#endif /* __linux__ */
 
 /* Win32 on Intel machines */
 #ifdef __WIN32__

--- a/gumps/Gamemenu_gump.cc
+++ b/gumps/Gamemenu_gump.cc
@@ -26,8 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif    // __GNUC__
 #include "SDL_events.h"
 #ifdef __GNUC__
-#	pragma GCC diagnostic push
-#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic pop
 #endif    // __GNUC__
 
 #include "Gamemenu_gump.h"

--- a/shapeid.cc
+++ b/shapeid.cc
@@ -437,8 +437,7 @@ Shape_manager::Cached_shape Shape_manager::cache_shape(int shape_kind, int shape
 		cache.shape = sman->shapes.get_shape(shapenum, framenum);
 		cache.has_trans = sman->shapes.get_info(shapenum).has_translucency();
 	} else if (shape_kind < SF_OTHER) {
-		cache.shape = sman->files[static_cast<int>(shape_kind)].get_shape(
-		            shapenum, framenum);
+		cache.shape = sman->files[shape_kind].get_shape(shapenum, framenum);
 		if (shape_kind == SF_SPRITES_VGA)
 			cache.has_trans = true;
 	} else {


### PR DESCRIPTION
First commit is for two leftovers of the exult_silent_clang_sdl Pull Request :
- Wrong setting of a closing pragma,
- Some unneeded cast.

Second commit fixes Timidity under Linux
- Wrong Linux detection caused wrong Endianness
- The `timidity.cfg` was not found at its expected location `share/exult`,
- The `timidity.cfg` was not properly parsed when it contained part line comments.