### PR TITLE
Exult Studio uses the ICU to convert strings from and to UTF-8

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -127,7 +127,7 @@ jobs:
           fi
           sudo apt-fast install -y \
             zlib1g-dev libogg-dev libvorbis-dev libasound2-dev libfluidsynth-dev libsdl2-dev libpng-dev libfreetype6-dev libgtk2.0-dev libgtk-3-dev \
-            libgdk-pixbuf2.0-dev libxml2-dev bison flex timidity libgimp2.0-dev
+            libgdk-pixbuf2.0-dev libxml2-dev bison flex timidity libgimp2.0-dev libicu-dev
       - name: Checkout code
         uses: actions/checkout@master
       - name: Run autogen

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -106,7 +106,7 @@ jobs:
           brew update
           brew upgrade || true
           brew install automake libtool pkg-config libpng zlib libogg libvorbis fluid-synth freetype gtk+3 libxml2 bison flex
-          brew install sdl2
+          brew install sdl2 icu4c
       - name: Checkout code
         uses: actions/checkout@master
       - name: Run autogen
@@ -118,7 +118,7 @@ jobs:
           export LDFLAGS="-L$(brew --prefix bison)/lib -L$(brew --prefix flex)/lib -L$(brew --prefix zlib)/lib"
           export CPPFLAGS="-I$(brew --prefix flex)/include -I$(brew --prefix zlib)/include"
           export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$(brew --prefix libxml2)/bin:$PATH"
-          export PKG_CONFIG_PATH="$(brew --prefix zlib)/lib/pkgconfig:$(brew --prefix libxml2)/lib/pkgconfig"
+          export PKG_CONFIG_PATH="$(brew --prefix zlib)/lib/pkgconfig:$(brew --prefix libxml2)/lib/pkgconfig:$(brew --prefix icu4c)/lib/pkgconfig"
           ./configure --with-debug=extreme --enable-exult-studio --enable-exult-studio-support --enable-compiler \
             --enable-zip-support --enable-shared --enable-gnome-shp-thumbnailer --enable-data --enable-mods \
             --disable-alsa --disable-timidity-midi --disable-oggtest --disable-vorbistest
@@ -127,5 +127,5 @@ jobs:
           export LDFLAGS="-L$(brew --prefix bison)/lib -L$(brew --prefix flex)/lib -L$(brew --prefix zlib)/lib"
           export CPPFLAGS="-I$(brew --prefix flex)/include -I$(brew --prefix zlib)/include"
           export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$(brew --prefix libxml2)/bin:$PATH"
-          export PKG_CONFIG_PATH="$(brew --prefix zlib)/lib/pkgconfig:$(brew --prefix libxml2)/lib/pkgconfig"
+          export PKG_CONFIG_PATH="$(brew --prefix zlib)/lib/pkgconfig:$(brew --prefix libxml2)/lib/pkgconfig:$(brew --prefix icu4c)/lib/pkgconfig"
           make -j 2

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -113,7 +113,7 @@ jobs:
             mingw-w64-x86_64-fluidsynth mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis mingw-w64-x86_64-munt-mt32emu
             mingw-w64-x86_64-libpng mingw-w64-x86_64-zlib mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-gtk3
             mingw-w64-x86_64-adwaita-icon-theme mingw-w64-x86_64-libxml2 mingw-w64-x86_64-freetype mingw-w64-x86_64-gtk2
-            mingw-w64-x86_64-gimp
+            mingw-w64-x86_64-gimp mingw-w64-x86_64-icu
       - name: Checkout code
         uses: actions/checkout@master
       - name: Build

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -83,9 +83,15 @@ FREETYPE2_INCLUDES:=$(shell pkg-config --cflags freetype2)
 # If this doesn't work, insert output of 'pkg-config --libs freetype2' manually
 FREETYPE2_LIBS:=$(shell pkg-config --libs freetype2)
 
