### PR TITLE
Fixes in Chunks and Map Editor

### DIFF
--- a/gamerend.cc
+++ b/gamerend.cc
@@ -162,18 +162,23 @@ void Game_render::paint_terrain_only(
 	int cx;
 	int cy;         // Chunk #'s.
 	// Paint all the flat scenery.
-	for (cy = start_chunky; cy != stop_chunky; cy = INCR_CHUNK(cy)) {
-		const int yoff = Figure_screen_offset(cy, gwin->scrollty) - gwin->get_scrollty_lo();
-		for (cx = start_chunkx; cx != stop_chunkx; cx = INCR_CHUNK(cx)) {
-			const int xoff = Figure_screen_offset(cx, gwin->scrolltx) - gwin->get_scrolltx_lo();
-			Map_chunk *chunk = map->get_chunk(cx, cy);
-			chunk->get_terrain()->render_all(cx, cy);
-			if (cheat.in_map_editor())
-				Paint_chunk_outline(gwin,
-				                    sman->get_special_pixel(HIT_PIXEL), cx, cy,
-				                    map->get_terrain_num(cx, cy), xoff, yoff);
+	for (int pass = 1; pass <= 3; pass ++)
+		for (cy = start_chunky; cy != stop_chunky; cy = INCR_CHUNK(cy)) {
+			const int yoff = Figure_screen_offset(cy, gwin->scrollty) -
+			    gwin->get_scrollty_lo();
+			for (cx = start_chunkx; cx != stop_chunkx; cx = INCR_CHUNK(cx)) {
+				const int xoff = Figure_screen_offset(cx, gwin->scrolltx) -
+				    gwin->get_scrolltx_lo();
+				if (pass < 3) {
+					Map_chunk *chunk = map->get_chunk(cx, cy);
+					chunk->get_terrain()->render_all(cx, cy, pass);
+				}
+				if (cheat.in_map_editor() && pass == 3)
+					Paint_chunk_outline(gwin,
+					    sman->get_special_pixel(HIT_PIXEL), cx, cy,
+					    map->get_terrain_num(cx, cy), xoff, yoff);
+			}
 		}
-	}
 	// Paint tile grid if desired.
 	if (cheat.show_tile_grid())
 		Paint_grid(gwin, sman->get_xform(16));
@@ -222,29 +227,37 @@ int Game_render::paint_map(
 	int cy;         // Chunk #'s.
 	// Paint all the flat scenery.
 	for (cy = start_chunky; cy != stop_chunky; cy = INCR_CHUNK(cy)) {
-		const int yoff = Figure_screen_offset(cy, scrollty) - gwin->get_scrollty_lo();
+		const int yoff = Figure_screen_offset(cy, scrollty) -
+		    gwin->get_scrollty_lo();
 		for (cx = start_chunkx; cx != stop_chunkx; cx = INCR_CHUNK(cx)) {
-			const int xoff = Figure_screen_offset(cx, scrolltx) - gwin->get_scrolltx_lo();
+			const int xoff = Figure_screen_offset(cx, scrolltx) -
+			    gwin->get_scrolltx_lo();
 			paint_chunk_flats(cx, cy, xoff, yoff);
-			if (cheat.in_map_editor())
-				Paint_chunk_outline(gwin,
-				                    sman->get_special_pixel(HIT_PIXEL), cx, cy,
-				                    map->get_terrain_num(cx, cy), xoff, yoff);
 		}
 	}
 	// Now the flat RLE terrain.
 	for (cy = start_chunky; cy != stop_chunky; cy = INCR_CHUNK(cy)) {
-		const int yoff = Figure_screen_offset(cy, scrollty) -  - gwin->get_scrollty_lo();
+		const int yoff = Figure_screen_offset(cy, scrollty) -
+		    gwin->get_scrollty_lo();
 		for (cx = start_chunkx; cx != stop_chunkx; cx = INCR_CHUNK(cx)) {
-			const int xoff = Figure_screen_offset(cx, scrolltx) -  - gwin->get_scrolltx_lo();
+			const int xoff = Figure_screen_offset(cx, scrolltx) -
+			    gwin->get_scrolltx_lo();
 			paint_chunk_flat_rles(cx, cy, xoff, yoff);
-
-			if (cheat.in_map_editor())
-				Paint_chunk_outline(gwin,
-				                    sman->get_special_pixel(HIT_PIXEL), cx, cy,
-				                    map->get_terrain_num(cx, cy), xoff, yoff);
 		}
 	}
+	// Draw the chunk grid in Map editor cheat mode.
+	if (cheat.in_map_editor())
+		for (cy = start_chunky; cy != stop_chunky; cy = INCR_CHUNK(cy)) {
+			const int yoff = Figure_screen_offset(cy, scrollty) -
+			    gwin->get_scrollty_lo();
+			for (cx = start_chunkx; cx != stop_chunkx; cx = INCR_CHUNK(cx)) {
+				const int xoff = Figure_screen_offset(cx, scrolltx) -
+				    gwin->get_scrolltx_lo();
+				Paint_chunk_outline(gwin,
+				    sman->get_special_pixel(HIT_PIXEL), cx, cy,
+				    map->get_terrain_num(cx, cy), xoff, yoff);
+			}
+		}
 	// Draw the chunks' objects
 	//   diagonally NE.
 	const int tmp_stopy = DECR_CHUNK(start_chunky);
@@ -283,8 +296,7 @@ int Game_render::paint_map(
 			Paint_grid(gwin, sman->get_xform(16));
 		if (cheat.get_edit_mode() == Cheat::select_chunks)
 			Paint_selected_chunks(gwin, sman->get_xform(13),
-			                      start_chunkx, start_chunky, stop_chunkx,
-			                      stop_chunky);
+			    start_chunkx, start_chunky, stop_chunkx, stop_chunky);
 	}
 	return light_sources;
 }

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -169,6 +169,7 @@ void Shape_draw::draw_shape_centered(
 		    ZoomUp( shape->get_width() + 8 ) :  alloc.width,
 		    winh < shape->get_height() + 8 ?
 		    ZoomUp(shape->get_height() + 8 ) : alloc.height);
+		cairo_reset_clip(drawgc);
 		gtk_widget_queue_draw(draw);
 	}
 	else {

--- a/objs/chunkter.cc
+++ b/objs/chunkter.cc
@@ -252,7 +252,7 @@ void Chunk_terrain::free_rendered_flats() {
  */
 
 void Chunk_terrain::render_all(
-    int cx, int cy          // Chunk rendering too.
+    int cx, int cy, int pass // Chunk rendering too.
 ) {
 	Image_window8 *iwin = gwin->get_win();
 	const int ctx = cx * c_tiles_per_chunk;
@@ -265,12 +265,12 @@ void Chunk_terrain::render_all(
 			Shape_frame *shape = get_shape(tilex, tiley);
 			if (!shape)
 				continue;
-			if (!shape->is_rle())
+			if (!shape->is_rle() && pass == 1)
 				iwin->copy8(shape->get_data(), c_tilesize,
 				            c_tilesize,
 				            (ctx + tilex - scrolltx)*c_tilesize,
 				            (cty + tiley - scrollty)*c_tilesize);
-			else {      // RLE.
+			else if (shape->is_rle() && pass == 2) {      // RLE.
 				int x;
 				int y;
 				const Tile_coord tile(ctx + tilex, cty + tiley, 0);

--- a/objs/chunkter.h
+++ b/objs/chunkter.h
@@ -92,7 +92,7 @@ public:
 		return rendered_flats
 		       ? rendered_flats : render_flats();
 	}
-	void render_all(int cx, int cy);// Render (in terrain-editing mode).
+	void render_all(int cx, int cy, int pass);// Render terrain-editing mode.
 	// Write out to chunk.
 	int write_flats(unsigned char *chunk_data, bool v2_chunks);
 };


### PR DESCRIPTION
Various fixes in Exult and Studio around the Chunks Browser and the Map Editor:

- Studio : In large Zooming, the single Shape displays ( like the main Shape in the Shape Editor ) could be barred by a white line.
The fix is a reset of the Cairo clip in `Shape_draw::draw_shape_centered` in `mapedit/shapedraw.cc` when enlarging the GtkDrawingArea.
- Studio : The Chunks Browser displays damaged chunks when those contain a mix of `non RLE` flats and `RLE` flats.
The fix is a two passes display in `Chunk_chooser::render_chunk` in `mapedit/chunklst.cc` :  `non RLE` shapes, followed by `RLE` shapes like in `Game_render::paint_map` in `gamerend.cc`, and a neutering of the invalid default origin `-1, -1` of `non RLE` shapes.
- Exult : The main map painter has a wrong sign pixel shift in the second pass of the Chunk display, when the Smooth Scroll mode of the Avatar ( Game Display gump option ) is active. This places the `RLE` shapes and Chunk grid at the wrong place.
The fix corrects the sign of the `scrolltx_lo` and `scrollty_lo` in the second pass in `Game_render::paint_map` in `gamerend.cc`.
- Exult : The main map painter places the Chunk grid two times, one time within each pass of the Chunk display, when in Map Editor mode.
The fix displays the Chunk grid as a third loop behind the two passes in `Game_render::paint_map` in `gamerend.cc`.
- Exult : The Terrain Editor mode map painter displays the mixed Chunks wrongly, rather like the Chunks Browser  in Studio.
The fix is a three passes display in `Game_render::paint_terrain_only` in `gamerend.cc`  and `Chunk_terrain::render_all` in `objs/chunkter.h + cc` : display the `non RLE` shapes, then display the `RLE shapes`, finally display the Chunk grid.