### PR TITLE
Ensure that Studio's FileList window has its full width at start

### DIFF
--- a/mapedit/exult_studio.glade
+++ b/mapedit/exult_studio.glade
@@ -3191,6 +3191,7 @@
                         </child>
                         <child>
                           <object class="GtkFrame" id="groups_frame">
+                            <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">fill</property>
                             <property name="valign">fill</property>


### PR DESCRIPTION
From issue #249 reopen :
Ensure that the FileList treeview has its larger width - set by the Groups page - at start, by making the Groups page active by default.