### PR TITLE
Zoom Shapes in Studio for HiDPI screens

### DIFF
--- a/gumps/VideoOptions_gump.cc
+++ b/gumps/VideoOptions_gump.cc
@@ -252,15 +252,30 @@ void VideoOptions_gump::load_settings(bool Fullscreen) {
 			std::set<uint32> Resolutions{
 				make_resolution(320, 200),
 				make_resolution(320, 240),
+				make_resolution(400, 250),
 				make_resolution(400, 300),
+				make_resolution(480, 300),
+				make_resolution(480, 360),
+				make_resolution(512, 320),
 				make_resolution(512, 384),
 				make_resolution(640, 400),
 				make_resolution(640, 480),
+				make_resolution(800, 500),
 				make_resolution(800, 600),
 				make_resolution(960, 600),
 				make_resolution(960, 720),
+				make_resolution(1024, 640),
 				make_resolution(1024, 768),
-				make_resolution(1200, 900)
+				make_resolution(1200, 750),
+				make_resolution(1200, 900),
+				make_resolution(1280, 800),
+				make_resolution(1280, 960),
+				make_resolution(1440, 900),
+				make_resolution(1440, 1080),
+				make_resolution(1600, 1000),
+				make_resolution(1600, 1200),
+				make_resolution(1920, 1200),
+				make_resolution(1920, 1440)
 			};
 			auto it = std::find(Resolutions.cbegin(), Resolutions.cend(), resolution);
 			if (it == Resolutions.cend()) {

--- a/mapedit/chunklst.h
+++ b/mapedit/chunklst.h
@@ -68,10 +68,13 @@ class Chunk_chooser: public Object_browser, public Shape_draw {
 	int to_del;         // Terrain # to delete, or -1.
 	void (*sel_changed)();      // Called when selection changes.
 	// Blit onto screen.
+	int voffset;
+	int per_row;
 	void show(int x, int y, int w, int h) override;
 	void tell_server();
 	void select(int new_sel);   // Show new selection.
 	void render() override;      // Draw list.
+	void setup_info(bool savepos = true) override;
 	void set_background_color(guint32 c) override {
 		Shape_draw::set_background_color(c);
 	}
@@ -82,7 +85,7 @@ class Chunk_chooser: public Object_browser, public Shape_draw {
 	void update_num_chunks(int new_num_chunks);
 	void set_chunk(const unsigned char *data, int datalen);
 	void render_chunk(int chunknum, int xoff, int yoff);
-	void scroll(int newindex);  // Scroll.
+	void scroll(int newpixel);  // Scroll.
 	void scroll(bool upwards);
 	void enable_controls();     // Enable/disable controls after sel.
 	//   has changed.

--- a/mapedit/combo.h
+++ b/mapedit/combo.h
@@ -156,12 +156,15 @@ class Combo_chooser: public Object_browser, public Shape_draw {
 	int info_cnt;           // # entries in info.
 	void (*sel_changed)();      // Called when selection changes.
 	// Blit onto screen.
+	int voffset;
+	int per_row;
 	void show(int x, int y, int w, int h) override;
 	void select(int new_sel);   // Show new selection.
 	void load() override {
 		load_internal();
 	}
 	void load_internal();        // Load from file data.
+	void setup_info(bool savepos = true) override;
 	void render() override;      // Draw list.
 	void set_background_color(guint32 c) override {
 		Shape_draw::set_background_color(c);
@@ -169,7 +172,7 @@ class Combo_chooser: public Object_browser, public Shape_draw {
 	int get_selected_id() override {
 		return selected < 0 ? -1 : info[selected].num;
 	}
-	void scroll(int newindex);  // Scroll.
+	void scroll(int newpixel);  // Scroll.
 	void scroll(bool upwards);
 	void enable_controls();     // Enable/disable controls after sel.
 	//   has changed.

--- a/mapedit/exult_studio.glade
+++ b/mapedit/exult_studio.glade
@@ -2875,7 +2875,7 @@
                 <property name="vexpand">False</property>
                 <property name="label-xalign">0</property>
                 <child>
-                  <object class="GtkBox" id="hbox9">
+                  <object class="GtkBox" id="menubar_box">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="margin-start">4</property>

--- a/mapedit/objbrowse.cc
+++ b/mapedit/objbrowse.cc
@@ -497,6 +497,17 @@ void Object_browser::draw_vscrolled( // For scroll events.
 	const gdouble new_unit   = pow(adj_pgsize, 2.0/3.0);
 #endif // MACOSX && !XWIN
 	const gdouble new_value  = (dy * new_unit) + adj_value;
+#ifdef DEBUG
+	std::cout << "Objects : Wheeled to " << dy
+	          << " at " << gtk_adjustment_get_value(adj)
+	          << " -> " << new_value
+	          << " of [ " << gtk_adjustment_get_lower(adj)
+	          << ", " << gtk_adjustment_get_upper(adj)
+	          << " ] by " << gtk_adjustment_get_step_increment(adj)
+	          << " ( " << gtk_adjustment_get_page_increment(adj)
+	          << ", " << gtk_adjustment_get_page_size(adj)
+	          << " )" << std::endl;
+#endif
 	gtk_adjustment_set_value(adj, new_value);
 }
 

--- a/mapedit/shapedraw.h
+++ b/mapedit/shapedraw.h
@@ -63,7 +63,7 @@ public:
 	void show() {
 		GtkAllocation alloc = {0, 0, 0, 0};
 		gtk_widget_get_allocation(draw, &alloc);
-		show(0, 0, alloc.width, alloc.height);
+		show(0, 0, ZoomDown(alloc.width), ZoomDown(alloc.height));
 	}
 	guint32 get_color(int i) {
 		return palette->colors[i];

--- a/mapedit/studio.h
+++ b/mapedit/studio.h
@@ -109,6 +109,14 @@ private:
 	char            *default_game;
 	guint32         background_color;
 	static ExultStudio  *self;
+	// Shape scaling
+	int             shape_scale;    // Zoom half-units : 100% is 2, 150% is 3 ...
+	bool            shape_bilinear; // True is Bilinear, False is Nearest.
+	GtkWidget       *shape_zlabel;  // Zoom shape label, set to 50 * shape_scale.
+	GtkWidget       *shape_zup;     // Zoom up arrow.
+	GtkWidget       *shape_zdown;   // Zoom down arrow.
+	static gboolean on_app_key_press(
+	    GtkEntry *entry, GdkEventKey *event, gpointer user_data);
 	// Modified one of the .dat's?
 	bool            shape_info_modified, shape_names_modified;
 	bool            npc_modified;
@@ -194,6 +202,8 @@ public:
 	ExultStudio(int argc, char **argv);
 	~ExultStudio();
 	bool okay_to_close();
+	int get_shape_scale() { return shape_scale; }
+	bool get_shape_bilinear() { return shape_bilinear; }
 	GtkWidget *get_widget(GtkBuilder *xml, const char *name) {
 		return GTK_WIDGET(gtk_builder_get_object(xml, name));
 	}
@@ -328,6 +338,10 @@ public:
 	                       const char *shname, Shape_info *info = nullptr);
 	void save_shape_window();
 	void close_shape_window();
+	void create_zoom_controls();
+	static void on_zoom_bilinear(GtkToggleButton *btn, gpointer user_data);
+	static void on_zoom_up(GtkButton *btn, gpointer user_data);
+	static void on_zoom_down(GtkButton *btn, gpointer user_data);
 	// Map locator.
 	void open_locator_window();
 	// Combo editor.
@@ -430,6 +444,16 @@ GtkWidget *Create_arrow_button(GtkArrowType dir,
                                GCallback clicked,
                                gpointer func_data);
 bool Copy_file(const char *src, const char *dest);
+}
+
+inline int ZoomUp( int size ) {
+	return ( (size * (ExultStudio::get_instance()->get_shape_scale())) / 2 );
+}
+inline int ZoomDown( int size ) {
+	return ( (size * 2) / (ExultStudio::get_instance()->get_shape_scale()) );
+}
+inline int ZoomGet() {
+	return (ExultStudio::get_instance()->get_shape_scale());
 }
 
 class convertToUTF8 {


### PR DESCRIPTION
  Commit 1 of 1 :
    gumps/VideoOptions_gump.cc
      Add resolutions up to 1600
      Pair all resolutions in 16:10 ( original 320x200 ) and 4:3
    mapedit/exult_studio.glade
      Name the GtkBox widget in the Menubar to add the Zoom widgets
    mapedit/studio.cc + h
      Parse and store the command line Zoom options
      Build and handle the Menubar Zoom widgets
      Handle keyboard + and - including Keypad to change the Zoom scale
    mapedit/objbrowse.cc, chunklst.cc, combo.cc, npclst.cc, shapelst.cc
      [ Debug ] Display event messages for the Scrollers, the Wheels
    mapedit/chunklst.cc + h, combo.cc + h
      Move the Scrollers setup when Zooming change into a new setup_info
      Switch the Scrollers to smoother - part row - than full row
    mapedit/shapedraw.cc + h
      Implement Zooming in Shape_draw::show, ExultStudio::shape_image
      Rework Shape_single which factorizes all single Shape displays
    mapedit/combo.cc, chunklst.cc, npclst.cc, shapelst.cc
      Respect the Zooming
         in the Grid of Shapes, the Selection and the vertical scolling
    mapedit/npclst.cc, shapelst.cc
      In Frames mode, respect the Zooming
         in the Grid of Shapes, the Selection and the horizontal scrolling
      Fix the vertical scrollers to handle the most bottom row

In Summary :

1. New resolutions in Exult
2. Name the MenuBar in Studio's Glade file to add the Zoom controls into it
3. studio.cc & h : provide the command line and GUI to set the Zoom
4. Chunks and Combos : Zoom the shapes, Scroll smoothly
5. NPCs and Shapes : Zoom the shapes