+### ICU libs and includes, for Exult Studio.
+# If this doesn't work, insert output of 'pkg-config --cflags icu-uc' manually
+ICU_INCLUDES:=$(shell pkg-config --cflags icu-uc)
+# If this doesn't work, insert output of 'pkg-config --libs icu-uc' manually
+ICU_LIBS:=$(shell pkg-config --libs icu-uc)
+
 ### Combined Exult Studio includes and libs.
-ES_INCLUDES:=$(GTK_INCLUDES) $(FREETYPE2_INCLUDES)
-ES_LIBS:=$(GTK_LIBS) $(FREETYPE2_LIBS) $(ZIP_LIBS) -lpng -luuid -lole32 -lwinmm -lws2_32 $(SUBSYSTEM)
+ES_INCLUDES:=$(GTK_INCLUDES) $(FREETYPE2_INCLUDES) $(ICU_INCLUDES)
+ES_LIBS:=$(GTK_LIBS) $(FREETYPE2_LIBS) $(ICU_LIBS) $(ZIP_LIBS) -lpng -luuid -lole32 -lwinmm -lws2_32 $(SUBSYSTEM)
 
 ### GIMP libs and includes, for the GIMP plugin.
 # If this doesn't work, insert output of 'gimptool --cflags' manually

--- a/configure.ac
+++ b/configure.ac
@@ -426,6 +426,14 @@ if test x$enable_android_apk = xno; then
 fi
 
 # ---------------------------------------------------------------------
+# Icu (for ES)
+# ---------------------------------------------------------------------
+
+if test x$enable_android_apk = xno; then
+    PKG_CHECK_MODULES(ICU, icu-uc, have_icu=yes, have_icu=no)
+fi
+
+# ---------------------------------------------------------------------
 # Gtk (for ES)
 # ---------------------------------------------------------------------
 
@@ -1049,8 +1057,13 @@ AC_MSG_CHECKING([whether to build Exult Studio])
 if test x$enable_exult_studio = xyes; then
 	AC_MSG_RESULT(yes)
 	if test x$have_gtk = xno; then
-		echo "Umm, but we don't have any Gtk+ stuff."
-		echo "Try again, either with Gtk-3.16 or newer, or with --disable-exult-studio"
+		echo "Exult Studio requires the GTK+ (aka the GIMP Tool Kit), but it is not installed."
+		echo "Please try again, either with the GTK+ installed as 3.16 or newer, or with '--disable-exult-studio'."
+		exit 1
+	fi
+	if test x$have_icu = xno; then
+		echo "Exult Studio requires the ICU (aka the International Components for Unicode), but it is not installed."
+		echo "Please try again, either with the ICU installed, or with '--disable-exult-studio'."
 		exit 1
 	fi
 	AM_CONDITIONAL(BUILD_STUDIO, true)
@@ -1285,6 +1298,9 @@ if test x$enable_android_apk = xno; then
 	if test x$enable_fluidsynth = xyes; then
 		PKG_CHECK_EXISTS(fluidsynth,
 			echo Fluidsynth................. : `$PKG_CONFIG --modversion fluidsynth`)
+	fi
+	if test x$have_icu = xyes; then
+		echo ICU........................ : `$PKG_CONFIG --modversion icu-uc`
 	fi
 	if test x$have_gtk = xyes; then
 		echo GLIB....................... : `$PKG_CONFIG --modversion glib-2.0`

--- a/mapedit/Makefile.am
+++ b/mapedit/Makefile.am
@@ -2,7 +2,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/headers -I$(top_srcdir) -I$(top_srcdir)/shapes \
 	-I$(top_srcdir)/imagewin -I$(top_srcdir)/conf -I$(top_srcdir)/gamemgr \
 	-I$(top_srcdir)/files -I$(top_srcdir)/server  -I$(top_srcdir)/usecode \
 	-I$(top_srcdir)/shapes/shapeinf \
-	$(GTK_CFLAGS) $(INCDIRS) $(WINDOWING_SYSTEM) \
+	$(GTK_CFLAGS) $(ICU_CFLAGS) $(INCDIRS) $(WINDOWING_SYSTEM) \
 	$(DEBUG_LEVEL) $(OPT_LEVEL) $(WARNINGS) $(CPPFLAGS) -DEXULT_DATADIR=\"$(EXULT_DATADIR)\"
 
 if GIMP_PLUGIN
