### PR TITLE
Set all includes of SDL into angle brackets not double quotes, promote to SDL.h

### DIFF
--- a/audio/Audio.cc
+++ b/audio/Audio.cc
@@ -19,12 +19,8 @@
 #include "pent_include.h"
 #include "ignore_unused_variable_warning.h"
 
-#include <SDL_audio.h>
-#include <SDL_timer.h>
-
 #include <fstream>
 #include <set>
-//#include "SDL_mapping.h"
 
 #include "Audio.h"
 #include "Configuration.h"

--- a/audio/Audio.h
+++ b/audio/Audio.h
@@ -28,7 +28,6 @@
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
 #include <SDL.h>
-#include <SDL_audio.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/audio/midi_drivers/LowLevelMidiDriver.h
+++ b/audio/midi_drivers/LowLevelMidiDriver.h
@@ -35,7 +35,6 @@ class XMidiSequence;
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
 #include <SDL.h>
-#include <SDL_thread.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/audio/midi_drivers/timidity/timidity.cpp
+++ b/audio/midi_drivers/timidity/timidity.cpp
@@ -29,15 +29,6 @@
 
 using std::vector;
 
-#ifdef __GNUC__
-#	pragma GCC diagnostic push
-#	pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif    // __GNUC__
-#include "SDL.h"
-#ifdef __GNUC__
-#	pragma GCC diagnostic pop
-#endif    // __GNUC__
-
 #include "timidity.h"
 #include "timidity_common.h"
 #include "timidity_instrum.h"

--- a/audio/soundtest.cc
+++ b/audio/soundtest.cc
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2000-2022 The Exult Team
- *  
+ *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
@@ -15,7 +15,7 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
- 
+
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
 #endif
@@ -24,7 +24,7 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_events.h"
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/browser.cc
+++ b/browser.cc
@@ -24,7 +24,7 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_events.h"
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/cheat.cc
+++ b/cheat.cc
@@ -29,7 +29,15 @@
 using std::setw;
 using std::setfill;
 
-#include "SDL_mouse.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
+
 #include "cheat.h"
 #include "exult.h"
 #include "gamewin.h"

--- a/cheat_screen.cc
+++ b/cheat_screen.cc
@@ -22,15 +22,6 @@
 
 #include <cstring>
 
-#ifdef __GNUC__
-#	pragma GCC diagnostic push
-#	pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif    // __GNUC__
-#include "SDL_events.h"
-#ifdef __GNUC__
-#	pragma GCC diagnostic pop
-#endif    // __GNUC__
-
 #include "files/U7file.h"
 #include "chunks.h"
 #include "gamemap.h"
@@ -47,7 +38,6 @@
 #include "schedule.h"
 #include "ucmachine.h"
 #include "Configuration.h"
-#include "SDL.h"
 #include "party.h"
 #include "miscinf.h"
 #include "gump_utils.h"

--- a/effects.cc
+++ b/effects.cc
@@ -41,7 +41,14 @@
 #include "ucmachine.h"
 #include "ignore_unused_variable_warning.h"
 
-#include "SDL_timer.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 #include "AudioMixer.h"
 using namespace Pentagram;

--- a/flic/playfli.cc
+++ b/flic/playfli.cc
@@ -35,7 +35,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "gamewin.h"
 #include "palette.h"
 
-#include "SDL_timer.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 using std::ifstream;
 using std::memset;

--- a/gamemgr/bggame.cc
+++ b/gamemgr/bggame.cc
@@ -52,9 +52,6 @@
 #include "touchui.h"
 #include "txtscroll.h"
 
-#include <SDL.h>
-#include <SDL_events.h>
-
 #include <cctype>
 #include <cstring>
 #include <string>

--- a/gamemgr/devgame.cc
+++ b/gamemgr/devgame.cc
@@ -23,15 +23,6 @@
 #include <cctype>
 #include <cstdlib>
 
-#ifdef __GNUC__
-#	pragma GCC diagnostic push
-#	pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif    // __GNUC__
-#include "SDL_events.h"
-#ifdef __GNUC__
-#	pragma GCC diagnostic pop
-#endif    // __GNUC__
-
 #include "files/U7file.h"
 #include "files/utils.h"
 #include "flic/playfli.h"

--- a/gamemgr/sigame.cc
+++ b/gamemgr/sigame.cc
@@ -24,15 +24,6 @@
 
 #include "array_size.h"
 
-#ifdef __GNUC__
-#	pragma GCC diagnostic push
-#	pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif    // __GNUC__
-#include "SDL_events.h"
-#ifdef __GNUC__
-#	pragma GCC diagnostic pop
-#endif    // __GNUC__
-
 #include "files/U7file.h"
 #include "files/utils.h"
 #include "flic/playfli.h"

