### PR TITLE
Fix enabling Edit Terrain after Locating a chunk near a superchunk boundary

### DIFF
--- a/gamemap.cc
+++ b/gamemap.cc
@@ -303,10 +303,14 @@ void Game_map::read_map_data(
 	const int firstsx = (scrolltx - 1) / c_tiles_per_schunk;
 	const int firstsy = (scrollty - 1) / c_tiles_per_schunk;
 	// End 8 tiles to right.
-	const int lastsx = (scrolltx + (w + c_tilesize - 2) / c_tilesize +
-	              c_tiles_per_chunk / 2) / c_tiles_per_schunk;
-	const int lastsy = (scrollty + (h + c_tilesize - 2) / c_tilesize +
-	              c_tiles_per_chunk / 2) / c_tiles_per_schunk;
+	// These 1 added to the chunk limits reflect the Game_render::paint_map
+	//       1 added to the chunk limits for the Smooth Scrolling.
+	// This prevents a crash in the Edit Terrain mode when jumping
+	//   to a chunk near a superchunk boundary.
+	const int lastsx = ( 1 + (scrolltx + (w + c_tilesize - 2) / c_tilesize +
+	    c_tiles_per_chunk / 2) / c_tiles_per_chunk ) / c_chunks_per_schunk;
+	const int lastsy = ( 1 + (scrollty + (h + c_tilesize - 2) / c_tilesize +
+	    c_tiles_per_chunk / 2) / c_tiles_per_chunk ) / c_chunks_per_schunk;
 	// Watch for wrapping.
 	const int stopsx = (lastsx + 1) % c_num_schunks;
 	const int stopsy = (lastsy + 1) % c_num_schunks;

--- a/gamerend.cc
+++ b/gamerend.cc
@@ -211,6 +211,9 @@ int Game_render::paint_map(
 	int start_chunky = (scrollty + y / c_tilesize - 1) / c_tiles_per_chunk;
 	start_chunky = (start_chunky + c_num_chunks) % c_num_chunks;
 	// End 8 tiles to right.
+	// The chunk limits were increased by 1 to support the Smooth Scrolling.
+	// The same increase had to be added into the Game_map::read_map_data
+	//   which builds the chunk cache that the Edit Terrain mode relies on.
 	int stop_chunkx = 2 + (scrolltx + (x + w + c_tilesize - 2) / c_tilesize +
 	                       c_tiles_per_chunk / 2) / c_tiles_per_chunk;
 	int stop_chunky = 2 + (scrollty + (y + h + c_tilesize - 2) / c_tilesize +


### PR DESCRIPTION
Fixes Issue #283 :

Discrepancy in the chunk cache between its build in `Game_map::read_map_data` and its use in `Game_render::paint_map` when the Edit Terrain mode is enabled.
The Smooth Scrolling mode in commit 237dc6881 requires one more chunk at the right and at the bottom in `Game_render::paint_map` but the chunk cache in `Game_map::read_map_data` was not altered.

This PR increases the chunk limits when building the chunk cache.