### PR TITLE
Silence more compiler warnings

### DIFF
--- a/audio/Audio.h
+++ b/audio/Audio.h
@@ -26,6 +26,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/audio/AudioMixer.cc
+++ b/audio/AudioMixer.cc
@@ -27,6 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/audio/OggAudioSample.cc
+++ b/audio/OggAudioSample.cc
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/audio/OggAudioSample.h
+++ b/audio/OggAudioSample.h
@@ -19,7 +19,15 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define OggAudioSample_H
 
 #include "AudioSample.h"
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif    // __GNUC__
 #include <vorbis/vorbisfile.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 #include <memory>
 
 namespace Pentagram {

--- a/audio/WavAudioSample.cc
+++ b/audio/WavAudioSample.cc
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/audio/midi_drivers/LowLevelMidiDriver.h
+++ b/audio/midi_drivers/LowLevelMidiDriver.h
@@ -33,6 +33,7 @@ class XMidiSequence;
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/audio/midi_drivers/MT32EmuMidiDriver.h
+++ b/audio/midi_drivers/MT32EmuMidiDriver.h
@@ -24,11 +24,22 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "LowLevelMidiDriver.h"
 
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wundef"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#	if defined(__llvm__) || defined(__clang__)
+#		pragma GCC diagnostic ignored "-Wmacro-redefined"
+#	endif
+#endif    // __GNUC__
 #ifdef __IPHONEOS__
 	#include <mt32emu.h>
 #else
 	#include <mt32emu/mt32emu.h>
 #endif
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 namespace MT32Emu {
 	class Synth;

--- a/audio/midi_drivers/timidity/timidity.cpp
+++ b/audio/midi_drivers/timidity/timidity.cpp
@@ -427,7 +427,7 @@ void Timidity_DeInit()
 }
 
 
-char timidity_error[1024] = "";
+char timidity_error[TIMIDITY_ERROR_SIZE] = "";
 char *Timidity_Error()
 {
 	return timidity_error;

--- a/audio/midi_drivers/timidity/timidity.h
+++ b/audio/midi_drivers/timidity/timidity.h
@@ -32,6 +32,8 @@ namespace NS_TIMIDITY {
 
 struct MidiSong;
 
+#define TIMIDITY_ERROR_SIZE	1024
+
 //extern int Timidity_Init(int rate, int format, int channels, int samples);
 extern char *Timidity_Error();
 extern void Timidity_SetVolume(int volume);

--- a/audio/midi_drivers/timidity/timidity_sdl_c.cpp
+++ b/audio/midi_drivers/timidity/timidity_sdl_c.cpp
@@ -108,7 +108,7 @@ static int cmsg(int type, int verbosity_level, const char *fmt, ...)
 	    ctl.verbosity<verbosity_level)
 		return 0;
 	va_start(ap, fmt);
-	vsprintf(timidity_error, fmt, ap);
+	vsnprintf(timidity_error, TIMIDITY_ERROR_SIZE, fmt, ap);
 	va_end(ap);
 	//perr.printf ("%s\n", timidity_error);
 	return 0;

--- a/audio/soundtest.cc
+++ b/audio/soundtest.cc
@@ -23,6 +23,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/browser.cc
+++ b/browser.cc
@@ -23,6 +23,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/cheat.cc
+++ b/cheat.cc
@@ -32,6 +32,7 @@ using std::setfill;
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/configure.ac
+++ b/configure.ac
@@ -673,14 +673,14 @@ if test x$enable_exult_studio = xyes; then
 # Gtk
 	PKG_CHECK_MODULES(GTK, gtk+-3.0 >= 3.16, have_gtk=yes, have_gtk=no)
 # Freetype2 (optional, used in ExultStudio, shapes/fontgen.cc)
-	AC_PATH_PROG(FT2CONFIG, freetype-config)
-	if test -n "$FT2CONFIG"; then
-		FREETYPE2_LIBS=`$FT2CONFIG --libs`
+	PKG_CHECK_MODULES(CHKFREETYPE, freetype2, chk_freetype=yes, chk_freetype=no)
+	if test x$chk_freetype = xyes; then
+		FREETYPE2_LIBS=`$PKG_CONFIG --libs freetype2`
 		SAVED_LDFLAGS="$LDFLAGS"
 		LDFLAGS="$LDFLAGS $FREETYPE2_LIBS"
 		AC_CHECK_FUNC(FT_Init_FreeType, have_freetype=yes, have_freetype=no)
 		LDFLAGS="$SAVED_LDFLAGS"
-		FREETYPE2_INCLUDES=`$FT2CONFIG --cflags`
+		FREETYPE2_INCLUDES=`$PKG_CONFIG --cflags freetype2`
 		if test x$have_freetype = xyes; then
 			AC_DEFINE(HAVE_FREETYPE2, 1, [Have freetype2])
 		else
@@ -1140,7 +1140,7 @@ CHK_WARN="$CHK_WARN -Wtrigraphs -Wundef -Wuninitialized -Wuseless-cast -Wwrite-s
 #CHK_WARN="$CHK_WARN -Wsuggest-final-methods -Wsuggest-final-types -Wsuggest-override -Wzero-as-null-pointer-constant"
 CHK_WARN="$CHK_WARN -Wzero-as-null-pointer-constant"
 # Clang warnings
-CHK_WARN="$CHK_WARN -Wunused-const-variables -Wabsolute-value -Wdeprecated-register -Wmismatched-tags -Wunused-private-field"
+CHK_WARN="$CHK_WARN -Wunused-const-variables -Wabsolute-value -Wdeprecated -Wdeprecated-register -Wmismatched-tags -Wunused-private-field"
 
 # Eliminate some spurious warnings due to low optimization level.
 if test x$opt_level = xnone -o x$opt_level = xdebug; then

--- a/effects.cc
+++ b/effects.cc
@@ -44,6 +44,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/exult.cc
+++ b/exult.cc
@@ -33,6 +33,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 static const Uint32 EXSDL_TOUCH_MOUSEID=SDL_TOUCH_MOUSEID;

--- a/files/sdlrwopsstreambuf.cc
+++ b/files/sdlrwopsstreambuf.cc
@@ -21,6 +21,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/flic/playfli.cc
+++ b/flic/playfli.cc
@@ -38,6 +38,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/gamemgr/bggame.cc
+++ b/gamemgr/bggame.cc
@@ -1060,41 +1060,42 @@ void BG_Game::scene_guardian() {
 }
 
 namespace {//anonymous
+
+enum HandlerScriptOps {
+	eNOP,                   // Does nothing except redraw static if needed
+	eHAND_HIT,              // Move hand to frame 3, and redraw static if needed
+	eHAND_RECOIL,           // Decrement hand frame, and redraw static if needed
+	eBLACK_SCREEN,          // Draw black screen
+	eSHOW_STATIC,           // Draw static
+	eFLASH_FAKE_TITLE,      // Draw fake title screen for 1 frame, then revert to black screen
+	eSHOW_FAKE_TITLE,       // Draw fake title screen permanently
+};
+
+static constexpr const HandlerScriptOps HandlerScript[] = {
+	eHAND_HIT        ,
+	eBLACK_SCREEN    ,
+	eSHOW_FAKE_TITLE ,
+	eSHOW_STATIC     , eHAND_RECOIL     ,
+	eNOP             , eHAND_RECOIL     ,
+	eNOP             , eHAND_RECOIL     ,
+	eBLACK_SCREEN    ,
+	eHAND_HIT        ,
+	eNOP             ,
+	eSHOW_FAKE_TITLE ,
+	eSHOW_STATIC     , eHAND_RECOIL     ,
+	eNOP             , eHAND_RECOIL     ,
+	eNOP             , eHAND_RECOIL     ,
+	eBLACK_SCREEN    ,
+	eHAND_HIT        ,
+	eNOP             ,
+	eFLASH_FAKE_TITLE, eHAND_RECOIL     ,
+	eFLASH_FAKE_TITLE, eHAND_RECOIL     ,
+	eFLASH_FAKE_TITLE, eHAND_RECOIL     ,
+	eSHOW_FAKE_TITLE
+};
+
 class Hand_Handler {
 private:
-	enum HandlerScriptOps {
-		eNOP,                   // Does nothing except redraw static if needed
-		eHAND_HIT,              // Move hand to frame 3, and redraw static if needed
-		eHAND_RECOIL,           // Decrement hand frame, and redraw static if needed
-		eBLACK_SCREEN,          // Draw black screen
-		eSHOW_STATIC,           // Draw static
-		eFLASH_FAKE_TITLE,      // Draw fake title screen for 1 frame, then revert to black screen
-		eSHOW_FAKE_TITLE,       // Draw fake title screen permanently
-	};
-
-	static constexpr const HandlerScriptOps HandlerScript[] = {
-		eHAND_HIT        ,
-		eBLACK_SCREEN    ,
-		eSHOW_FAKE_TITLE ,
-		eSHOW_STATIC     , eHAND_RECOIL     ,
-		eNOP             , eHAND_RECOIL     ,
-		eNOP             , eHAND_RECOIL     ,
-		eBLACK_SCREEN    ,
-		eHAND_HIT        ,
-		eNOP             ,
-		eSHOW_FAKE_TITLE ,
-		eSHOW_STATIC     , eHAND_RECOIL     ,
-		eNOP             , eHAND_RECOIL     ,
-		eNOP             , eHAND_RECOIL     ,
-		eBLACK_SCREEN    ,
-		eHAND_HIT        ,
-		eNOP             ,
-		eFLASH_FAKE_TITLE, eHAND_RECOIL     ,
-		eFLASH_FAKE_TITLE, eHAND_RECOIL     ,
-		eFLASH_FAKE_TITLE, eHAND_RECOIL     ,
-		eSHOW_FAKE_TITLE
-	};
-
 	Image_window8 *win;
 	Shape_manager *sman;
 	std::unique_ptr<Shape_file> handshp;
@@ -1139,8 +1140,6 @@ public:
 		backup.reset();
 	}
 };
-
-constexpr const Hand_Handler::HandlerScriptOps Hand_Handler::HandlerScript[];
 
 bool Hand_Handler::draw_frame() {
 	if (scriptPosition >= array_size(HandlerScript)) {

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -806,10 +806,10 @@ void Game_window::locate_npc(
 	char msg[80];
 	Actor *npc = get_npc(npc_num);
 	if (!npc) {
-		snprintf(msg, 80, "NPC %d does not exist.", npc_num);
+		snprintf(msg, sizeof(msg), "NPC %d does not exist.", npc_num);
 		effects->center_text(msg);
 	} else if (npc->is_pos_invalid()) {
-		snprintf(msg, 80, "NPC %d is not on the map.", npc_num);
+		snprintf(msg, sizeof(msg), "NPC %d is not on the map.", npc_num);
 		effects->center_text(msg);
 	} else {
 		// ++++WHAT IF on a different map???
@@ -817,7 +817,7 @@ void Game_window::locate_npc(
 		center_view(pos);
 		cheat.clear_selected();
 		cheat.append_selected(npc);
-		snprintf(msg, 80, "NPC %d: '%s'.", npc_num,
+		snprintf(msg, sizeof(msg), "NPC %d: '%s'.", npc_num,
 		         npc->get_npc_name().c_str());
 		const int above = pos.tz + npc->get_info().get_3d_height() - 1;
 		if (skip_above_actor > above)
@@ -878,7 +878,7 @@ void Game_window::resized(
 	// Do the following only if in game (not for menus)
 	if (!gump_man->gump_mode()) {
 		char msg[80];
-		snprintf(msg, 80, "%ux%ux%u", neww, newh, newsc);
+		snprintf(msg, sizeof(msg), "%ux%ux%u", neww, newh, newsc);
 		effects->center_text(msg);
 	}
 	if(g_shortcutBar)
@@ -2094,9 +2094,8 @@ void Game_window::show_items(
 	        (npc->get_npc_num() > 0 || npc == main_actor)) {
 		char str[64];
 		const std::string namestr = Get_object_name(obj);
-		snprintf(str, sizeof(str)-1, "(%i) %s", npc->get_npc_num(),
+		snprintf(str, sizeof(str), "(%i) %s", npc->get_npc_num(),
 		         namestr.c_str());
-		str[sizeof(str)-1] = 0;
 		effects->add_text(str, obj);
 	} else if (obj) {
 		// Show name.
@@ -2108,9 +2107,8 @@ void Game_window::show_items(
 		// Combat and an NPC?
 		if (in_combat() && Combat::mode != Combat::original && npc) {
 			char buf[128];
-			snprintf(buf, sizeof(buf)-1, " (%d)",
+			snprintf(buf, sizeof(buf), " (%d)",
 			        npc->get_property(Actor::health));
-			buf[sizeof(buf)-1] = 0;
 			namestr += buf;
 		}
 		effects->add_text(namestr.c_str(), obj);
@@ -2118,9 +2116,8 @@ void Game_window::show_items(
 		// Show flat, but not when editing ter.
 		const ShapeID id = get_flat(x, y);
 		char str[20];
-		snprintf(str, sizeof(str)-1, "Flat %d:%d",
+		snprintf(str, sizeof(str), "Flat %d:%d",
 		         id.get_shapenum(), id.get_framenum());
-		str[sizeof(str)-1] = 0;
 		effects->add_text(str, x, y);
 	}
 	// If it's an actor and we want to grab the actor, grab it.

--- a/gumps/AudioOptions_gump.cc
+++ b/gumps/AudioOptions_gump.cc
@@ -22,6 +22,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/gumps/File_gump.cc
+++ b/gumps/File_gump.cc
@@ -26,6 +26,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/gumps/GameDisplayOptions_gump.cc
+++ b/gumps/GameDisplayOptions_gump.cc
@@ -26,6 +26,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/gumps/GameEngineOptions_gump.cc
+++ b/gumps/GameEngineOptions_gump.cc
@@ -26,6 +26,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/gumps/Gump_manager.h
+++ b/gumps/Gump_manager.h
@@ -27,6 +27,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/gumps/InputOptions_gump.cc
+++ b/gumps/InputOptions_gump.cc
@@ -26,6 +26,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/gumps/ShortcutBar_gump.h
+++ b/gumps/ShortcutBar_gump.h
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/gumps/Spellbook_gump.cc
+++ b/gumps/Spellbook_gump.cc
@@ -23,6 +23,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/gumps/VideoOptions_gump.cc
+++ b/gumps/VideoOptions_gump.cc
@@ -29,6 +29,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__
@@ -206,9 +207,7 @@ void VideoOptions_gump::rebuild_dynamic_buttons() {
 		// the text arrays is freed by the destructor of the button
 		std::vector<std::string> scalingtext;
 		for (int i = 0; i < num_scales; i++) {
-			char buf[10];
-			snprintf(buf, sizeof(buf), "x%d", i + 1);
-			scalingtext.emplace_back(buf);
+			scalingtext.push_back('x' + std::to_string(i + 1));
 		}
 		buttons[id_scaling] = std::make_unique<VideoTextToggle>(this, &VideoOptions_gump::toggle_scaling,
 		        std::move(scalingtext), scaling, colx[2], rowy[4], 74);

--- a/gumps/Yesno_gump.cc
+++ b/gumps/Yesno_gump.cc
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/gumps/gump_utils.h
+++ b/gumps/gump_utils.h
@@ -24,6 +24,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -46,6 +46,7 @@ Boston, MA  02111-1307, USA.
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -37,6 +37,7 @@ Boston, MA  02111-1307, USA.
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/imagewin/iwin8.cc
+++ b/imagewin/iwin8.cc
@@ -34,6 +34,7 @@ Boston, MA  02111-1307, USA.
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/imagewin/manip.h
+++ b/imagewin/manip.h
@@ -23,6 +23,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/imagewin/save_screenshot.cc
+++ b/imagewin/save_screenshot.cc
@@ -38,6 +38,7 @@ It has been partly rewritten to use an SDL surface as input.
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/imagewin/scale_hq2x.cc
+++ b/imagewin/scale_hq2x.cc
@@ -28,6 +28,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/keys.cc
+++ b/keys.cc
@@ -23,6 +23,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/keys.h
+++ b/keys.h
@@ -22,6 +22,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -71,8 +71,15 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <cstdlib>
 #include <memory>
 
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif    // __GNUC__
 #include <unicode/ucnv.h>
 #include <unicode/ucnv_cb.h>
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 using std::cerr;
 using std::cout;

--- a/menulist.h
+++ b/menulist.h
@@ -26,6 +26,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 static const Uint32 EXSDL_TOUCH_MOUSEID=SDL_TOUCH_MOUSEID;

--- a/mouse.cc
+++ b/mouse.cc
@@ -25,6 +25,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/npcnear.cc
+++ b/npcnear.cc
@@ -38,6 +38,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/palette.cc
+++ b/palette.cc
@@ -35,6 +35,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/schedule.cc
+++ b/schedule.cc
@@ -25,6 +25,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/server/server.cc
+++ b/server/server.cc
@@ -81,6 +81,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/touchui.h
+++ b/touchui.h
@@ -24,6 +24,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/tqueue.cc
+++ b/tqueue.cc
@@ -28,6 +28,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__

--- a/txtscroll.cc
+++ b/txtscroll.cc
@@ -34,6 +34,7 @@
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <SDL.h>
 #ifdef __GNUC__


### PR DESCRIPTION
- audio/midi_drivers/timidity_sdl_c.cpp + timidity.h + .cpp : Replace the last (v)sprintf by a (v)snprintf,
- configure.ac : Rework the failing FreeType2 installation check, made Gen_shadow useless, Enable -Wdeprecated,
- gamemgr/bggame.cc : Remove a declaration duplicated [ spotted by -Wdeprecated ],
- pathfinder/Pathfinder.h : Fix a new C++ deprecated warning [ -Wdeprecated ]. @marzojr I am not sure of this fix, would you please review it ?
- many with #include <SDL.h> : Silent -Wzero-as-null-pointer-constant,
- gamewin.cc : Replace some hardcoded string size by sizeof, Remove useless store of zero at end of sprintf because snprintf always provides a ( possibly truncated ) zero terminated string,
- gumps/VideoOptions_gump.cc : Enlarge a sprintf target string to ensure it has space enough.
- audio/OggAudioSample.h : Silence Vorbis warnings
- audio/midi_drivers/MT32EmuMidiDriver.h : Silence MT32Emu warnings
- mapedit/Studio.cc : Silence ICU warnings

For issues #394 and #416 