@@ -21,7 +21,7 @@ u7shp_SOURCES = u7shp.cc
 
 u7shp_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/files -I$(top_srcdir)/headers \
 	-I$(top_srcdir)/shapes -I$(top_srcdir)/imagewin -I$(top_srcdir)/files \
-	$(GIMP_INCLUDES) $(GTK_CFLAGS) $(INCDIRS) \
+	$(GIMP_INCLUDES) $(GTK_CFLAGS) $(ICU_CFLAGS) $(INCDIRS) \
 	$(DEBUG_LEVEL) $(OPT_LEVEL) $(WARNINGS) $(CPPFLAGS) -DHAVE_CONFIG_H
 
 u7shp_LDADD = \
@@ -81,9 +81,9 @@ exult_studio_LDADD = \
 	../server/libserver.la		\
 	../usecode/libusecode.la		\
 	../shapes/shapeinf/libshapeinf.la	\
-	-lpng $(FREETYPE2_LIBS) $(SYSLIBS) $(x_libraries) $(GTK_LIBS) $(ZLIB_LIBS)
+	-lpng $(FREETYPE2_LIBS) $(SYSLIBS) $(x_libraries) $(GTK_LIBS) $(ICU_LIBS) $(ZLIB_LIBS)
 
-exult_studio_CFLAGS = $(GTK_CFLAGS)
+exult_studio_CFLAGS = $(GTK_CFLAGS) $(ICU_CFLAGS)
 exult_studio_LDFLAGS = -export-dynamic		# For Gtk+ 2.x
 
 mapeditdir = $(datadir)/exult

--- a/mapedit/exult_studio.glade
+++ b/mapedit/exult_studio.glade
@@ -1361,9 +1361,6 @@
       <row>
         <col id="0" translatable="yes">Celtic (ISO-8859-14)</col>
       </row>
-      <row>
-        <col id="0" translatable="yes">Romanian (ISO-8859-16)</col>
-      </row>
     </data>
   </object>
   <object class="GtkImage" id="close_img13">
@@ -27065,6 +27062,7 @@ Coordinates</property>
   <object class="GtkWindow" id="barge_window">
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Exult Barge</property>
+    <signal name="delete-event" handler="gtk_widget_hide" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox40">
         <property name="visible">True</property>
@@ -28756,6 +28754,7 @@ will be added automatically</property>
     <property name="title" translatable="yes">Set Game Information</property>
     <property name="modal">True</property>
     <property name="type-hint">dialog</property>
+    <signal name="delete-event" handler="gtk_widget_hide" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox115">
         <property name="visible">True</property>

