### PR TITLE
Remove trailing zero from Drag and Drop file name

### DIFF
--- a/shapes/u7drag.cc
+++ b/shapes/u7drag.cc
@@ -69,8 +69,8 @@ int Store_u7_shapeid(
     int shape,            // 0-0xffff.
     int frame             // 0-0xff.
 ) {
-	return 1 + snprintf(reinterpret_cast<char *>(data), U7DND_DATA_LENGTH(3),
-	                    FILE_URI "/%s.%d.%d.%d", U7_TARGET_SHAPEID_NAME, file, shape, frame);
+	return snprintf(reinterpret_cast<char *>(data), U7DND_DATA_LENGTH(3),
+	                FILE_URI "/%s.%d.%d.%d", U7_TARGET_SHAPEID_NAME, file, shape, frame);
 }
 
 /*
@@ -107,8 +107,8 @@ int Store_u7_chunkid(
     unsigned char *data,
     int cnum              // 0-0xffff.
 ) {
-	return 1 + snprintf(reinterpret_cast<char *>(data), U7DND_DATA_LENGTH(1),
-	                    FILE_URI "/%s.%d", U7_TARGET_CHUNKID_NAME, cnum);
+	return snprintf(reinterpret_cast<char *>(data), U7DND_DATA_LENGTH(1),
+	                FILE_URI "/%s.%d", U7_TARGET_CHUNKID_NAME, cnum);
 }
 
 /*
@@ -143,8 +143,8 @@ int Store_u7_npcid(
     unsigned char *data,
     int npcnum            // 0-0xffff.
 ) {
-	return 1 + snprintf(reinterpret_cast<char *>(data), U7DND_DATA_LENGTH(1),
-	                    FILE_URI "/%s.%d", U7_TARGET_NPCID_NAME, npcnum);
+	return snprintf(reinterpret_cast<char *>(data), U7DND_DATA_LENGTH(1),
+	                FILE_URI "/%s.%d", U7_TARGET_NPCID_NAME, npcnum);
 }
 
 /*
@@ -193,7 +193,7 @@ int Store_u7_comboid(
 		                     ".%d.%d.%d.%d.%d",
 		                     ents[i].tx, ents[i].ty, ents[i].tz, ents[i].shape, ents[i].frame);
 	}
-	return ptr + 1 - data;
+	return ptr - data;
 }
 
 /*


### PR DESCRIPTION
This fixes issue #390 
=> BackPorted from exult-sdl3 branch

  Commit 1 of 1 :
    shapes/u7drag.cc
      Shape, Chunk, Npc, Combo : Remove trailing zero from encoded size