### PR TITLE
Fix Clang compiler name

### DIFF
--- a/version.cc
+++ b/version.cc
@@ -134,7 +134,7 @@ void getVersionInfo(std::ostream &out) {
 #ifdef __INTEL_COMPILER
 #	define COMPILER __VERSION__
 #elif defined(__clang__)
-#	define COMPILER "GCC " __VERSION__
+#	define COMPILER __VERSION__
 #elif defined(__GNUC__)
 #	define COMPILER "GCC " __VERSION__
 #elif defined(_MSC_FULL_VER)


### PR DESCRIPTION
(under FreeBSD)

`exult --version` compiled with Clang:
`Compiler: GCC FreeBSD Clang 14.0.5`
fixed:
`Compiler: FreeBSD Clang 14.0.5`

`exult --version` compiled with GCC:
`Compiler: GCC 11.3.0`

I've searched code but I didn't found why is FreeBSD showing up in compiler version section.