### PR TITLE
Fix <DATA> spurious override in Studio, find properly exult_studio.glade

### DIFF
--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -747,8 +747,7 @@ ExultStudio::ExultStudio(int argc, char **argv): glade_path(nullptr),
 		datastr = get_system_path("<BUNDLE>");
 	} else
 #endif
-	config->value("config/disk/data_path", datastr, EXULT_DATADIR);
-	add_system_path("<DATA>", datastr);
+	datastr = get_system_path("<DATA>");
 
 	if (!xmldir)
 		xmldir = datastr.c_str();


### PR DESCRIPTION
1. Studio sets `<DATA>` two times, the first one is correct with `setup_data_dir`, the second one overrides it improperly with the default or config path. Remove that second setting.

2. Obtain the current `<DATA>` to find `exult_studio.glade`.

Discussion in issue #408 
