### PR TITLE
Fix crash in Cheat menu when holding Shift for some time

### DIFF
--- a/cheat_screen.cc
+++ b/cheat_screen.cc
@@ -477,7 +477,7 @@ bool CheatScreen::SharedInput(char *input, int len, int &command, Cheat_Prompt &
 					activate = true;
 				} else if ((key.sym == '-' || key.sym == SDLK_KP_MINUS) && !input[0]) {
 					input[0] = '-';
-				} else if (std::isxdigit(key.sym)) {
+				} else if ((key.sym < 256 && key.sym >= 0 ? std::isxdigit(key.sym) : false)) {
 					const int curlen = std::strlen(input);
 					if (curlen < (len - 1)) {
 						input[curlen] = std::tolower(key.sym);
@@ -497,7 +497,7 @@ bool CheatScreen::SharedInput(char *input, int len, int &command, Cheat_Prompt &
 			} else if (mode >= CP_Name) {      // Want Text input (len chars)
 				if (key.sym == SDLK_RETURN || key.sym == SDLK_KP_ENTER) {
 					activate = true;
-				} else if (std::isalnum(key.sym) || key.sym == ' ') {
+				} else if ((key.sym < 256 && key.sym >= 0 ? std::isalnum(key.sym) : false) || key.sym == ' ') {
 					const int curlen = std::strlen(input);
 					char chr = key.sym;
 					if (key.mod & KMOD_SHIFT) {
@@ -524,7 +524,7 @@ bool CheatScreen::SharedInput(char *input, int len, int &command, Cheat_Prompt &
 					activate = true;
 				} else if ((key.sym == '-' || key.sym == SDLK_KP_MINUS) && !input[0]) {
 					input[0] = '-';
-				} else if (std::isdigit(key.sym)) {
+				} else if ((key.sym < 256 && key.sym >= 0 ? std::isdigit(key.sym) : false)) {
 					const int curlen = std::strlen(input);
 					if (curlen < (len - 1)) {
 						input[curlen] = key.sym;


### PR DESCRIPTION
When expecting a Name, a Decimal number or an Hexadecimal number, the Cheat menu crashes when the user holds a control key ( Shift, Control, ... ) for some time.

Then SDL sends a key event, whose SDL_Keysym is outside the range 0..255 and then `std::isdigit`, `std::isxdigit`, `std::isalnum` index a `ctype` array outside its bounds.
Ensure that the SDL_Keysym is in the range 0..255 or return false to the check.