--- a/gumps/AudioOptions_gump.cc
+++ b/gumps/AudioOptions_gump.cc
@@ -23,7 +23,7 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_events.h"
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/gumps/File_gump.cc
+++ b/gumps/File_gump.cc
@@ -27,7 +27,7 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_events.h"
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/gumps/GameDisplayOptions_gump.cc
+++ b/gumps/GameDisplayOptions_gump.cc
@@ -27,7 +27,7 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_events.h"
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/gumps/GameEngineOptions_gump.cc
+++ b/gumps/GameEngineOptions_gump.cc
@@ -27,7 +27,6 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_events.h"
 #include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop

--- a/gumps/Gamemenu_gump.cc
+++ b/gumps/Gamemenu_gump.cc
@@ -20,15 +20,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #  include <config.h>
 #endif
 
-#ifdef __GNUC__
-#	pragma GCC diagnostic push
-#	pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif    // __GNUC__
-#include "SDL_events.h"
-#ifdef __GNUC__
-#	pragma GCC diagnostic pop
-#endif    // __GNUC__
-
 #include "Gamemenu_gump.h"
 #include "AudioOptions_gump.h"
 #include "VideoOptions_gump.h"

--- a/gumps/Gump_manager.cc
+++ b/gumps/Gump_manager.cc
@@ -22,22 +22,20 @@
 #  include <config.h>
 #endif
 
-#ifdef __GNUC__
-#	pragma GCC diagnostic push
-#	pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif    // __GNUC__
-#include "SDL_events.h"
-#include "SDL_keyboard.h"
-static const Uint32 EXSDL_TOUCH_MOUSEID=SDL_TOUCH_MOUSEID;
-#ifdef __GNUC__
-#	pragma GCC diagnostic pop
-#endif    // __GNUC__
-
 #include "Configuration.h"
 #include "exult.h"
 #include "Gump.h"
 #include "Gump_manager.h"
 #include "gamewin.h"
+
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+static const Uint32 EXSDL_TOUCH_MOUSEID=SDL_TOUCH_MOUSEID;
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 #include "Actor_gump.h"
 #include "Paperdoll_gump.h"

--- a/gumps/Gump_manager.h
+++ b/gumps/Gump_manager.h
@@ -28,7 +28,7 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_events.h"
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/gumps/InputOptions_gump.cc
+++ b/gumps/InputOptions_gump.cc
@@ -27,7 +27,7 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_events.h"
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/gumps/ItemMenu_gump.cc
+++ b/gumps/ItemMenu_gump.cc
@@ -20,15 +20,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #  include <config.h>
 #endif
 
-#ifdef __GNUC__
-#	pragma GCC diagnostic push
-#	pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif    // __GNUC__
-#include "SDL_events.h"
-#ifdef __GNUC__
-#	pragma GCC diagnostic pop
-#endif    // __GNUC__
-
 #include "ItemMenu_gump.h"
 
 #include "exult.h"

--- a/gumps/Modal_gump.h
+++ b/gumps/Modal_gump.h
@@ -20,7 +20,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define MODAL_GUMP_H
 
 #include "Gump.h"
