### PR TITLE
Studio Shape Zooming : Follow vertical scroller value changing scale

### DIFF
--- a/mapedit/chunklst.cc
+++ b/mapedit/chunklst.cc
@@ -327,6 +327,7 @@ void Chunk_chooser::setup_info(
 	gtk_widget_get_allocation(draw, &alloc);
 	const int w = ZoomDown(alloc.width);
 	const int h = ZoomDown(alloc.height);
+	const int per_row_old = per_row;
 	per_row = std::max((w - border) / (128 + border), 1);
 	GtkAdjustment *adj = gtk_range_get_adjustment(GTK_RANGE(vscroll));
 	gtk_adjustment_set_upper(adj,
@@ -334,6 +335,8 @@ void Chunk_chooser::setup_info(
 	gtk_adjustment_set_step_increment(adj, ZoomDown(16));
 	gtk_adjustment_set_page_increment(adj, h - border);
 	gtk_adjustment_set_page_size(adj, h - border);
+	gtk_adjustment_set_value(adj,
+	    (gtk_adjustment_get_value(adj) * per_row_old / per_row));
 	g_signal_emit_by_name(G_OBJECT(adj), "changed");
 }
 

--- a/mapedit/combo.cc
+++ b/mapedit/combo.cc
@@ -1317,6 +1317,7 @@ void Combo_chooser::setup_info(
 	gtk_widget_get_allocation(draw, &alloc);
 	const int w = ZoomDown(alloc.width);
 	const int h = ZoomDown(alloc.height);
+	const int per_row_old = per_row;
 	per_row = std::max((w - border) / (128 + border), 1);
 	GtkAdjustment *adj = gtk_range_get_adjustment(GTK_RANGE(vscroll));
 	gtk_adjustment_set_upper(adj,
@@ -1324,6 +1325,8 @@ void Combo_chooser::setup_info(
 	gtk_adjustment_set_step_increment(adj, ZoomDown(16));
 	gtk_adjustment_set_page_increment(adj, h - border);
 	gtk_adjustment_set_page_size(adj, h - border);
+	gtk_adjustment_set_value(adj,
+	    (gtk_adjustment_get_value(adj) * per_row_old / per_row));
 	g_signal_emit_by_name(G_OBJECT(adj), "changed");
 }
 


### PR DESCRIPTION
  Commit 1 of 1:
    mapedit/chunklst.cc + combo.cc
      Adjust the scroller value at zoom change to remain in place

Follow up of PR #281 : Try to remain in place in the Combo browser and in the Chunk browser when changing the Zooming scale.