--- a/mapedit/npcedit.cc
+++ b/mapedit/npcedit.cc
@@ -437,8 +437,8 @@ int ExultStudio::init_npc_window(
 	// Store address with window.
 	g_object_set_data(G_OBJECT(npcwin), "user_data", addr);
 	// Store name, ident, num.
-	const utf8Str utf8name(name.c_str());
-	set_entry("npc_name_entry", utf8name);
+	const std::string utf8name(convertToUTF8(name.c_str()));
+	set_entry("npc_name_entry", utf8name.c_str());
 	// (Not allowed to change npc#.).
 	set_entry("npc_num_entry", npc_num, true, false);
 	set_entry("npc_ident_entry", ident);
@@ -546,8 +546,7 @@ int ExultStudio::save_npc_window(
 	const int tx = -1;
 	const int ty = -1;
 	const int tz = -1;  // +++++For now.
-	const codepageStr locname(get_text_entry("npc_name_entry"));
-	const std::string name(locname);
+	const std::string name(convertFromUTF8(get_text_entry("npc_name_entry")));
 	const short npc_num = get_num_entry("npc_num_entry");
 	const short ident = get_num_entry("npc_ident_entry");
 	const int shape = get_num_entry("npc_shape");

--- a/mapedit/shapeedit.cc
+++ b/mapedit/shapeedit.cc
@@ -3254,8 +3254,8 @@ void ExultStudio::init_shape_notebook(
 		GtkTreeStore *store = GTK_TREE_STORE(model);
 		GtkTreeIter iter;
 		const Frame_name_info *first = nullptr;
-		const codepageStr locsname(get_text_entry("shinfo_name"));
-		const char *sname = locsname.get_str();
+		const string locsname(convertFromUTF8(get_text_entry("shinfo_name")));
+		const char *sname = locsname.c_str();
 		for (const auto &nmit : nmvec) {
 			if (nmit.is_invalid())
 				continue;
@@ -3269,14 +3269,14 @@ void ExultStudio::init_shape_notebook(
 			const int otype = type <= 0 ? -1 : (otmsg < 0 ? otmsg : 2);
 			const char *otmsgstr = otype == -255 ? sname :
 			                       (otype == -1 || otmsg >= get_num_misc_names() ? nullptr : get_misc_name(otmsg));
-			const utf8Str utf8msg(msgstr);
-			const utf8Str utf8otmsg(otmsgstr);
+			const string utf8msg(convertToUTF8(msgstr));
+			const string utf8otmsg(convertToUTF8(otmsgstr));
 			GdkPixbuf *nshape = shape_image(shpfile, shnum, nmit.get_frame(), true);
 			gtk_tree_store_append(store, &iter, nullptr);
 			gtk_tree_store_set(store, &iter, FNAME_FRAME, nmit.get_frame(),
 			                   FNAME_QUALITY, nmit.get_quality(), FNAME_MSGTYPE, type,
-			                   FNAME_MSGSTR, utf8msg.get_str(), FNAME_OTHERTYPE, otype,
-			                   FNAME_OTHERMSG, utf8otmsg.get_str(), FNAME_FROM_PATCH, nmit.from_patch(),
+			                   FNAME_MSGSTR, utf8msg.c_str(), FNAME_OTHERTYPE, otype,
+			                   FNAME_OTHERMSG, utf8otmsg.c_str(), FNAME_FROM_PATCH, nmit.from_patch(),
 			                   FNAME_MODIFIED, nmit.was_modified(),
 			                   FNAME_SHAPE_IMAGE, nshape, -1);
 			if (nshape) {
@@ -3298,10 +3298,10 @@ void ExultStudio::init_shape_notebook(
 			const int otype = type <= 0 ? -1 : (otmsg < 0 ? otmsg : 2);
 			const char *otmsgstr = otype == -255 ? sname :
 			                       (otype == -1 || otmsg >= get_num_misc_names() ? "" : get_misc_name(otmsg));
-			const utf8Str utf8msg(msgstr);
-			const utf8Str utf8otmsg(otmsgstr);
+			const string utf8msg(convertToUTF8(msgstr));
+			const string utf8otmsg(convertToUTF8(otmsgstr));
 			Set_framenames_fields(first->get_frame(), first->get_quality(),
-			                      type, utf8msg, otype, utf8otmsg);
+			                      type, utf8msg.c_str(), otype, utf8otmsg.c_str());
 		} else
 			Set_framenames_fields();
 	} else
@@ -3507,10 +3507,10 @@ struct Update_framenames {
 private:
 	int Find_name_id(const char *msg) {
 		ExultStudio *studio = ExultStudio::get_instance();
-		const codepageStr locmsg(msg);
-		const int idnum = studio->find_misc_name(locmsg);
+		const string locmsg(convertFromUTF8(msg));
+		const int idnum = studio->find_misc_name(locmsg.c_str());
 		if (idnum < 0)
-			return studio->add_misc_name(locmsg);
+			return studio->add_misc_name(locmsg.c_str());
 		return idnum;
 	}
 public:
@@ -4357,8 +4357,8 @@ void ExultStudio::open_shape_window(
 	set_spin("shinfo_frameflags_frame_num", 0, nframes - 1);
 	set_spin("shinfo_frameusecode_frame_num", 0, nframes - 1);
 	// Store name, #frames.
-	const utf8Str utf8shname(shname ? shname : "");
-	set_entry("shinfo_name", utf8shname);
+	const string utf8shname(convertToUTF8(shname ? shname : ""));
+	set_entry("shinfo_name", utf8shname.c_str());
 //	set_spin("shinfo_num_frames", nframes);
 	// Show xright, ybelow.
 	Shape_frame *shape = ifile->get_shape(shnum, frnum);
@@ -4688,8 +4688,8 @@ void ExultStudio::save_shape_window(
 	                      g_object_get_data(G_OBJECT(shapewin), "file_info"));
 	Vga_file *ifile = file_info->get_ifile();
 	if (info) {         // If 'shapes.vga', get name.
-		const codepageStr locnm(get_text_entry("shinfo_name"));
-		const gchar *nm = locnm.get_str();
+		const string locnm(convertFromUTF8(get_text_entry("shinfo_name")));
+		const gchar *nm = locnm.c_str();
 		if (!nm)
 			nm = "";
 		const char *oldname = get_shape_name(shnum);

--- a/mapedit/shapefile.cc
+++ b/mapedit/shapefile.cc
@@ -254,7 +254,7 @@ bool Npcs_file_info::read_npc(unsigned num) {
 	npcs[num].shapenum = Read2(newptr); // -1 if unused.
 	if (npcs[num].shapenum >= 0) {
 		npcs[num].unused = (*newptr++ != 0);
-		const utf8Str utf8name(reinterpret_cast<const char *>(newptr));
+		const string utf8name(convertToUTF8(reinterpret_cast<const char *>(newptr)));
 		npcs[num].name = utf8name;
 	} else {
 		npcs[num].unused = true;
@@ -306,7 +306,7 @@ void Npcs_file_info::setup(
 		npcs[i].shapenum = Read2(newptr);   // -1 if unused.
 		if (npcs[i].shapenum >= 0) {
 			npcs[i].unused = (*newptr++ != 0);
-			const utf8Str utf8name(reinterpret_cast<const char *>(newptr));
+			const string utf8name(convertToUTF8(reinterpret_cast<const char *>(newptr)));
 			npcs[i].name = utf8name;
 		} else {
 			npcs[i].unused = true;

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -1347,7 +1347,7 @@ void Shape_chooser::import_all_frames(
 	const int shnum = chooser->info[chooser->selected].shapenum;
 	const int len = strlen(fname);
 	// Ensure we have a valid file name.
-	std::string file = fname;
+	string file = fname;
 	if (file[len - 4] == '.')
 		file[len - 6] = 0;
 	chooser->import_all_pngs(file.c_str(), shnum);
@@ -2156,11 +2156,11 @@ void Shape_chooser::search(
 	int i;
 	start += dir;
 	const int stop = dir == -1 ? -1 : static_cast<int>(info.size());
-	const codepageStr srch(search);
+	const string srch(convertFromUTF8(search));
 	for (i = start; i != stop; i += dir) {
 		const int shnum = info[i].shapenum;
 		const char *nm = studio->get_shape_name(shnum);
-		if (nm && search_name(nm, srch))
+		if (nm && search_name(nm, srch.c_str()))
 			break;      // Found it.
 		const Shape_info &info = shapes_file->get_info(shnum);
 		if (info.has_frame_name_info()) {
@@ -2172,7 +2172,7 @@ void Shape_chooser::search(
 				if (type == -255 || type == -1 || msgid >= get_num_misc_names()
 				        || !get_misc_name(msgid))
 					continue;   // Keep looking.
-				if (search_name(get_misc_name(msgid), srch)) {
+				if (search_name(get_misc_name(msgid), srch.c_str())) {
 					found = true;
 					break;      // Found it.
 				}
@@ -2450,10 +2450,10 @@ void Shape_chooser::update_statusbar(
 		if (shapes_file) {
 			const char *nm;
 			if ((nm = studio->get_shape_name(shapenum))) {
-				const utf8Str utf8nm(nm);
+				const string utf8nm(convertToUTF8(nm));
 				const int len = strlen(buf);
 				g_snprintf(buf + len, sizeof(buf) - len,
-				           ":  '%s'", utf8nm.get_str());
+				           ":  '%s'", utf8nm.c_str());
 			}
 			if (shapes_file->read_info(studio->get_game_type(), true))
 				studio->set_shapeinfo_modified();
@@ -2490,14 +2490,14 @@ void Shape_chooser::update_statusbar(
 							prefix = msgstr;
 							suffix = otmsgstr;
 						}
-						const utf8Str utf8prf(prefix);
-						const utf8Str utf8suf(suffix);
+						const string utf8prf(convertToUTF8(prefix));
+						const string utf8suf(convertToUTF8(suffix));
 						g_snprintf(buf + len, sizeof(buf) - len,
-						           "  -  '%s%s'", utf8prf.get_str(), utf8suf.get_str());
+						           "  -  '%s%s'", utf8prf.c_str(), utf8suf.c_str());
 					} else {
-						const utf8Str utf8msg(msgstr);
+						const string utf8msg(convertToUTF8(msgstr));
 						g_snprintf(buf + len, sizeof(buf) - len,
-						           "  -  '%s'", utf8msg.get_str());
+						           "  -  '%s'", utf8msg.c_str());
 					}
 				}
 			}

--- a/mapedit/studio.h
+++ b/mapedit/studio.h
@@ -456,49 +456,16 @@ inline int ZoomGet() {
 	return (ExultStudio::get_instance()->get_shape_scale());
 }
 
-class convertToUTF8 {
-private:
-	void convert(gchar *&_convstr, const char *str, const char *enc);
-public:
-	void operator()(gchar *&_convstr, const char *str, const char *enc) {
-		convert(_convstr, str, enc);
-	}
-};
-
-class convertFromUTF8 {
-private:
-	void convert(gchar *&_convstr, const char *str, const char *enc);
-public:
-	void operator()(gchar *&_convstr, const char *str, const char *enc) {
-		convert(_convstr, str, enc);
-	}
-};
-
-template <class T>
-class strCodepageConvert {
-protected:
-	gchar *_convstr;
-	T Convert;
-public:
-	strCodepageConvert(const char *str) {
-		Convert(_convstr, str, ExultStudio::get_instance()->get_encoding().c_str());
-	}
-	strCodepageConvert(const char *str, const char *enc) {
-		Convert(_convstr, str, enc);
-	}
-	~strCodepageConvert() {
-		if (_convstr) g_free(_convstr);
-	}
-	const char *get_str() const {
-		return _convstr ? reinterpret_cast<const char *>(_convstr) : "";
-	}
-	operator const char *() const {
-		return get_str();
-	}
-};
-
-using utf8Str = strCodepageConvert<convertToUTF8>;
-using codepageStr = strCodepageConvert<convertFromUTF8>;
+std::string          convertToUTF8(const char *src_str, const char *enc);
+inline std::string   convertToUTF8(const char *src_str) {
+	return   convertToUTF8(src_str,
+	                       ExultStudio::get_instance()->get_encoding().c_str());
+}
+std::string        convertFromUTF8(const char *src_str, const char *enc);
+inline std::string convertFromUTF8(const char *src_str) {
+	return convertFromUTF8(src_str,
+	                       ExultStudio::get_instance()->get_encoding().c_str());
+}
 
 struct ExultRgbCmap {
 	guint32 colors[256];


### PR DESCRIPTION
  Commit 1 of 1
    .github/workflows/ci-linux.yml + ci-macos/yml + ci-windows.yml
      Add the ICU to the required components
    Makefile.mingw + configure.ac + mapedit/Makefile.am
      Add the ICU CFLAGS and LIBS to the build of Studio
    mapedit/exult_studio.glade
      Fix two windows that closed badly whex clicked on the cross
      Remove the not supported ISO-8859-16
    mapedit/npcedit.cc + shapeedit.cc + shapefile.cc + shapelst.cc
      Use the explicit conversion function, avoid string replicas
    mapedit/studio.h
      Replace the scaffolding classes utf8Str and codepageStr
        by explicit conversion functions
    mapedit/studio.cc [ the only source with ICU includes ]
      Implement the conversion functions, no longer any retry
      Use std::string as result