-#include "SDL_events.h"
 #include "ignore_unused_variable_warning.h"
 
 /*

--- a/gumps/Notebook_gump.cc
+++ b/gumps/Notebook_gump.cc
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "gamewin.h"
 #include "gameclk.h"
 #include "actors.h"
-#include "SDL_events.h"
 #include "Configuration.h"
 #include "msgfile.h"
 #include "fnames.h"

--- a/gumps/ShortcutBar_gump.cc
+++ b/gumps/ShortcutBar_gump.cc
@@ -22,8 +22,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "ShortcutBar_gump.h"
 
-#include "SDL_events.h"
-
 #include "fnames.h"
 #include "exult.h"
 #include "keyactions.h"

--- a/gumps/ShortcutBar_gump.h
+++ b/gumps/ShortcutBar_gump.h
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL.h"
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/gumps/Slider_gump.cc
+++ b/gumps/Slider_gump.cc
@@ -20,16 +20,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #  include <config.h>
 #endif
 
-#ifdef __GNUC__
-#	pragma GCC diagnostic push
-#	pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif    // __GNUC__
-#include "SDL_events.h"
-#include "SDL_keyboard.h"
-#ifdef __GNUC__
-#	pragma GCC diagnostic pop
-#endif    // __GNUC__
-
 #include "game.h"
 #include "gamewin.h"
 #include "Gump_button.h"

--- a/gumps/Spellbook_gump.cc
+++ b/gumps/Spellbook_gump.cc
@@ -20,7 +20,15 @@
 #  include <config.h>
 #endif
 
-#include <SDL_timer.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
+
 #include "actors.h"
 #include "cheat.h"
 #include "gamewin.h"

--- a/gumps/VideoOptions_gump.cc
+++ b/gumps/VideoOptions_gump.cc
@@ -30,7 +30,7 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_events.h"
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/gumps/Yesno_gump.cc
+++ b/gumps/Yesno_gump.cc
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include <SDL_events.h>
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/gumps/Yesno_gump.h
+++ b/gumps/Yesno_gump.h
@@ -23,8 +23,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "Modal_gump.h"
 
-#include <SDL.h>
-
 class Yesno_button;
 
 /*

--- a/gumps/gump_utils.h
+++ b/gumps/gump_utils.h
@@ -25,8 +25,7 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_timer.h"
-#include "SDL_events.h"
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/imagewin/ArbScaler.h
+++ b/imagewin/ArbScaler.h
@@ -23,15 +23,6 @@
 #include "imagewin.h"
 #include "manip.h"
 
-#ifdef __GNUC__
-#	pragma GCC diagnostic push
-#	pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif    // __GNUC__
-#include <SDL.h>
-#ifdef __GNUC__
-#	pragma GCC diagnostic pop
-#endif    // __GNUC__
-
 namespace Pentagram {
 
 /// Base Scaler class

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -43,14 +43,18 @@ Boston, MA  02111-1307, USA.
 
 #include "istring.h"
 
-#include <SDL_video.h>
-#include <SDL_error.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 #include "manip.h"
 #include "BilinearScaler.h"
 #include "PointScaler.h"
-
-#include "SDL.h"
 
 #include "Configuration.h"
 

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -27,7 +27,6 @@ Boston, MA  02111-1307, USA.
 #ifndef INCL_IMAGEWIN
 #define INCL_IMAGEWIN   1
 
-//#include "SDL_video.h"
 #include "imagebuf.h"
 #include "common_types.h"
 #include <string>
@@ -35,7 +34,15 @@ Boston, MA  02111-1307, USA.
 #include <memory>
 #include <vector>
 
-#include "SDL_video.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
+
 #include "ignore_unused_variable_warning.h"
 
 struct SDL_Surface;

--- a/imagewin/iwin8.cc
+++ b/imagewin/iwin8.cc
@@ -31,7 +31,15 @@ Boston, MA  02111-1307, USA.
 
 #include <cstring>
 
-#include "SDL_video.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
+
 #include "iwin8.h"
 #include "common_types.h"
 #include "gamma.h"

--- a/imagewin/manip.h
+++ b/imagewin/manip.h
@@ -20,7 +20,15 @@
 #ifndef INCL_MANIP_H
 #define INCL_MANIP_H    1
 
-#include "SDL_video.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
+
 #include <cstdlib>
 #include <cstring>
 

--- a/imagewin/save_screenshot.cc
+++ b/imagewin/save_screenshot.cc
@@ -35,8 +35,15 @@ It has been partly rewritten to use an SDL surface as input.
 
 #include <cstdlib>
 
-#include "SDL_video.h"
-#include "SDL_endian.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
+
 #include <iostream>
 
 using std::cout;

--- a/imagewin/scale_hq2x.cc
+++ b/imagewin/scale_hq2x.cc
@@ -25,7 +25,14 @@
 
 #ifdef USE_HQ2X_SCALER
 
-#include "SDL_video.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 #include "imagewin.h"
 #include <cstdlib>

--- a/imagewin/scale_hq3x.cc
+++ b/imagewin/scale_hq3x.cc
@@ -25,8 +25,6 @@
 
 #ifdef USE_HQ3X_SCALER
 
-#include "SDL_video.h"
-
 #include "imagewin.h"
 #include <cstdlib>
 #include <cstring>

--- a/imagewin/scale_hq4x.cc
+++ b/imagewin/scale_hq4x.cc
@@ -25,8 +25,6 @@
 
 #ifdef USE_HQ4X_SCALER
 
-#include "SDL_video.h"
-
 #include "imagewin.h"
 #include <cstdlib>
 #include <cstring>

--- a/imagewin/scale_xbr.cc
+++ b/imagewin/scale_xbr.cc
@@ -28,8 +28,6 @@
 
 #ifdef USE_XBR_SCALER
 
-#include "SDL_video.h"
-
 #include "imagewin.h"
 #include <cstdlib>
 #include <cstring>

--- a/keys.cc
+++ b/keys.cc
@@ -20,7 +20,14 @@
 #  include <config.h>
 #endif
 
-#include "SDL_keyboard.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 #include "actors.h"
 #include "keys.h"

--- a/keys.h
+++ b/keys.h
@@ -23,10 +23,11 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_events.h"
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__
+
 #include "game.h"
 
 #include <vector>

--- a/mapedit/tools/mockup/main.c
+++ b/mapedit/tools/mockup/main.c
@@ -16,8 +16,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "SDL.h"
-#include "SDL_image.h"
+#include <SDL.h>
+#include <SDL_image.h>
 
 #include "defs.h"
 #include "main.h"

--- a/mapedit/tools/smooth/globals.h
+++ b/mapedit/tools/smooth/globals.h
@@ -24,7 +24,7 @@ typedef void *libhandle_t;
 // since we use indexed images, we have a limitation of 256 colours
 #define MAX_COLOURS 256
 
-#include "SDL.h"
+#include <SDL.h>
 
 // note: there are some almost static stuff and some very variable stuff
 // global's variables

--- a/mapedit/tools/smooth/image.c
+++ b/mapedit/tools/smooth/image.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "SDL_image.h"
+#include <SDL_image.h>
 
 #include "globals.h"
 

--- a/menulist.h
+++ b/menulist.h
@@ -27,7 +27,7 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_events.h"
+#include <SDL.h>
 static const Uint32 EXSDL_TOUCH_MOUSEID=SDL_TOUCH_MOUSEID;
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop

--- a/mouse.cc
+++ b/mouse.cc
@@ -27,8 +27,6 @@
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
 #include <SDL.h>
-#include "SDL_mouse.h"
-#include "SDL_timer.h"
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__

--- a/npcnear.cc
+++ b/npcnear.cc
@@ -35,7 +35,14 @@
 #include "cheat.h"
 #include "ignore_unused_variable_warning.h"
 
-#include "SDL_timer.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 using std::rand;
 

--- a/palette.cc
+++ b/palette.cc
@@ -32,7 +32,14 @@
 #include "exceptions.h"
 #include "ignore_unused_variable_warning.h"
 
-#include "SDL_timer.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 using std::memcpy;
 using std::memset;

--- a/schedule.cc
+++ b/schedule.cc
@@ -22,7 +22,15 @@
 #  include <config.h>
 #endif
 
-#include "SDL_timer.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
+
 #include "actors.h"
 #include "schedule.h"
 #include "Zombie.h"

--- a/server/server.cc
+++ b/server/server.cc
@@ -78,8 +78,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "cheat.h"
 #endif
 
-#include <SDL_timer.h>
-#include <SDL_events.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 using std::cout;
 using std::cerr;

--- a/tools/shp2pcx.cc
+++ b/tools/shp2pcx.cc
@@ -20,7 +20,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #  include <config.h>
 #endif
 
-#include "SDL_endian.h"
+// This is the only place in Exult where a sub include of SDL
+//    is not promoted to full SDL.h :
+// 1- shp2pcx has no use for SDL, it only uses SDL_endian.h
+//    to get the SDL_BYTEORDER macro for Endianness.
+// 2- Including SDL.h in full redirects main() to SDL_main()
+//    when the code is a stand alone executable, which shp2pcx is.
+#include <SDL_endian.h>
 
 #include <cassert>
 #include <iostream>

--- a/touchui.h
+++ b/touchui.h
@@ -29,6 +29,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__
+
 #include "common_types.h"
 
 class TouchUI {

--- a/tqueue.cc
+++ b/tqueue.cc
@@ -24,7 +24,15 @@
 
 #include "tqueue.h"
 #include <algorithm>
-#include <SDL_timer.h>
+
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
+#include <SDL.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 /*
  *  Remove all entries.

--- a/txtscroll.cc
+++ b/txtscroll.cc
@@ -35,10 +35,7 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif    // __GNUC__
-#include "SDL_timer.h"
-#include "SDL_events.h"
-#include "SDL_stdinc.h"
-#include "SDL_scancode.h"
+#include <SDL.h>
 #ifdef __GNUC__
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__


### PR DESCRIPTION
- Prefer `#include <SDLblabla.h>` to `#include "SDLblabla.h"`. Apply everywhere.
- Prefer `#include <SDL.h>` to `#include <SDLblabla.h>`. Apply everywhere except for `tools/shp2pcx.cc` with remains with `#include <SDL_endian.h>` because it only uses the `SDL_BYTEORDER` endianness macro at compile time, but not any SDL service at run time. Moreover, including full `SDL.h` in a stand alone executable, which `shp2pcx` is, disturbs the `main()` logic, as it is renamed into `SDL_main()`.