### PR TITLE
Follow current shape or selected shape while changing zoom

### DIFF
--- a/mapedit/chunklst.cc
+++ b/mapedit/chunklst.cc
@@ -333,7 +333,6 @@ gint Chunk_chooser::configure(
 void Chunk_chooser::setup_info(
     bool savepos            // Try to keep current position.
 ) {
-	ignore_unused_variable_warning(savepos);
 	// Set new scroll amounts.
 	GtkAllocation alloc = {0, 0, 0, 0};
 	gtk_widget_get_allocation(draw, &alloc);
@@ -347,8 +346,18 @@ void Chunk_chooser::setup_info(
 	gtk_adjustment_set_step_increment(adj, ZoomDown(16));
 	gtk_adjustment_set_page_increment(adj, h - border);
 	gtk_adjustment_set_page_size(adj, h - border);
-	gtk_adjustment_set_value(adj,
-	    (gtk_adjustment_get_value(adj) * per_row_old / per_row));
+	if (savepos && selected >= 0) {
+		gtk_adjustment_set_value(adj,
+		    ((128 + border) * info[selected].num) / per_row);
+	}
+	else if (savepos) {
+		gtk_adjustment_set_value(adj,
+		    (gtk_adjustment_get_value(adj) * per_row_old / per_row));
+	}
+	if (gtk_adjustment_get_value(adj) >
+	      (gtk_adjustment_get_upper(adj) - gtk_adjustment_get_page_size(adj)))
+		gtk_adjustment_set_value(adj,
+		  (gtk_adjustment_get_upper(adj) - gtk_adjustment_get_page_size(adj)));
 	g_signal_emit_by_name(G_OBJECT(adj), "changed");
 }
 

--- a/mapedit/combo.cc
+++ b/mapedit/combo.cc
@@ -109,13 +109,14 @@ void ExultStudio::save_combos(
 gboolean Combo_editor::on_combo_draw_expose_event(
     GtkWidget *widget,      // The view window.
     cairo_t *cairo,
-    gpointer data) {
+    gpointer data
+) {
 	ignore_unused_variable_warning(data);
 	auto *combo = static_cast<Combo_editor *>(g_object_get_data(
 	                  G_OBJECT(gtk_widget_get_toplevel(GTK_WIDGET(widget))), "user_data"));
+	combo->set_graphic_context(cairo);
 	GdkRectangle area = { 0, 0, 0, 0 };
 	gdk_cairo_get_clip_rectangle(cairo, &area);
-	combo->set_graphic_context(cairo);
 	combo->render_area(&area);
 	combo->set_graphic_context(nullptr);
 	return TRUE;
@@ -1311,7 +1312,6 @@ gint Combo_chooser::configure(
 void Combo_chooser::setup_info(
     bool savepos            // Try to keep current position.
 ) {
-	ignore_unused_variable_warning(savepos);
 	// Set new scroll amounts.
 	GtkAllocation alloc = {0, 0, 0, 0};
 	gtk_widget_get_allocation(draw, &alloc);
@@ -1325,8 +1325,18 @@ void Combo_chooser::setup_info(
 	gtk_adjustment_set_step_increment(adj, ZoomDown(16));
 	gtk_adjustment_set_page_increment(adj, h - border);
 	gtk_adjustment_set_page_size(adj, h - border);
-	gtk_adjustment_set_value(adj,
-	    (gtk_adjustment_get_value(adj) * per_row_old / per_row));
+	if (savepos && selected >= 0) {
+		gtk_adjustment_set_value(adj,
+		    ((128 + border) * info[selected].num) / per_row);
+	}
+	else if (savepos) {
+		gtk_adjustment_set_value(adj,
+		    (gtk_adjustment_get_value(adj) * per_row_old / per_row));
+	}
+	if (gtk_adjustment_get_value(adj) >
+	      (gtk_adjustment_get_upper(adj) - gtk_adjustment_get_page_size(adj)))
+		gtk_adjustment_set_value(adj,
+		  (gtk_adjustment_get_upper(adj) - gtk_adjustment_get_page_size(adj)));
 	g_signal_emit_by_name(G_OBJECT(adj), "changed");
 }
 

--- a/mapedit/npclst.cc
+++ b/mapedit/npclst.cc
@@ -185,7 +185,7 @@ static int Get_x_offset(
 void Npc_chooser::setup_info(
     bool savepos            // Try to keep current position.
 ) {
-	const unsigned oldind = rows[row0].index0;
+	const unsigned oldind = (selected >= 0 ? selected : rows[row0].index0);
 	info.resize(0);
 	rows.resize(0);
 	row0 = row0_voffset = 0;
@@ -839,6 +839,10 @@ void Npc_chooser::setup_hscrollbar(
 	gtk_adjustment_set_page_size(adj, ZoomDown(alloc.width));
 	if (gtk_adjustment_get_page_size(adj) > gtk_adjustment_get_upper(adj))
 		gtk_adjustment_set_upper(adj, gtk_adjustment_get_page_size(adj));
+	if (gtk_adjustment_get_value(adj) >
+	      (gtk_adjustment_get_upper(adj) - gtk_adjustment_get_page_size(adj)))
+		gtk_adjustment_set_value(adj,
+		  (gtk_adjustment_get_upper(adj) - gtk_adjustment_get_page_size(adj)));
 	g_signal_emit_by_name(G_OBJECT(adj), "changed");
 }
 

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -267,7 +267,7 @@ static int Get_x_offset(
 void Shape_chooser::setup_info(
     bool savepos            // Try to keep current position.
 ) {
-	const unsigned oldind = rows[row0].index0;
+	const unsigned oldind = (selected >= 0 ? selected : rows[row0].index0);
 	info.resize(0);
 	rows.resize(0);
 	row0 = row0_voffset = 0;
@@ -1856,6 +1856,10 @@ void Shape_chooser::setup_hscrollbar(
 	gtk_adjustment_set_page_size(adj, ZoomDown(alloc.width));
 	if (gtk_adjustment_get_page_size(adj) > gtk_adjustment_get_upper(adj))
 		gtk_adjustment_set_upper(adj, gtk_adjustment_get_page_size(adj));
+	if (gtk_adjustment_get_value(adj) >
+	      (gtk_adjustment_get_upper(adj) - gtk_adjustment_get_page_size(adj)))
+		gtk_adjustment_set_value(adj,
+		  (gtk_adjustment_get_upper(adj) - gtk_adjustment_get_page_size(adj)));
 	g_signal_emit_by_name(G_OBJECT(adj), "changed");
 }
 


### PR DESCRIPTION
This Pull Request, to complete the Issue #278, contains

- Two cosmetic fixes into `combo.cc`,
- A check to prevent an horizontal scroller bar to overflow on the right when the Zoom decreases,
- A better tracking of the _current_ Shape, that is, either the selected Shape, or the leftmost topmost visible Shape, to ensure that it remains visible while the Zoom changes, the Shape browser, the Npc browser, the Combo browser, the Chunk browser.
