### PR TITLE
Support mouse wheel vertical scrolling in shape browsers

### DIFF
--- a/mapedit/chunklst.cc
+++ b/mapedit/chunklst.cc
@@ -728,6 +728,8 @@ Chunk_chooser::Chunk_chooser(
 	g_signal_connect(G_OBJECT(chunk_adj), "value-changed",
 	                 G_CALLBACK(scrolled), this);
 	gtk_widget_show(vscroll);
+	// Scroll events.
+	enable_draw_vscroll(draw);
 
 	// At the bottom, status bar:
 	GtkWidget *hbox1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/mapedit/combo.cc
+++ b/mapedit/combo.cc
@@ -1161,6 +1161,8 @@ Combo_chooser::Combo_chooser(
 	g_signal_connect(G_OBJECT(combo_adj), "value-changed",
 	                 G_CALLBACK(scrolled), this);
 	gtk_widget_show(vscroll);
+	// Scroll events.
+	enable_draw_vscroll(draw);
 
 	// At the bottom, status bar:
 	GtkWidget *hbox1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/mapedit/gtk_redefines.h
+++ b/mapedit/gtk_redefines.h
@@ -48,10 +48,12 @@ inline T1 *gtk_cast(T2 *obj) {
 #  undef _G_TYPE_CIC
 #  undef _G_TYPE_CCC
 #  undef _G_TYPE_CIT
+#  undef _G_TYPE_CIFT
 #  ifndef G_DISABLE_CAST_CHECKS
 #    define _G_TYPE_CIC(ip, gt, ct)     gtk_cast<ct>(g_type_check_instance_cast(gtk_cast<GTypeInstance>((ip)), gt))
 #    define _G_TYPE_CCC(cp, gt, ct)     gtk_cast<ct>(g_type_check_class_cast(gtk_cast<GTypeClass>((cp)), gt))
 #    define _G_TYPE_CIT(ip, gt)                     (g_type_check_instance_is_a(gtk_cast<GTypeInstance>((ip)), gt))
+#    define _G_TYPE_CIFT(ip, ft)                    (g_type_check_instance_is_fundamentally_a(gtk_cast<GTypeInstance>((ip)), ft))
 #  else /* G_DISABLE_CAST_CHECKS */
 #    define _G_TYPE_CIC(ip, gt, ct)     gtk_cast<ct>((ip))
 #    define _G_TYPE_CCC(cp, gt, ct)     gtk_cast<ct>((cp))

--- a/mapedit/npclst.cc
+++ b/mapedit/npclst.cc
@@ -1083,6 +1083,8 @@ Npc_chooser::Npc_chooser(
 	g_signal_connect(G_OBJECT(shape_adj), "value-changed",
 	                 G_CALLBACK(hscrolled), this);
 //++++  gtk_widget_hide(hscroll);   // Only shown in 'frames' mode.
+	// Scroll events.
+	enable_draw_vscroll(draw);
 
 	// At the bottom, status bar & frame:
 	GtkWidget *hbox1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/mapedit/objbrowse.h
+++ b/mapedit/objbrowse.h
@@ -39,6 +39,7 @@ protected:
 	//   displayed list.
 	GtkWidget *vscroll = nullptr;         // Vertical scrollbar.
 	GtkWidget *hscroll = nullptr;         // Horizontal scrollbar.
+	GtkEventController *vscroll_ctlr = nullptr; // Vertical scroll in browser.
 	Shape_group *group;                   // Non-null to use filter.
 	GtkWidget *popup = nullptr;           // Popup menu in draw area.
 	Shape_file_info *file_info;           // Our creator (or null).
@@ -96,6 +97,10 @@ public:
 	virtual GtkWidget *create_popup() {
 		return create_popup_internal(true);
 	}
+	// Handle scroll events.
+	void enable_draw_vscroll(GtkWidget *draw);
+	static void draw_vscrolled(GtkEventControllerScroll *self,
+	                           gdouble dx, gdouble dy, gpointer data);
 
 protected:
 	GtkWidget *create_popup_internal(bool files);// Popup menu.

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -2314,6 +2314,8 @@ Shape_chooser::Shape_chooser(
 	g_signal_connect(G_OBJECT(shape_adj), "value-changed",
 	                 G_CALLBACK(hscrolled), this);
 //++++  gtk_widget_hide(hscroll);   // Only shown in 'frames' mode.
+	// Scroll events.
+	enable_draw_vscroll(draw);
 
 	// At the bottom, status bar & frame:
 	GtkWidget *hbox1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);


### PR DESCRIPTION
To complete issue #249 :  

- Declare a ( static ) Scroll Event Handler in `mapedit/chunklst.h + combo.h + npclst.h + shapelst.h`
- Create and Bind a Scroll Event Handler in the browser constructor in ` mapedit/chunklst.cc + combo.cc + npclst.cc + shapelst.cc`
- Implement the Scroll Event handler in ` mapedit/chunklst.cc + combo.cc + npclst.cc + shapelst.cc` emulating the GTK effect of a mouse wheel event _on the vertical scroller_ :

1. Mouse wheel Scroll Events _on non macOS_ are in click units, then send a Scroller move of
`numberOfClicks * ( browserHeight ** 2/3 )`,
3. Mouse wheel Scroll Events _on macOS_ are in pixel units, then send a Scroller move of `numberOfPixels`.