### PR TITLE
Exult Studio : Make File List left panel vertically scrollable

### DIFF
--- a/mapedit/exult_studio.glade
+++ b/mapedit/exult_studio.glade
@@ -3166,7 +3166,7 @@
                             <property name="hexpand">False</property>
                             <property name="vexpand">False</property>
                             <property name="hscrollbar-policy">never</property>
-                            <property name="vscrollbar-policy">never</property>
+                            <property name="min-content-height">360</property>
                             <property name="shadow-type">in</property>
                             <child>
                               <object class="GtkTreeView" id="file_list">


### PR DESCRIPTION
To fix issue #249, alter `mapedit/exult_studio.glade`, GtkScrolledWindow `scrolledwindow2` :
Replace `hscrollbar-policy` `never` ( switches to default `automatic` ) by `min-content-height` `360` ( to ensure a reasonably sized Tree View, such that the `Forge of Virtue` file list fits)