### PR TITLE
Normalize all (v)snprintf, Silence macOS over ICU

### DIFF
--- a/audio/Midi.cc
+++ b/audio/Midi.cc
@@ -766,7 +766,7 @@ bool MyMidiPlayer::ogg_play_track(const std::string& filename, int num, bool rep
 		else if (filename == MAINMUS || filename == MAINMUS_AD)
 			{
 			char outputstr[255];
-			snprintf(outputstr, 255, "%02dbg.ogg", num);
+			snprintf(outputstr, sizeof(outputstr), "%02dbg.ogg", num);
 			ogg_name = outputstr;
 			}
 		else if (filename == EXULT_BG_FLX)
@@ -796,7 +796,7 @@ bool MyMidiPlayer::ogg_play_track(const std::string& filename, int num, bool rep
 			else
 				{
 				char outputstr[255];
-				snprintf(outputstr, 255, "%02dsi.ogg", num);
+				snprintf(outputstr, sizeof(outputstr), "%02dsi.ogg", num);
 				ogg_name = outputstr;
 				}
 			}
@@ -808,7 +808,7 @@ bool MyMidiPlayer::ogg_play_track(const std::string& filename, int num, bool rep
 	else
 		{
 		char outputstr[255];
-		snprintf(outputstr, 255, "%02dmus.ogg", num);
+		snprintf(outputstr, sizeof(outputstr), "%02dmus.ogg", num);
 		ogg_name = outputstr;
 		basepath = "<STATIC>/music/";
 		}

--- a/audio/midi_drivers/XMidiFile.cpp
+++ b/audio/midi_drivers/XMidiFile.cpp
@@ -1349,7 +1349,7 @@ int XMidiFile::ExtractTracks (IDataSource *source)
 	VolumeCurve.set_gamma (atof(s.c_str()));
 	const int igam = std::lround(VolumeCurve.get_gamma()*10000);
 	char buf[32];
-	snprintf (buf, 32, "%d.%04d", igam/10000, igam%10000);
+	snprintf (buf, sizeof(buf), "%d.%04d", igam/10000, igam%10000);
 	config->set("config/audio/midi/volume_curve",buf,true);
 
 	// Read first 4 bytes of header

--- a/audio/midi_drivers/timidity/timidity_common.cpp
+++ b/audio/midi_drivers/timidity/timidity_common.cpp
@@ -34,7 +34,6 @@
 #include "timidity_common.h"
 #include "timidity_output.h"
 #include "timidity_controls.h"
-#include "array_size.h"
 #include "ignore_unused_variable_warning.h"
 
 #ifdef NS_TIMIDITY
@@ -105,7 +104,7 @@ static FILE *try_to_open(char *name, int decompress, int noise_mode)
 			}
 			*cp2=0;
 
-			snprintf(tmp, array_size(tmp), *(dec+1), tmp2);
+			snprintf(tmp, sizeof(tmp), *(dec+1), tmp2);
 			return popen(tmp, "r");
 		}
 	}

--- a/audio/soundtest.cc
+++ b/audio/soundtest.cc
@@ -101,7 +101,7 @@ void SoundTester::test_sound()
 			line += height;
 			font->paint_text_fixedwidth(ibuf, "    S - Stop Music", left, line, width);
 
-			snprintf (buf, 256, "%2s Music %c %3i %c %s",
+			snprintf (buf, sizeof(buf), "%2s Music %c %3i %c %s",
 					active==0?"->":"",
 					active==0?'<':' ',
 					song,
@@ -110,7 +110,7 @@ void SoundTester::test_sound()
 			line += height*2;
 			font->paint_text_fixedwidth(ibuf, buf, left, line, width);
 
-			snprintf (buf, 256, "%2s SFX   %c %3i %c",
+			snprintf (buf, sizeof(buf), "%2s SFX   %c %3i %c",
 					active==1?"->":"",
 						active==1?'<':' ',
 					sfx,
@@ -119,7 +119,7 @@ void SoundTester::test_sound()
 			line += height*2;
 			font->paint_text_fixedwidth(ibuf, buf, left, line, width);
 
-			snprintf (buf, 256, "%2s Voice %c %3i %c",
+			snprintf (buf, sizeof(buf), "%2s Voice %c %3i %c",
 					active==2?"->":"",
 					active==2?'<':' ',
 					voice,

--- a/browser.cc
+++ b/browser.cc
@@ -87,7 +87,7 @@ void ShapeBrowser::browse_shapes() {
 	char buf[255];
 	const char *fname;
 
-	snprintf(buf, 255, "files/shapes/%d", current_file);
+	snprintf(buf, sizeof(buf), "files/shapes/%d", current_file);
 	fname = game->get_resource(buf).str;
 	if (!shapes)
 		shapes = new Vga_file(fname);
@@ -99,13 +99,13 @@ void ShapeBrowser::browse_shapes() {
 	do {
 		if (redraw) {
 			gwin->clear_screen();
-			snprintf(buf, 255, "palettes/%d", current_palette);
+			snprintf(buf, sizeof(buf), "palettes/%d", current_palette);
 			const str_int_pair &pal_tuple = game->get_resource(buf);
-			snprintf(buf, 255, "palettes/patch/%d", current_palette);
+			snprintf(buf, sizeof(buf), "palettes/patch/%d", current_palette);
 			const str_int_pair &patch_tuple = game->get_resource(buf);
 			if (current_xform > 0) {
 				char xfrsc[256];
-				snprintf(xfrsc, 255, "xforms/%d",
+				snprintf(xfrsc, sizeof(xfrsc), "xforms/%d",
 				         current_xform);
 				const str_int_pair &xform_tuple = game->get_resource(xfrsc);
 				pal.load(pal_tuple.str, patch_tuple.str,
@@ -116,21 +116,21 @@ void ShapeBrowser::browse_shapes() {
 			pal.apply();
 			font->paint_text_fixedwidth(ibuf, "Show [K]eys", 2, maxy - 50, 8);
 
-			snprintf(buf, 255, "VGA File: '%s'", fname);
+			snprintf(buf, sizeof(buf), "VGA File: '%s'", fname);
 			//font->draw_text(ibuf, 0, 170, buf);
 			font->paint_text_fixedwidth(ibuf, buf, 2, maxy - 30, 8);
 
 			num_shapes = shapes->get_num_shapes();
-			snprintf(buf, 255, "Shape: %2d/%d", current_shape, num_shapes - 1);
+			snprintf(buf, sizeof(buf), "Shape: %2d/%d", current_shape, num_shapes - 1);
 			//font->draw_text(ibuf, 0, 180, buf);
 			font->paint_text_fixedwidth(ibuf, buf, 2, maxy - 20, 8);
 
 			num_frames = shapes->get_num_frames(current_shape);
-			snprintf(buf, 255, "Frame: %2d/%d", current_frame, num_frames - 1);
+			snprintf(buf, sizeof(buf), "Frame: %2d/%d", current_frame, num_frames - 1);
 			//font->draw_text(ibuf, 160, 180, buf);
 			font->paint_text_fixedwidth(ibuf, buf, 162, maxy - 20, 8);
 
-			snprintf(buf, 255, "Palette: %s, %d", pal_tuple.str, pal_tuple.num);
+			snprintf(buf, sizeof(buf), "Palette: %s, %d", pal_tuple.str, pal_tuple.num);
 			//font->draw_text(ibuf, 0, 190, buf);
 			font->paint_text_fixedwidth(ibuf, buf, 2, maxy - 10, 8);
 
@@ -139,14 +139,14 @@ void ShapeBrowser::browse_shapes() {
 				                         current_shape, current_frame);
 
 				if (frame) {
-					snprintf(buf, 255, "%d x %d", frame->get_width(), frame->get_height());
+					snprintf(buf, sizeof(buf), "%d x %d", frame->get_width(), frame->get_height());
 					//font->draw_text(ibuf, 32, 32, buf);
 					font->paint_text_fixedwidth(ibuf, buf, 2, 22, 8);
 
 					const Shape_info &info =
 					    ShapeID::get_info(current_shape);
 
-					snprintf(buf, 255, "class: %2i  ready_type: 0x%02x", info.get_shape_class(), info.get_ready_type());
+					snprintf(buf, sizeof(buf), "class: %2i  ready_type: 0x%02x", info.get_shape_class(), info.get_ready_type());
 					font->paint_text_fixedwidth(ibuf, buf, 2, 12, 8);
 
 					// TODO: do we want to display something other than
@@ -191,7 +191,7 @@ void ShapeBrowser::browse_shapes() {
 				current_shape = 0;
 				current_frame = 0;
 				delete shapes;
-				snprintf(buf, 255, "files/shapes/%d", current_file);
+				snprintf(buf, sizeof(buf), "files/shapes/%d", current_file);
 				fname = game->get_resource(buf).str;
 				shapes = new Vga_file(fname);
 				break;

--- a/cheat_screen.cc
+++ b/cheat_screen.cc
@@ -342,12 +342,12 @@ void CheatScreen::SharedPrompt(char *input, const Cheat_Prompt &mode) {
 		break;
 
 	case CP_XCoord:
-		snprintf(buf, 512, "Enter X Coord. Max %i (-1 to cancel)", c_num_tiles);
+		snprintf(buf, sizeof(buf), "Enter X Coord. Max %i (-1 to cancel)", c_num_tiles);
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, promptmes, 8);
 		break;
 
 	case CP_YCoord:
-		snprintf(buf, 512, "Enter Y Coord. Max %i (-1 to cancel)", c_num_tiles);
+		snprintf(buf, sizeof(buf), "Enter Y Coord. Max %i (-1 to cancel)", c_num_tiles);
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, promptmes, 8);
 		break;
 
@@ -357,7 +357,7 @@ void CheatScreen::SharedPrompt(char *input, const Cheat_Prompt &mode) {
 
 	case CP_GFlagNum: {
 		char buf[50];
-		snprintf(buf, 50, "Enter Global Flag 0-%d. (-1 to cancel)", c_last_gflag);
+		snprintf(buf, sizeof(buf), "Enter Global Flag 0-%d. (-1 to cancel)", c_last_gflag);
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, promptmes, 8);
 		break;
 	}
@@ -399,12 +399,12 @@ void CheatScreen::SharedPrompt(char *input, const Cheat_Prompt &mode) {
 		break;
 
 	case CP_HexXCoord:
-		snprintf(buf, 512, "Enter X Coord. Max %04x (-1 to cancel)", c_num_tiles);
+		snprintf(buf, sizeof(buf), "Enter X Coord. Max %04x (-1 to cancel)", c_num_tiles);
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, promptmes, 8);
 		break;
 
 	case CP_HexYCoord:
-		snprintf(buf, 512, "Enter Y Coord. Max %04x (-1 to cancel)", c_num_tiles);
+		snprintf(buf, sizeof(buf), "Enter Y Coord. Max %04x (-1 to cancel)", c_num_tiles);
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, promptmes, 8);
 		break;
 
@@ -618,19 +618,19 @@ void CheatScreen::NormalDisplay() {
 	font->paint_text_fixedwidth(ibuf, "Colourless' Advanced Option Cheat Screen", 0, offsety1, 8);
 
 	if (Game::get_game_type() == BLACK_GATE)
-		snprintf(buf, 512, "Running \"Ultima 7: The Black Gate\"");
+		snprintf(buf, sizeof(buf), "Running \"Ultima 7: The Black Gate\"");
 	else if (Game::get_game_type() == SERPENT_ISLE)
-		snprintf(buf, 512, "Running \"Ultima 7: Part 2: Serpent Isle\"");
+		snprintf(buf, sizeof(buf), "Running \"Ultima 7: Part 2: Serpent Isle\"");
 	else
-		snprintf(buf, 512, "Running Unknown Game Type %i", Game::get_game_type());
+		snprintf(buf, sizeof(buf), "Running Unknown Game Type %i", Game::get_game_type());
 
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, offsety1 + 18, 8);
 
-	snprintf(buf, 512, "Exult Version %s", VERSION);
+	snprintf(buf, sizeof(buf), "Exult Version %s", VERSION);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, offsety1 + 27, 8);
 
 
-	snprintf(buf, 512, "Current time: %i:%02i %s  Day: %i",
+	snprintf(buf, sizeof(buf), "Current time: %i:%02i %s  Day: %i",
 	         ((clock->get_hour() + 11) % 12) + 1,
 	         clock->get_minute(),
 	         clock->get_hour() < 12 ? "AM" : "PM",
@@ -639,16 +639,16 @@ void CheatScreen::NormalDisplay() {
 
 	const int longi = ((t.tx - 0x3A5) / 10);
 	const int lati = ((t.ty - 0x46E) / 10);
-	snprintf(buf, 512, "Coordinates %d %s %d %s, Map #%d",
+	snprintf(buf, sizeof(buf), "Coordinates %d %s %d %s, Map #%d",
 		abs(lati), (lati < 0 ? "North" : "South"),
 		abs(longi), (longi < 0 ? "West" : "East"), curmap);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, 63 - offsety2, 8);
 
-	snprintf(buf, 512, "Coords in hex (%04x, %04x, %02x)",
+	snprintf(buf, sizeof(buf), "Coords in hex (%04x, %04x, %02x)",
 	         t.tx, t.ty, t.tz);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, 72 - offsety2, 8);
 
-	snprintf(buf, 512, "Coords in dec (%04i, %04i, %02i)",
+	snprintf(buf, sizeof(buf), "Coords in dec (%04i, %04i, %02i)",
 	         t.tx, t.ty, t.tz);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, 81 - offsety2, 8);
 }
@@ -678,30 +678,30 @@ void CheatScreen::NormalMenu() {
 	// Paperdolls can be toggled in the gumps, no need here for small screens
 	Shape_manager *sman = Shape_manager::get_instance();
 	if (sman->can_use_paperdolls() && sman->are_paperdolls_enabled())
-		snprintf(buf, 512, "[P]aperdolls..: Yes");
+		snprintf(buf, sizeof(buf), "[P]aperdolls..: Yes");
 	else
-		snprintf(buf, 512, "[P]aperdolls..:  No");
+		snprintf(buf, sizeof(buf), "[P]aperdolls..:  No");
 	font->paint_text_fixedwidth(ibuf, buf, 0, maxy - 99, 8);
 #endif
 
 	// GodMode
-	snprintf(buf, 512, "[G]od Mode....: %3s", cheat.in_god_mode() ? "On" : "Off");
+	snprintf(buf, sizeof(buf), "[G]od Mode....: %3s", cheat.in_god_mode() ? "On" : "Off");
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 90, 8);
 
 	// Archwizzard Mode
-	snprintf(buf, 512, "[W]izard Mode.: %3s", cheat.in_wizard_mode() ? "On" : "Off");
+	snprintf(buf, sizeof(buf), "[W]izard Mode.: %3s", cheat.in_wizard_mode() ? "On" : "Off");
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 81, 8);
 
 	// Infravision
-	snprintf(buf, 512, "[I]nfravision.: %3s", cheat.in_infravision() ? "On" : "Off");
+	snprintf(buf, sizeof(buf), "[I]nfravision.: %3s", cheat.in_infravision() ? "On" : "Off");
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 72, 8);
 
 	// Hackmover
-	snprintf(buf, 512, "[H]ack Mover..: %3s", cheat.in_hack_mover() ? "Yes" : "No");
+	snprintf(buf, sizeof(buf), "[H]ack Mover..: %3s", cheat.in_hack_mover() ? "Yes" : "No");
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 63, 8);
 
 	// Eggs
-	snprintf(buf, 512, "[E]ggs Visible: %3s", gwin->paint_eggs ? "Yes" : "No");
+	snprintf(buf, sizeof(buf), "[E]ggs Visible: %3s", gwin->paint_eggs ? "Yes" : "No");
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 54, 8);
 
 	// Set Time
@@ -710,7 +710,7 @@ void CheatScreen::NormalMenu() {
 #if !defined(__IPHONEOS__) && !defined(ANDROID)
 	// for small screens taking the liberty of leaving that out
 	// Time Rate
-	snprintf(buf, 512, "[+-] Time Rate: %3i", clock->get_time_rate());
+	snprintf(buf, sizeof(buf), "[+-] Time Rate: %3i", clock->get_time_rate());
 	font->paint_text_fixedwidth(ibuf, buf, 0, maxy - 36, 8);
 #endif
 
@@ -895,14 +895,14 @@ void CheatScreen::ActivityDisplay() {
 #endif
 
 	for (int i = 0; i < 11; i++) {
-		snprintf(buf, 512, "%2i %s", i, schedules[i]);
+		snprintf(buf, sizeof(buf), "%2i %s", i, schedules[i]);
 		font->paint_text_fixedwidth(ibuf, buf, 0, i * 9 + offsety1, 8);
 
-		snprintf(buf, 512, "%2i %s", i + 11, schedules[i + 11]);
+		snprintf(buf, sizeof(buf), "%2i %s", i + 11, schedules[i + 11]);
 		font->paint_text_fixedwidth(ibuf, buf, 112, i * 9 + offsety1, 8);
 
 		if (i != 10) {
-			snprintf(buf, 512, "%2i %s", i + 22, schedules[i + 22]);
+			snprintf(buf, sizeof(buf), "%2i %s", i + 22, schedules[i + 22]);
 			font->paint_text_fixedwidth(ibuf, buf, 224, i * 9 + offsety1, 8);
 		}
 	}
@@ -1024,10 +1024,10 @@ CheatScreen::Cheat_Prompt CheatScreen::GlobalFlagLoop(int num) {
 #endif
 
 		// First the info
-		snprintf(buf, 512, "Global Flag %i", num);
+		snprintf(buf, sizeof(buf), "Global Flag %i", num);
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 99, 8);
 
-		snprintf(buf, 512, "Flag is %s", usecode->get_global_flag(num) ? "SET" : "UNSET");
+		snprintf(buf, sizeof(buf), "Flag is %s", usecode->get_global_flag(num) ? "SET" : "UNSET");
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 90, 8);
 
 		// Now the Menu Column
@@ -1206,50 +1206,50 @@ void CheatScreen::NPCDisplay(Actor *actor, int &num) {
 
 		// Now the info
 		const std::string namestr = actor->get_npc_name();
-		snprintf(buf, 512, "NPC %i - %s", num, namestr.c_str());
+		snprintf(buf, sizeof(buf), "NPC %i - %s", num, namestr.c_str());
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, 0, 8);
 
-		snprintf(buf, 512, "Loc (%04i, %04i, %02i)",
+		snprintf(buf, sizeof(buf), "Loc (%04i, %04i, %02i)",
 		         t.tx, t.ty, t.tz);
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, 9, 8);
 
-		snprintf(buf, 512, "Shape %04i:%02i  %s", actor->get_shapenum(), actor->get_framenum(), actor->get_flag(Obj_flags::met) ? "Met" : "Not Met");
+		snprintf(buf, sizeof(buf), "Shape %04i:%02i  %s", actor->get_shapenum(), actor->get_framenum(), actor->get_flag(Obj_flags::met) ? "Met" : "Not Met");
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, 18, 8);
 
-		snprintf(buf, 512, "Current Activity: %2i - %s", actor->get_schedule_type(), schedules[actor->get_schedule_type()]);
+		snprintf(buf, sizeof(buf), "Current Activity: %2i - %s", actor->get_schedule_type(), schedules[actor->get_schedule_type()]);
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, offsety1 + 36, 8);
 
-		snprintf(buf, 512, "Experience: %i", actor->get_property(Actor::exp));
+		snprintf(buf, sizeof(buf), "Experience: %i", actor->get_property(Actor::exp));
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, offsety1 + 45, 8);
 
-		snprintf(buf, 512, "Level: %i", actor->get_level());
+		snprintf(buf, sizeof(buf), "Level: %i", actor->get_level());
 		font->paint_text_fixedwidth(ibuf, buf, offsetx + 144, offsety1 + 45, 8);
 
-		snprintf(buf, 512, "Training: %2i  Health: %2i", actor->get_property(Actor::training), actor->get_property(Actor::health));
+		snprintf(buf, sizeof(buf), "Training: %2i  Health: %2i", actor->get_property(Actor::training), actor->get_property(Actor::health));
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, offsety1 + 54, 8);
 
 		if (num != -1) {
 			int ucitemnum = 0x10000 - num;
 			if (!num) ucitemnum = 0xfe9c;
-			snprintf(buf, 512, "Usecode item %4x function %x", ucitemnum, actor->get_usecode());
+			snprintf(buf, sizeof(buf), "Usecode item %4x function %x", ucitemnum, actor->get_usecode());
 			font->paint_text_fixedwidth(ibuf, buf, offsetx, offsety1 + 63, 8);
 		} else {
-			snprintf(buf, 512, "Usecode function %x", actor->get_usecode());
+			snprintf(buf, sizeof(buf), "Usecode function %x", actor->get_usecode());
 			font->paint_text_fixedwidth(ibuf, buf, offsetx, offsety1 + 63, 8);
 		}
 
 		if (actor->get_flag(Obj_flags::charmed))
-			snprintf(buf, 512, "Alignment: %s (orig: %s)", alignments[actor->get_effective_alignment()], alignments[actor->get_alignment()]);
+			snprintf(buf, sizeof(buf), "Alignment: %s (orig: %s)", alignments[actor->get_effective_alignment()], alignments[actor->get_alignment()]);
 		else
-			snprintf(buf, 512, "Alignment: %s", alignments[actor->get_alignment()]);
+			snprintf(buf, sizeof(buf), "Alignment: %s", alignments[actor->get_alignment()]);
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, offsety1 + 72, 8);
 
 		if (actor->get_polymorph() != -1) {
-			snprintf(buf, 512, "Polymorphed from %04i", actor->get_polymorph());
+			snprintf(buf, sizeof(buf), "Polymorphed from %04i", actor->get_polymorph());
 			font->paint_text_fixedwidth(ibuf, buf, offsetx, offsety1 + 81, 8);
 		}
 	} else {
-		snprintf(buf, 512, "NPC %i - Invalid NPC!", num);
+		snprintf(buf, sizeof(buf), "NPC %i - Invalid NPC!", num);
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, 0, 8);
 	}
 }
@@ -1540,27 +1540,27 @@ void CheatScreen::FlagMenu(Actor *actor) {
 	// Left Column
 
 	// Asleep
-	snprintf(buf, 512, "[A] Asleep.%c", actor->get_flag(Obj_flags::asleep) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[A] Asleep.%c", actor->get_flag(Obj_flags::asleep) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 108, 8);
 
 	// Charmed
-	snprintf(buf, 512, "[B] Charmd.%c", actor->get_flag(Obj_flags::charmed) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[B] Charmd.%c", actor->get_flag(Obj_flags::charmed) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 99, 8);
 
 	// Cursed
-	snprintf(buf, 512, "[C] Cursed.%c", actor->get_flag(Obj_flags::cursed) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[C] Cursed.%c", actor->get_flag(Obj_flags::cursed) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 90, 8);
 
 	// Paralyzed
-	snprintf(buf, 512, "[D] Prlyzd.%c", actor->get_flag(Obj_flags::paralyzed) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[D] Prlyzd.%c", actor->get_flag(Obj_flags::paralyzed) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 81, 8);
 
 	// Poisoned
-	snprintf(buf, 512, "[E] Poisnd.%c", actor->get_flag(Obj_flags::poisoned) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[E] Poisnd.%c", actor->get_flag(Obj_flags::poisoned) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 72, 8);
 
 	// Protected
-	snprintf(buf, 512, "[F] Prtctd.%c", actor->get_flag(Obj_flags::protection) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[F] Prtctd.%c", actor->get_flag(Obj_flags::protection) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 63, 8);
 
 	// Advanced Editor
@@ -1573,45 +1573,45 @@ void CheatScreen::FlagMenu(Actor *actor) {
 	// Center Column
 
 	// Party
-	snprintf(buf, 512, "[I] Party..%c", actor->get_flag(Obj_flags::in_party) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[I] Party..%c", actor->get_flag(Obj_flags::in_party) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 104, maxy - offsety1 - 108, 8);
 
 	// Invisible
-	snprintf(buf, 512, "[J] Invsbl.%c", actor->get_flag(Obj_flags::invisible) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[J] Invsbl.%c", actor->get_flag(Obj_flags::invisible) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 104, maxy - offsety1 - 99, 8);
 
 	// Fly
-	snprintf(buf, 512, "[K] Fly....%c", actor->get_type_flag(Actor::tf_fly) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[K] Fly....%c", actor->get_type_flag(Actor::tf_fly) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 104, maxy - offsety1 - 90, 8);
 
 	// Walk
-	snprintf(buf, 512, "[L] Walk...%c", actor->get_type_flag(Actor::tf_walk) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[L] Walk...%c", actor->get_type_flag(Actor::tf_walk) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 104, maxy - offsety1 - 81, 8);
 
 	// Swim
-	snprintf(buf, 512, "[M] Swim...%c", actor->get_type_flag(Actor::tf_swim) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[M] Swim...%c", actor->get_type_flag(Actor::tf_swim) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 104, maxy - offsety1 - 72, 8);
 
 	// Ethereal
-	snprintf(buf, 512, "[N] Ethrel.%c", actor->get_type_flag(Actor::tf_ethereal) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[N] Ethrel.%c", actor->get_type_flag(Actor::tf_ethereal) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 104, maxy - offsety1 - 63, 8);
 
 	// Protectee
-	snprintf(buf, 512, "[O] Prtcee.%c", '?');
+	snprintf(buf, sizeof(buf), "[O] Prtcee.%c", '?');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 104, maxy - offsety1 - 54, 8);
 
 	// Conjured
-	snprintf(buf, 512, "[P] Conjrd.%c", actor->get_type_flag(Actor::tf_conjured) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[P] Conjrd.%c", actor->get_type_flag(Actor::tf_conjured) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 104, maxy - offsety1 - 45, 8);
 
 	// Tournament (Original is SI only -- allowing for BG in Exult)
-	snprintf(buf, 512, "[3] Tourna.%c", actor->get_flag(
+	snprintf(buf, sizeof(buf), "[3] Tourna.%c", actor->get_flag(
 	             Obj_flags::tournament) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 104, maxy - offsety1 - 36, 8);
 
 	// Naked (AV ONLY)
 	if (!actor->get_npc_num()) {
-		snprintf(buf, 512, "[7] Naked..%c", actor->get_flag(Obj_flags::naked) ? 'Y' : 'N');
+		snprintf(buf, sizeof(buf), "[7] Naked..%c", actor->get_flag(Obj_flags::naked) ? 'Y' : 'N');
 		font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 104, maxy - offsety1 - 27, 8);
 	}
 
@@ -1619,65 +1619,65 @@ void CheatScreen::FlagMenu(Actor *actor) {
 	// Right Column
 
 	// Summoned
-	snprintf(buf, 512, "[Q] Summnd.%c", actor->get_type_flag(Actor::tf_summonned) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[Q] Summnd.%c", actor->get_type_flag(Actor::tf_summonned) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 108, 8);
 
 	// Bleeding
-	snprintf(buf, 512, "[R] Bleedn.%c", actor->get_type_flag(Actor::tf_bleeding) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[R] Bleedn.%c", actor->get_type_flag(Actor::tf_bleeding) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 99, 8);
 
 	if (!actor->get_npc_num()) { // Avatar
 		// Sex
-		snprintf(buf, 512, "[S] Sex....%c", actor->get_type_flag(Actor::tf_sex) ? 'F' : 'M');
+		snprintf(buf, sizeof(buf), "[S] Sex....%c", actor->get_type_flag(Actor::tf_sex) ? 'F' : 'M');
 		font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 90, 8);
 
 		// Skin
-		snprintf(buf, 512, "[1] Skin...%d", actor->get_skin_color());
+		snprintf(buf, sizeof(buf), "[1] Skin...%d", actor->get_skin_color());
 		font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 81, 8);
 
 		// Read
-		snprintf(buf, 512, "[4] Read...%c", actor->get_flag(Obj_flags::read) ? 'Y' : 'N');
+		snprintf(buf, sizeof(buf), "[4] Read...%c", actor->get_flag(Obj_flags::read) ? 'Y' : 'N');
 		font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 72, 8);
 	} else { // Not Avatar
 		// Met
-		snprintf(buf, 512, "[T] Met....%c", actor->get_flag(Obj_flags::met) ? 'Y' : 'N');
+		snprintf(buf, sizeof(buf), "[T] Met....%c", actor->get_flag(Obj_flags::met) ? 'Y' : 'N');
 		font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 90, 8);
 
 		// NoCast
-		snprintf(buf, 512, "[U] NoCast.%c", actor->get_flag(
+		snprintf(buf, sizeof(buf), "[U] NoCast.%c", actor->get_flag(
 		             Obj_flags::no_spell_casting) ? 'Y' : 'N');
 		font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 81, 8);
 
 		// ID
-		snprintf(buf, 512, "[V] ID#:%02i", actor->get_ident());
+		snprintf(buf, sizeof(buf), "[V] ID#:%02i", actor->get_ident());
 		font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 72, 8);
 	}
 
 	// Freeze
-	snprintf(buf, 512, "[W] Freeze.%c", actor->get_flag(
+	snprintf(buf, sizeof(buf), "[W] Freeze.%c", actor->get_flag(
 	             Obj_flags::freeze) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 63, 8);
 
 	// Party
 	if (actor->is_in_party()) {
 		// Temp
-		snprintf(buf, 512, "[Y] Temp: %02i",
+		snprintf(buf, sizeof(buf), "[Y] Temp: %02i",
 		         actor->get_temperature());
 		font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 54, 8);
 
 		// Conjured
-		snprintf(buf, 512, "Warmth: %04i",
+		snprintf(buf, sizeof(buf), "Warmth: %04i",
 		         actor->figure_warmth());
 		font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 45, 8);
 	}
 
 	// Polymorph
-	snprintf(buf, 512, "[2] Polymo.%c", actor->get_flag(Obj_flags::polymorph) ? 'Y' : 'N');
+	snprintf(buf, sizeof(buf), "[2] Polymo.%c", actor->get_flag(Obj_flags::polymorph) ? 'Y' : 'N');
 	font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 36, 8);
 
 	// Patra (AV SI ONLY)
 	if (!actor->get_npc_num()) {
-		snprintf(buf, 512, "[5] Petra..%c", actor->get_flag(Obj_flags::petra) ? 'Y' : 'N');
+		snprintf(buf, sizeof(buf), "[5] Petra..%c", actor->get_flag(Obj_flags::petra) ? 'Y' : 'N');
 		font->paint_text_fixedwidth(ibuf, buf, offsetx1 + 208, maxy - offsety1 - 27, 8);
 	}
 
@@ -2116,10 +2116,10 @@ void CheatScreen::BusinessDisplay(Actor *actor) {
 
 	// Now the info
 	const std::string namestr = actor->get_npc_name();
-	snprintf(buf, 512, "NPC %i - %s - Schedules:", actor->get_npc_num(), namestr.c_str());
+	snprintf(buf, sizeof(buf), "NPC %i - %s - Schedules:", actor->get_npc_num(), namestr.c_str());
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, 0, 8);
 
-	snprintf(buf, 512, "Loc (%04i, %04i, %02i)", t.tx, t.ty, t.tz);
+	snprintf(buf, sizeof(buf), "Loc (%04i, %04i, %02i)", t.tx, t.ty, t.tz);
 	font->paint_text_fixedwidth(ibuf, buf, 0, 8, 8);
 
 #if defined(__IPHONEOS__) || defined(ANDROID)
@@ -2127,7 +2127,7 @@ void CheatScreen::BusinessDisplay(Actor *actor) {
 #else
 	const char activity_msg[] = "Current Activity:  %2i - %s";
 #endif
-	snprintf(buf, 512, activity_msg, actor->get_schedule_type(), schedules[actor->get_schedule_type()]);
+	snprintf(buf, sizeof(buf), activity_msg, actor->get_schedule_type(), schedules[actor->get_schedule_type()]);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx2, offsety2, 8);
 
 
@@ -2163,7 +2163,7 @@ void CheatScreen::BusinessDisplay(Actor *actor) {
 		font->paint_text_fixedwidth(ibuf, " 9 PM:", offsetx, 92 - offsety1, 8);
 
 		for (int i = 0; i < 8; i++) if (types[i] != -1) {
-				snprintf(buf, 512, "%2i (%4i,%4i) - %s", types[i], x[i], y[i], schedules[types[i]]);
+				snprintf(buf, sizeof(buf), "%2i (%4i,%4i) - %s", types[i], x[i], y[i], schedules[types[i]]);
 				font->paint_text_fixedwidth(ibuf, buf, offsetx + 56, (36  - offsety1) + i * 8, 8);
 			}
 	}
@@ -2402,36 +2402,36 @@ void CheatScreen::StatMenu(Actor *actor) {
 	// Left Column
 
 	// Dexterity
-	snprintf(buf, 512, "[D]exterity....%3i", actor->get_property(Actor::dexterity));
+	snprintf(buf, sizeof(buf), "[D]exterity....%3i", actor->get_property(Actor::dexterity));
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 108 , 8);
 
 	// Food Level
-	snprintf(buf, 512, "[F]ood Level...%3i", actor->get_property(Actor::food_level));
+	snprintf(buf, sizeof(buf), "[F]ood Level...%3i", actor->get_property(Actor::food_level));
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 99, 8);
 
 	// Intelligence
-	snprintf(buf, 512, "[I]ntellicence.%3i", actor->get_property(Actor::intelligence));
+	snprintf(buf, sizeof(buf), "[I]ntellicence.%3i", actor->get_property(Actor::intelligence));
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 90, 8);
 
 	// Strength
-	snprintf(buf, 512, "[S]trength.....%3i", actor->get_property(Actor::strength));
+	snprintf(buf, sizeof(buf), "[S]trength.....%3i", actor->get_property(Actor::strength));
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 81, 8);
 
 	// Combat Skill
-	snprintf(buf, 512, "[C]ombat Skill.%3i", actor->get_property(Actor::combat));
+	snprintf(buf, sizeof(buf), "[C]ombat Skill.%3i", actor->get_property(Actor::combat));
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 72, 8);
 
 	// Hit Points
-	snprintf(buf, 512, "[H]it Points...%3i", actor->get_property(Actor::health));
+	snprintf(buf, sizeof(buf), "[H]it Points...%3i", actor->get_property(Actor::health));
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 63, 8);
 
 	// Magic
 	// Magic Points
-	snprintf(buf, 512, "[M]agic Points.%3i", actor->get_property(Actor::magic));
+	snprintf(buf, sizeof(buf), "[M]agic Points.%3i", actor->get_property(Actor::magic));
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 54, 8);
 
 	// Mana
-	snprintf(buf, 512, "[V]ana Level...%3i", actor->get_property(Actor::mana));
+	snprintf(buf, sizeof(buf), "[V]ana Level...%3i", actor->get_property(Actor::mana));
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 45, 8);
 
 	// Exit
@@ -2574,12 +2574,12 @@ CheatScreen::Cheat_Prompt CheatScreen::AdvancedFlagLoop(int num, Actor *actor) {
 
 		// First the info
 		if (flag_names[num])
-			snprintf(buf, 512, "NPC Flag %i: %s", num, flag_names[num]);
+			snprintf(buf, sizeof(buf), "NPC Flag %i: %s", num, flag_names[num]);
 		else
-			snprintf(buf, 512, "NPC Flag %i", num);
+			snprintf(buf, sizeof(buf), "NPC Flag %i", num);
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 108, 8);
 
-		snprintf(buf, 512, "Flag is %s", actor->get_flag(num) ? "SET" : "UNSET");
+		snprintf(buf, sizeof(buf), "Flag is %s", actor->get_flag(num) ? "SET" : "UNSET");
 		font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 90, 8);
 
 
@@ -2766,27 +2766,27 @@ void CheatScreen::TeleportDisplay() {
 	const int longi = ((t.tx - 0x3A5) / 10);
 	const int lati = ((t.ty - 0x46E) / 10);
 #if defined(__IPHONEOS__) || defined(ANDROID)
-	snprintf(buf, 512, "Coords %d %s %d %s, Map #%d of %d",
+	snprintf(buf, sizeof(buf), "Coords %d %s %d %s, Map #%d of %d",
 		abs(lati), (lati < 0 ? "North" : "South"),
 		abs(longi), (longi < 0 ? "West" : "East"), curmap, highest);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, 9, 8);
 #else
-	snprintf(buf, 512, "Coordinates   %d %s %d %s",
+	snprintf(buf, sizeof(buf), "Coordinates   %d %s %d %s",
 		abs(lati), (lati < 0 ? "North" : "South"),
 		abs(longi), (longi < 0 ? "West" : "East"));
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, 63, 8);
 #endif
 
-	snprintf(buf, 512, "Coords in hex (%04x, %04x, %02x)",
+	snprintf(buf, sizeof(buf), "Coords in hex (%04x, %04x, %02x)",
 	         t.tx, t.ty, t.tz);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, 72 - offsety1, 8);
 
-	snprintf(buf, 512, "Coords in dec (%04i, %04i, %02i)",
+	snprintf(buf, sizeof(buf), "Coords in dec (%04i, %04i, %02i)",
 	         t.tx, t.ty, t.tz);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, 81 - offsety1, 8);
 
 #if !defined(__IPHONEOS__) && !defined(ANDROID)
-	snprintf(buf, 512, "On Map #%d of %d",
+	snprintf(buf, sizeof(buf), "On Map #%d of %d",
 	         curmap, highest);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, 90, 8);
 #endif

--- a/exult.cc
+++ b/exult.cc
@@ -2292,19 +2292,19 @@ void change_gamma(bool down) {
 
 	// Message
 	Image_window8::get_gamma(r, g, b);
-	snprintf(text, 256, "Gamma Set to R: %01.2f G: %01.2f B: %01.2f", r, g, b);
+	snprintf(text, sizeof(text), "Gamma Set to R: %01.2f G: %01.2f B: %01.2f", r, g, b);
 	gwin->get_effects()->center_text(text);
 
 	int igam = std::lround(r * 10000);
-	snprintf(text, 256, "%d.%04d", igam / 10000, igam % 10000);
+	snprintf(text, sizeof(text), "%d.%04d", igam / 10000, igam % 10000);
 	config->set("config/video/gamma/red", text, true);
 
 	igam = std::lround(b * 10000);
-	snprintf(text, 256, "%d.%04d", igam / 10000, igam % 10000);
+	snprintf(text, sizeof(text), "%d.%04d", igam / 10000, igam % 10000);
 	config->set("config/video/gamma/green", text, true);
 
 	igam = std::lround(g * 10000);
-	snprintf(text, 256, "%d.%04d", igam / 10000, igam % 10000);
+	snprintf(text, sizeof(text), "%d.%04d", igam / 10000, igam % 10000);
 	config->set("config/video/gamma/blue", text, true);
 }
 

--- a/game.cc
+++ b/game.cc
@@ -121,9 +121,8 @@ Game* Game::create_game(BaseGameInfo* mygame) {
 	config->set("config/gameplay/bg_paperdolls", str, true);
 	char buf[256];
 	if (!mygame->get_mod_title().empty())
-		snprintf(
-				buf, 256, " with the '%s' modification.",
-				mygame->get_mod_title().c_str());
+		snprintf(buf, sizeof(buf), " with the '%s' modification.",
+	             mygame->get_mod_title().c_str());
 	else
 		buf[0] = 0;
 	switch (game_type) {
@@ -335,9 +334,8 @@ const str_int_pair& Game::get_resource(const char* name) {
 		return resources[name];
 	} else {
 		char buf[250];
-		snprintf(
-				buf, array_size(buf),
-				"Game::get_resource: Illegal resource requested: '%s'", name);
+		snprintf(buf, sizeof(buf),
+		         "Game::get_resource: Illegal resource requested: '%s'", name);
 		throw exult_exception(buf);
 	}
 }
@@ -417,7 +415,7 @@ bool Game::show_menu(bool skip) {
 
 	const Vga_file exult_flx(BUNDLE_CHECK(BUNDLE_EXULT_FLX, EXULT_FLX));
 	char           npc_name[16];
-	snprintf(npc_name, 16, "Exult");
+	snprintf(npc_name, sizeof(npc_name), "Exult");
 	bool play     = false;
 	bool fadeout  = true;
 	bool exitmenu = false;

--- a/gamedat.cc
+++ b/gamedat.cc
@@ -240,7 +240,7 @@ void Game_window::restore_gamedat(
     int num             // 0-9, currently.
 ) {
 	char fname[50];         // Set up name.
-	snprintf(fname, 50, SAVENAME, num,
+	snprintf(fname, sizeof(fname), SAVENAME, num,
 	         Game::get_game_type() == BLACK_GATE ? "bg" :
 	         Game::get_game_type() == SERPENT_ISLE ? "si" : "dev");
 	restore_gamedat(fname);
@@ -386,7 +386,7 @@ void Game_window::save_gamedat(
     const char *savename            // User's savegame name.
 ) {
 	char fname[50];         // Set up name.
-	snprintf(fname, 50, SAVENAME, num,
+	snprintf(fname, sizeof(fname), SAVENAME, num,
 	         Game::get_game_type() == BLACK_GATE ? "bg" :
 	         Game::get_game_type() == SERPENT_ISLE ? "si" : "dev");
 	save_gamedat(fname, savename);
@@ -403,7 +403,7 @@ void Game_window::read_save_names(
 ) {
 	for (unsigned int i = 0; i < array_size(save_names); i++) {
 		char fname[50];     // Set up name.
-		snprintf(fname, 50, SAVENAME, static_cast<int>(i),
+		snprintf(fname, sizeof(fname), SAVENAME, static_cast<int>(i),
 		         GAME_BG ? "bg" : (GAME_SI ? "si" : "dev"));
 		try {
 			auto pIn = U7open_in(fname);
@@ -588,7 +588,7 @@ void Game_window::read_saveinfo(IDataSource *in,
 
 bool Game_window::get_saveinfo(int num, char *&name, std::unique_ptr<Shape_file> &map, SaveGame_Details *&details, SaveGame_Party  *&party) {
 	char fname[50];         // Set up name.
-	snprintf(fname, 50, SAVENAME, num,
+	snprintf(fname, sizeof(fname), SAVENAME, num,
 	         Game::get_game_type() == BLACK_GATE ? "bg" :
 	         Game::get_game_type() == SERPENT_ISLE ? "si" : "dev");
 

--- a/gumps/Actor_gump.cc
+++ b/gumps/Actor_gump.cc
@@ -216,7 +216,7 @@ void Actor_gump::paint(
 	const int max_weight = container->get_max_weight();
 	const int weight = container->get_weight() / 10;
 	char text[20];
-	snprintf(text, 20, "%d/%d", weight, max_weight);
+	snprintf(text, sizeof(text), "%d/%d", weight, max_weight);
 	const int twidth = sman->get_text_width(2, text);
 	const int boxw = 102;
 	sman->paint_text(2, text, x + 28 + (boxw - twidth) / 2, y + 120);

--- a/gumps/Gump_manager.cc
+++ b/gumps/Gump_manager.cc
@@ -782,7 +782,7 @@ void Gump_manager::paint_num(
 	//  Shape_manager *sman = Shape_manager::get_instance();
 	const int font = 2;
 	char buf[20];
-	snprintf(buf, 20, "%d", num);
+	snprintf(buf, sizeof(buf), "%d", num);
 	sman->paint_text(font, buf, x - sman->get_text_width(font, buf), y);
 }
 

--- a/gumps/Newfile_gump.cc
+++ b/gumps/Newfile_gump.cc
@@ -940,7 +940,7 @@ void Newfile_gump::LoadSaveGameDetails() {
 	// Now read save game details
 	char    mask[256];
 
-	snprintf(mask, 256, SAVENAME2, GAME_BG ? "bg" : GAME_SI ? "si" : "dev");
+	snprintf(mask, sizeof(mask), SAVENAME2, GAME_BG ? "bg" : GAME_SI ? "si" : "dev");
 
 	FileList filenames;
 	U7ListFiles(mask, filenames);

--- a/gumps/Paperdoll_gump.cc
+++ b/gumps/Paperdoll_gump.cc
@@ -484,9 +484,9 @@ void Paperdoll_gump::paint(
 	const int weight = actor->get_weight() / 10;
 	char text[20];
 	if (gwin->failed_copy_protection())
-		snprintf(text, 6, "Oink!");
+		snprintf(text, sizeof(text), "Oink!");
 	else
-		snprintf(text, 20, "%d/%d", weight, max_weight);
+		snprintf(text, sizeof(text), "%d/%d", weight, max_weight);
 	const int twidth = sman->get_text_width(2, text);
 	sman->paint_text(2, text, x + 84 - (twidth / 2), y + 114);
 }

--- a/gumps/Spellbook_gump.cc
+++ b/gumps/Spellbook_gump.cc
@@ -478,7 +478,7 @@ void Spellbook_gump::paint(
 					else if (num >= 1000 || cheat.in_wizard_mode())
 						std::strcpy(text, "999");
 					else
-						snprintf(text, 7, "%d", num);
+						snprintf(text, sizeof(text), "%d", num);
 				} else  // prevent garbage text
 					std::strcpy(text, "");
 			sman->paint_text(5, text,

--- a/gumps/Yesno_gump.cc
+++ b/gumps/Yesno_gump.cc
@@ -191,8 +191,7 @@ bool Countdown_gump::run() {
 	if (remaining <= 0)  set_answer(0);
 
 	char *new_text = new char[text_fmt.size() + 32];
-	snprintf(new_text, text_fmt.size() + 31, "%s %i...", text_fmt.c_str(), remaining / 1000);
-	new_text[text_fmt.size() + 31] = 0;
+	snprintf(new_text, text_fmt.size() + 32, "%s %i...", text_fmt.c_str(), remaining / 1000);
 	text = new_text;
 	delete [] new_text;
 

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -1100,8 +1100,8 @@ bool Image_window::fillmode_to_string(FillMode fmode, std::string &str) {
 		if (factor == 2)
 			factor_str[0] = 0;
 		else {
-			snprintf(factor_str, 15, (factor & 1) ? " x%d.5" : " x%d", factor / 2);
-			factor_str[15] = 0;
+			snprintf(factor_str, sizeof(factor_str),
+			         (factor & 1) ? " x%d.5" : " x%d", factor / 2);
 		}
 
 		if (fmode & 1)
@@ -1116,8 +1116,7 @@ bool Image_window::fillmode_to_string(FillMode fmode, std::string &str) {
 		if (!fw || !fh) return false;
 
 		char factor_str[16];
-		snprintf(factor_str, 15, "%dx%d", fw, fh);
-		factor_str[15] = 0;
+		snprintf(factor_str, sizeof(factor_str), "%dx%d", fw, fh);
 		str = std::string(factor_str);
 
 		return true;

--- a/mapedit/maps.cc
+++ b/mapedit/maps.cc
@@ -26,7 +26,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #	include <config.h>
 #endif
 
-#include "array_size.h"
 #include "exult_constants.h"
 #include "fnames.h"
 #include "servemsg.h"
@@ -147,8 +146,8 @@ C_EXPORT void on_newmap_ok_clicked(
 		for (int schunk = 0; schunk < 12 * 12; schunk++) {
 			char pname[128];
 			char sname[128];
-			snprintf(pname, array_size(pname), "%s%02x", PATCH_U7IFIX, schunk);
-			snprintf(sname, array_size(sname), "%s%02x", U7IFIX, schunk);
+			snprintf(pname, sizeof(pname), "%s%02x", PATCH_U7IFIX, schunk);
+			snprintf(sname, sizeof(sname), "%s%02x", U7IFIX, schunk);
 			if (!Copy_static_file(sname, pname, frommap, num))
 				break;
 		}
@@ -159,10 +158,10 @@ C_EXPORT void on_newmap_ok_clicked(
 		for (int schunk = 0; schunk < 12 * 12; schunk++) {
 			Get_mapped_name(U7IREG, frommap, fname);
 			const size_t fnamelen = strlen(fname);
-			snprintf(fname + fnamelen, array_size(fname) - fnamelen, "%02x", schunk);
+			snprintf(fname + fnamelen, sizeof(fname) - fnamelen, "%02x", schunk);
 			Get_mapped_name(U7IREG, num, tname);
 			const size_t tnamelen = strlen(tname);
-			snprintf(tname + tnamelen, array_size(tname) - tnamelen, "%02x", schunk);
+			snprintf(tname + tnamelen, sizeof(tname) - tnamelen, "%02x", schunk);
 			if (U7exists(fname))
 				if (!EStudio::Copy_file(fname, tname))
 					break;
@@ -209,7 +208,7 @@ void ExultStudio::setup_maps_list(
 	int num = 0;
 	while ((num = Find_next_map(num + 1, 10)) != -1) {
 		char name[40];
-		snprintf(name, array_size(name), "Map #%02x", num);
+		snprintf(name, sizeof(name), "Map #%02x", num);
 		auto *ptrnum = reinterpret_cast<gpointer>(uintptr(num));
 		GtkWidget *item =
 		    Add_menu_item(maps, name, G_CALLBACK(on_map_activate), ptrnum, group);

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "shapelst.h"
 
-#include "array_size.h"
 #include "databuf.h"
 #include "fontgen.h"
 #include "frnameinf.h"
@@ -769,7 +768,7 @@ time_t Shape_chooser::export_tiled_png(
 		if (frame->is_rle() || frame->get_width() != c_tilesize ||
 		        frame->get_height() != c_tilesize) {
 			char buf[250];
-			snprintf(buf, array_size(buf), "Can only tile %dx%d flat shapes",
+			snprintf(buf, sizeof(buf), "Can only tile %dx%d flat shapes",
 			         c_tilesize, c_tilesize);
 			Alert("%s", buf);
 			return 0;
@@ -2444,7 +2443,7 @@ void Shape_chooser::update_statusbar(
 	if (selected >= 0) {
 		const int shapenum = info[selected].shapenum;
 		const int nframes = ifile->get_num_frames(shapenum);
-		g_snprintf(buf, array_size(buf), "Shape %d (0x%03x, %d frames)",
+		g_snprintf(buf, sizeof(buf), "Shape %d (0x%03x, %d frames)",
 		           shapenum, shapenum, nframes);
 		ExultStudio *studio = ExultStudio::get_instance();
 		if (shapes_file) {

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -74,6 +74,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
+#	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif    // __GNUC__
 #include <unicode/ucnv.h>
 #include <unicode/ucnv_cb.h>

--- a/mapedit/ucbrowse.cc
+++ b/mapedit/ucbrowse.cc
@@ -28,7 +28,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "ucbrowse.h"
 
-#include "headers/array_size.h"
 #include "ucsymtbl.h"
 #include "utils.h"
 
@@ -365,7 +364,7 @@ void Usecode_browser::setup_list(
 			continue;
 		}
 		char num[20];
-		snprintf(num, array_size(num), "%05xH", sym->get_val());
+		snprintf(num, sizeof(num), "%05xH", sym->get_val());
 		GtkTreeIter iter;
 		gtk_tree_store_append(model, &iter, nullptr);
 		gtk_tree_store_set(model, &iter, NAME_COL, nm,

--- a/objs/objnames.cc
+++ b/objs/objnames.cc
@@ -100,7 +100,7 @@ static void get_plural_name(
 ) {
 	char buf[20];
 
-	snprintf(buf, 20, "%d ", quantity); // Output the quantity
+	snprintf(buf, sizeof(buf), "%d ", quantity); // Output the quantity
 	output_name = buf;
 
 	// Skip the first part
@@ -209,7 +209,7 @@ string Game_object::get_name(
 		else {
 			char buf[50];
 
-			snprintf(buf, 50, "%d %s", quantity, name);
+			snprintf(buf, sizeof(buf), "%d %s", quantity, name);
 			display_name = buf;
 		}
 	} else if (quantity <= 1)   // quantity might be zero?

--- a/server/server.cc
+++ b/server/server.cc
@@ -55,7 +55,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <sys/un.h>
 #endif
 
-#include "array_size.h"
 #include "server.h"
 #include "servemsg.h"
 #include "utils.h"
@@ -474,7 +473,7 @@ static void Handle_client_message(
 		const Tile_coord pos = gwin->get_main_actor()->get_tile();
 		const int num = Read2(ptr);
 		gwin->teleport_party(pos, true, num);
-		snprintf(msg, array_size(msg), "Map #%02x", num);
+		snprintf(msg, sizeof(msg), "Map #%02x", num);
 		gwin->get_effects()->center_text(msg);
 		break;
 	}

--- a/shapes/data_utils.h
+++ b/shapes/data_utils.h
@@ -259,7 +259,7 @@ public:
 		if (game != BLACK_GATE && game != SERPENT_ISLE)
 			return;
 		/*  ++++ Not because of ES.
-		snprintf(buf, 50, "config/%s", fname);
+		snprintf(buf, sizeof(buf), "config/%s", fname);
 		str_int_pair resource = game->get_resource(buf);
 		U7object txtobj(resource.str, resource.num);
 		*/
@@ -510,7 +510,7 @@ static void Read_text_data_file(
 	char buf[50];
 	if (game == BLACK_GATE || game == SERPENT_ISLE) {
 		/*  ++++ Not because of ES.
-		snprintf(buf, 50, "config/%s", fname);
+		snprintf(buf, sizeof(buf), "config/%s", fname);
 		str_int_pair resource = game->get_resource(buf);
 		U7object txtobj(resource.str, resource.num);
 		*/
@@ -523,7 +523,7 @@ static void Read_text_data_file(
 		                 static_strings, sections, numsections);
 	} else {
 		try {
-			snprintf(buf, 50, "<STATIC>/%s.txt", fname);
+			snprintf(buf, sizeof(buf), "<STATIC>/%s.txt", fname);
 			auto pIn = U7open_in(buf, false);
 			if (!pIn)
 				throw file_open_exception(buf);
@@ -540,7 +540,7 @@ static void Read_text_data_file(
 		}
 	}
 	patch_strings.resize(numsections);
-	snprintf(buf, 50, "<PATCH>/%s.txt", fname);
+	snprintf(buf, sizeof(buf), "<PATCH>/%s.txt", fname);
 	if (U7exists(buf)) {
 		auto pIn = U7open_in(buf, false);
 		if (!pIn)
@@ -858,7 +858,7 @@ static void Write_text_data_file(
 		return;
 	}
 	char buf[50];
-	snprintf(buf, 50, "<PATCH>/%s.txt", fname);
+	snprintf(buf, sizeof(buf), "<PATCH>/%s.txt", fname);
 	auto pOut = U7open_out(buf, true); // (It's a text file.)
 	if (!pOut)
 		return;

--- a/shapes/fontgen.cc
+++ b/shapes/fontgen.cc
@@ -219,21 +219,18 @@ static bool Gen_font_shape_win32(
 	logfont.lfPitchAndFamily = DEFAULT_PITCH;
 
 	if (font == nullptr && stylename) {
-		snprintf(logfont.lfFaceName, LF_FACESIZE - 1, "%s %s", famname, stylename);
-		logfont.lfFaceName[LF_FACESIZE - 1] = 0;
+		snprintf(logfont.lfFaceName, LF_FACESIZE, "%s %s", famname, stylename);
 
 		if (!EnumFontFamilies(dc, logfont.lfFaceName, reinterpret_cast<FONTENUMPROC>(&EnumFontFamProc), 0))
 			font = CreateFontIndirect(&logfont);
 	}
 	if (font == nullptr && stylename) {
-		snprintf(logfont.lfFaceName, LF_FACESIZE - 1, "%s%s", famname, stylename);
-		logfont.lfFaceName[LF_FACESIZE - 1] = 0;
+		snprintf(logfont.lfFaceName, LF_FACESIZE, "%s%s", famname, stylename);
 		if (!EnumFontFamilies(dc, logfont.lfFaceName, reinterpret_cast<FONTENUMPROC>(&EnumFontFamProc), 0))
 			font = CreateFontIndirect(&logfont);
 	}
 	if (font  == nullptr) {
-		strncpy(logfont.lfFaceName, famname, LF_FACESIZE - 1);
-		logfont.lfFaceName[LF_FACESIZE - 1] = 0;
+		snprintf(logfont.lfFaceName, LF_FACESIZE, "%s", famname);
 		if (!EnumFontFamilies(dc, logfont.lfFaceName, reinterpret_cast<FONTENUMPROC>(&EnumFontFamProc), reinterpret_cast<LPARAM>(stylename)))
 			font = CreateFontIndirect(&logfont);
 	}

--- a/shapes/miscinf.cc
+++ b/shapes/miscinf.cc
@@ -377,14 +377,14 @@ void Shapeinfo_lookup::Read_data_file(
 	int patch_version = 1;
 	char buf[50];
 	if (GAME_BG || GAME_SI) {
-		snprintf(buf, 50, "config/%s", fname);
+		snprintf(buf, sizeof(buf), "config/%s", fname);
 		const str_int_pair &resource = game->get_resource(buf);
 		IExultDataSource ds(resource.str, resource.num);
 		static_version = Read_text_msg_file_sections(&ds,
 		                 static_strings, sections, numsections);
 	} else {
 		try {
-			snprintf(buf, 50, "<STATIC>/%s.txt", fname);
+			snprintf(buf, sizeof(buf), "<STATIC>/%s.txt", fname);
 			auto pIn = U7open_in(buf, false);
 			if (!pIn)
 				throw file_open_exception(buf);
@@ -399,7 +399,7 @@ void Shapeinfo_lookup::Read_data_file(
 		}
 	}
 	patch_strings.resize(numsections);
-	snprintf(buf, 50, "<PATCH>/%s.txt", fname);
+	snprintf(buf, sizeof(buf), "<PATCH>/%s.txt", fname);
 	if (U7exists(buf)) {
 		auto pIn = U7open_in(buf, false);
 		if (!pIn)

--- a/tools/expack.cc
+++ b/tools/expack.cc
@@ -304,7 +304,7 @@ int main(int argc, char **argv)
 				exit(1);
 			}
 			char outfile[32];
-			snprintf(outfile, 32, "%05lu.%s", n, ext);
+			snprintf(outfile, sizeof(outfile), "%05lu.%s", n, ext);
 			Write_Object(f, outfile);   // may throw!
 		} else {
 			U7FileManager *fm = U7FileManager::get_ptr();
@@ -313,7 +313,7 @@ int main(int argc, char **argv)
 			for (int index = 0; index < count; index++) {
 				U7object o(fname, index);
 				char outfile[32];
-				snprintf(outfile, 32, "%05d.%s", index, ext);
+				snprintf(outfile, sizeof(outfile), "%05d.%s", index, ext);
 				Write_Object(o, outfile);
 			}
 		}

--- a/tools/rip.cc
+++ b/tools/rip.cc
@@ -1,5 +1,3 @@
-#include "array_size.h"
-
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
@@ -118,7 +116,7 @@ int main(int argc, char *argv[]) {
 		char s[10];
 		char filename[18];
 		if (number == all_functions || number == only_index || number == fn) {
-			snprintf(s, array_size(s), "%04X", fn);
+			snprintf(s, sizeof(s), "%04X", fn);
 			strcpy(filename, s);
 			strcat(filename, ".uco");
 			fprintf(fo2, "%s\n", s);

--- a/tools/shp2pcx.cc
+++ b/tools/shp2pcx.cc
@@ -34,7 +34,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <cstring>
 #include <string>
 
-#include "array_size.h"
 #include "common_types.h"
 
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
@@ -427,7 +426,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	for (int i = 0; i < sh->num_frames; i++) {
-		snprintf(outfilename, array_size(outfilename), "%s%02i.pcx", outprefix, i);
+		snprintf(outfilename, sizeof(outfilename), "%s%02i.pcx", outprefix, i);
 		cout << "Writing frame " << i << " to " << outfilename << "..." << endl;
 		save_image(sh->frames[i].pixels, palette, sh->width, sh->height, outfilename);
 	}

--- a/usecode/compiler/ucclass.cc
+++ b/usecode/compiler/ucclass.cc
@@ -31,7 +31,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <vector>
 #include <cstring>
 
-#include "array_size.h"
 #include "ucclass.h"
 #include "ucsymtbl.h"
 #include "ucfun.h"
@@ -149,7 +148,7 @@ void Uc_class::add_method(
 				return;
 			} else {
 				char buf[150];
-				snprintf(buf, array_size(buf), "Duplicate decl. of virtual member function '%s'.", m->get_name());
+				snprintf(buf, sizeof(buf), "Duplicate decl. of virtual member function '%s'.", m->get_name());
 				Uc_location::yyerror(buf);
 				return;
 			}

--- a/usecode/compiler/ucexpr.cc
+++ b/usecode/compiler/ucexpr.cc
@@ -36,7 +36,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "ucclass.h"
 #include "ucloc.h"
 #include "basic_block.h"
-#include "array_size.h"
 #include "ignore_unused_variable_warning.h"
 
 using std::vector;
@@ -75,7 +74,7 @@ Uc_var_symbol *Uc_expression::need_var(
 ) {
 	static int cnt = 0;
 	char buf[50];
-	snprintf(buf, array_size(buf), "_tmpval_%d", cnt++);
+	snprintf(buf, sizeof(buf), "_tmpval_%d", cnt++);
 	// Create a 'tmp' variable.
 	Uc_var_symbol *var = fun->add_symbol(buf, true);
 	if (var == nullptr) {
@@ -116,7 +115,7 @@ void Uc_var_expression::gen_value(
 ) {
 	if (!var->gen_value(out)) {
 		char buf[150];
-		snprintf(buf, array_size(buf), "Can't use value of '%s'", var->get_name());
+		snprintf(buf, sizeof(buf), "Can't use value of '%s'", var->get_name());
 		error(buf);
 	}
 }
@@ -130,7 +129,7 @@ void Uc_var_expression::gen_assign(
 ) {
 	if (!var->gen_assign(out)) {
 		char buf[150];
-		snprintf(buf, array_size(buf), "Can't assign to '%s'", var->get_name());
+		snprintf(buf, sizeof(buf), "Can't assign to '%s'", var->get_name());
 		error(buf);
 	}
 }
@@ -146,7 +145,7 @@ int Uc_fun_name_expression::is_object_function(bool error) const {
 	else {
 		if (error) {
 			char buf[180];
-			snprintf(buf, array_size(buf), "'%s' must be 'shape#' or 'object#'",
+			snprintf(buf, sizeof(buf), "'%s' must be 'shape#' or 'object#'",
 			        fun->get_name());
 			Uc_location::yyerror(buf);
 		}
@@ -493,7 +492,7 @@ int Uc_int_expression::is_object_function(bool error) const {
 	char buf[150];
 	if (value < 0) {
 		if (error) {
-			snprintf(buf, array_size(buf), "Invalid fun. ID (%d): can't call negative function", value);
+			snprintf(buf, sizeof(buf), "Invalid fun. ID (%d): can't call negative function", value);
 			Uc_location::yyerror(buf);
 		}
 		return 2;
@@ -505,7 +504,7 @@ int Uc_int_expression::is_object_function(bool error) const {
 		return -1;  // Can't determine.
 	else if (sym->get_function_type() == Uc_function_symbol::utility_fun) {
 		if (error) {
-			snprintf(buf, array_size(buf),
+			snprintf(buf, sizeof(buf),
 			        "'%s' (fun. ID %d)  must be 'shape#' or 'object#'",
 			        sym->get_name(), value);
 			Uc_location::yyerror(buf);
@@ -727,14 +726,14 @@ int Uc_call_expression::is_object_function(bool error) const {
 		// *Could* be, if not a high shape.
 		// Let's say it is, but issue a warning.
 		if (error) {
-			snprintf(buf, array_size(buf), "Shape # is equal to fun. ID only for shapes < 0x400; use UI_get_usecode_fun instead");
+			snprintf(buf, sizeof(buf), "Shape # is equal to fun. ID only for shapes < 0x400; use UI_get_usecode_fun instead");
 			Uc_location::yywarning(buf);
 		}
 		return -2;
 	}
 	// For now, no other intrinsics return a valid fun ID.
 	if (error) {
-		snprintf(buf, array_size(buf), "Return of intrinsic '%s' is not fun. ID", fun->get_name());
+		snprintf(buf, sizeof(buf), "Return of intrinsic '%s' is not fun. ID", fun->get_name());
 		Uc_location::yyerror(buf);
 	}
 	return 3;
@@ -758,7 +757,7 @@ void Uc_call_expression::check_params() {
 	if (parmscnt != protoparms.size()) {
 		char buf[150];
 		const unsigned long protoparmcnt = protoparms.size() - ignore_this;
-		snprintf(buf, array_size(buf),
+		snprintf(buf, sizeof(buf),
 		        "# parms. passed (%lu) doesn't match '%s' count (%lu)",
 		        parmscnt - ignore_this, sym->get_name(), protoparmcnt);
 		Uc_location::yyerror(buf);
@@ -772,12 +771,12 @@ void Uc_call_expression::check_params() {
 		char buf[180];
 		if (expr->is_class()) {
 			if (!cls) {
-				snprintf(buf, array_size(buf),
+				snprintf(buf, sizeof(buf),
 				        "Error in parm. #%lu: cannot convert class to non-class", i + 1);
 				Uc_location::yyerror(buf);
 			} else if (!expr->get_cls()->is_class_compatible(
 			               cls->get_cls()->get_name())) {
-				snprintf(buf, array_size(buf),
+				snprintf(buf, sizeof(buf),
 				        "Error in parm. #%lu: class '%s' cannot be converted into class '%s'",
 				        i + 1, expr->get_cls()->get_name(),
 				        cls->get_cls()->get_name());
@@ -785,7 +784,7 @@ void Uc_call_expression::check_params() {
 			}
 		} else {
 			if (cls) {
-				snprintf(buf, array_size(buf),
+				snprintf(buf, sizeof(buf),
 				        "Error in parm. #%lu: cannot convert non-class into class", i + 1);
 				Uc_location::yyerror(buf);
 			}
@@ -820,7 +819,7 @@ void Uc_call_expression::gen_value(
 	if (!sym->gen_call(out, function, original, itemref,
 	                   parms, return_value, meth_scope)) {
 		char buf[150];
-		snprintf(buf, array_size(buf), "'%s' isn't a function or intrinsic",
+		snprintf(buf, sizeof(buf), "'%s' isn't a function or intrinsic",
 		        sym->get_name());
 		sym = nullptr;        // Avoid repeating error if in loop.
 		error(buf);
@@ -832,7 +831,7 @@ void Uc_class_expression::gen_value(
 ) {
 	if (!var->gen_value(out)) {
 		char buf[150];
-		snprintf(buf, array_size(buf), "Can't assign to '%s'", var->get_name());
+		snprintf(buf, sizeof(buf), "Can't assign to '%s'", var->get_name());
 		error(buf);
 	}
 }
@@ -850,7 +849,7 @@ void Uc_class_expression::gen_assign(
 ) {
 	if (!var->gen_assign(out)) {
 		char buf[150];
-		snprintf(buf, array_size(buf), "Can't assign to '%s'", var->get_name());
+		snprintf(buf, sizeof(buf), "Can't assign to '%s'", var->get_name());
 		error(buf);
 	}
 }
@@ -868,12 +867,12 @@ Uc_new_expression::Uc_new_expression(
 	if (cls->get_num_vars() > pushed_parms) {
 		char buf[180];
 		const int missing = cls->get_num_vars() - pushed_parms;
-		snprintf(buf, array_size(buf), "%d argument%s missing in constructor of class '%s'",
+		snprintf(buf, sizeof(buf), "%d argument%s missing in constructor of class '%s'",
 		        missing, (missing > 1) ? "s" : "", cls->get_name());
 		yywarning(buf);
 	} else if (cls->get_num_vars() < pushed_parms) {
 		char buf[180];
-		snprintf(buf, array_size(buf), "Too many arguments in constructor of class '%s'",
+		snprintf(buf, sizeof(buf), "Too many arguments in constructor of class '%s'",
 		        cls->get_name());
 		yyerror(buf);
 	}

--- a/usecode/compiler/uclex.ll
+++ b/usecode/compiler/uclex.ll
@@ -42,7 +42,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "ucparse.h"
 #include "ucloc.h"
 #include "ucfun.h"
-#include "array_size.h"
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
@@ -154,7 +153,7 @@ static void Include
 	if (!yyin)
 		{
 		char msg[180];
-		snprintf(msg, array_size(msg), "Can't open '%s'", name);
+		snprintf(msg, sizeof(msg), "Can't open '%s'", name);
 		Uc_location::yyerror(msg);
 		exit(1);
 		}
@@ -293,7 +292,7 @@ char *Handle_string
 				if (escape.size() != 2 && escape.size() != 3) {
 					// Just in case.
 					char buf[150];
-					snprintf(buf, array_size(buf), "Invalid rune escape sequence '\\{%s}'. "
+					snprintf(buf, sizeof(buf), "Invalid rune escape sequence '\\{%s}'. "
 					             "Valid escapes are: '\\{dot}', '\\{ea}', '\\{ee}', '\\{ng}', '\\{st}', '\\{th}'",
 								 escape.c_str());
 					Uc_location::yyerror(buf);
@@ -307,7 +306,7 @@ char *Handle_string
 		default:
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "Unknown escape sequence '\\%c'. If you are trying "
+			snprintf(buf, sizeof(buf), "Unknown escape sequence '\\%c'. If you are trying "
 			             "to insert a literal backslash ('\\') into text, "
 			             "write it as '\\\\'.", *from);
 			Uc_location::yywarning(buf);

--- a/usecode/compiler/ucparse.yy
+++ b/usecode/compiler/ucparse.yy
@@ -33,7 +33,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <string>
 #include <vector>
 
-#include "array_size.h"
 #include "ucfun.h"
 #include "ucclass.h"
 #include "ucexpr.h"
@@ -552,7 +551,7 @@ opt_trailing_label:
 		if (cur_fun->has_ret())
 			{
 			char buf[180];
-			snprintf(buf, array_size(buf), "Trailing label '%s' in non-void function '%s' is not allowed",
+			snprintf(buf, sizeof(buf), "Trailing label '%s' in non-void function '%s' is not allowed",
 					$1->get_label().c_str(), cur_fun->get_name());
 			yyerror(buf);
 			$$ = nullptr;
@@ -584,13 +583,13 @@ function_proto:
 			char buf[180];
 			if (has_ret || struct_type)
 				{
-				snprintf(buf, array_size(buf), "Functions declared with '%s#' cannot return a value",
+				snprintf(buf, sizeof(buf), "Functions declared with '%s#' cannot return a value",
 					$4->kind == Uc_function_symbol::shape_fun ? "shape" : "object");
 				yyerror(buf);
 				}
 			if (!$6->empty())
 				{
-				snprintf(buf, array_size(buf), "Functions declared with '%s#' cannot have arguments",
+				snprintf(buf, sizeof(buf), "Functions declared with '%s#' cannot have arguments",
 					$4->kind == Uc_function_symbol::shape_fun ? "shape" : "object");
 				yyerror(buf);
 				}
@@ -705,13 +704,13 @@ const_int_val:
 		char buf[180];
 		if (!sym)
 			{
-			snprintf(buf, array_size(buf), "'%s' not declared", $1);
+			snprintf(buf, sizeof(buf), "'%s' not declared", $1);
 			yyerror(buf);
 			$$ = -1;
 			}
 		else if ((var = dynamic_cast<Uc_const_int_symbol *>(sym)) == nullptr)
 			{
-			snprintf(buf, array_size(buf), "'%s' is not a constant integer", $1);
+			snprintf(buf, sizeof(buf), "'%s' is not a constant integer", $1);
 			yyerror(buf);
 			$$ = -1;
 			}
@@ -1010,7 +1009,7 @@ var_decl:
 		if (cur_class && !cur_fun)
 			{
 			char buf[180];
-			snprintf(buf, array_size(buf), "Initialization of class member var '%s' must be done through constructor", $1);
+			snprintf(buf, sizeof(buf), "Initialization of class member var '%s' must be done through constructor", $1);
 			yyerror(buf);
 			$$ = nullptr;
 			}
@@ -1027,7 +1026,7 @@ var_decl:
 		if (cur_class && !cur_fun)
 			{
 			char buf[180];
-			snprintf(buf, array_size(buf), "Initialization of class member var '%s' must be done through constructor", $1);
+			snprintf(buf, sizeof(buf), "Initialization of class member var '%s' must be done through constructor", $1);
 			yyerror(buf);
 			$$ = nullptr;
 			}
@@ -1128,7 +1127,7 @@ struct_decl:
 		if (cur_class && !cur_fun)
 			{
 			char buf[180];
-			snprintf(buf, array_size(buf), "Initialization of class member struct '%s' must be done through constructor", $1);
+			snprintf(buf, sizeof(buf), "Initialization of class member struct '%s' must be done through constructor", $1);
 			yyerror(buf);
 			$$ = nullptr;
 			}
@@ -1152,7 +1151,7 @@ class_expr:
 		if (!sym)
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "'%s' not declared", $1);
+			snprintf(buf, sizeof(buf), "'%s' not declared", $1);
 			yyerror(buf);
 			cur_fun->add_symbol($1, false);
 			$$ = nullptr;
@@ -1160,7 +1159,7 @@ class_expr:
 		else if (sym->get_sym_type() != Uc_symbol::Class)
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "'%s' not a class", $1);
+			snprintf(buf, sizeof(buf), "'%s' not a class", $1);
 			yyerror(buf);
 			$$ = nullptr;
 			}
@@ -1642,7 +1641,7 @@ start_array_loop:
 		if ($4->get_cls())
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "Can't convert class '%s' into non-class",
+			snprintf(buf, sizeof(buf), "Can't convert class '%s' into non-class",
 					$4->get_name());
 			yyerror(buf);
 			}
@@ -1714,7 +1713,7 @@ return_statement:
 		if (!cur_fun->has_ret())
 			{
 			char buf[180];
-			snprintf(buf, array_size(buf), "Function '%s' can't return a value",
+			snprintf(buf, sizeof(buf), "Function '%s' can't return a value",
 					cur_fun->get_name());
 			yyerror(buf);
 			$$ = nullptr;
@@ -1733,7 +1732,7 @@ return_statement:
 				else
 					{
 					char buf[210];
-					snprintf(buf, array_size(buf), "Function '%s' expects a return of %s '%s' but supplied value is %s'%s'",
+					snprintf(buf, sizeof(buf), "Function '%s' expects a return of %s '%s' but supplied value is %s'%s'",
 							cur_fun->get_name(),
 							trg ? "class" : "type",
 							trg ? trg->get_name() : "var",
@@ -1755,7 +1754,7 @@ return_statement:
 			{
 			Uc_class *cls = cur_fun->get_cls();
 			char buf[180];
-			snprintf(buf, array_size(buf), "Function '%s' must return a '%s'",
+			snprintf(buf, sizeof(buf), "Function '%s' must return a '%s'",
 					cur_fun->get_name(), cls ? cls->get_name() : "var");
 			yyerror(buf);
 			$$ = nullptr;
@@ -2188,7 +2187,7 @@ start_call:
 			if ($2->is_object_function() == -1)
 				{	// Don't know.
 				char buf[180];
-				snprintf(buf, array_size(buf), "Please ensure that 'call' uses a function declared with 'shape#' or 'object#'");
+				snprintf(buf, sizeof(buf), "Please ensure that 'call' uses a function declared with 'shape#' or 'object#'");
 				yywarning(buf);
 				}
 			$$ = $2;
@@ -2329,7 +2328,7 @@ label_statement:
 		if (cur_fun->search_label($1))
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "duplicate label: '%s'", $1);
+			snprintf(buf, sizeof(buf), "duplicate label: '%s'", $1);
 			yyerror(buf);
 			$$ = nullptr;
 			}
@@ -2357,7 +2356,7 @@ delete_statement:
 		if (!cls)
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "'%s' is not a class", $2->get_name());
+			snprintf(buf, sizeof(buf), "'%s' is not a class", $2->get_name());
 			yyerror(buf);
 			$$ = nullptr;
 			}
@@ -2495,7 +2494,7 @@ addressof:
 		if (!sym)	/* See if the symbol is defined */
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "'%s' not declared", $2);
+			snprintf(buf, sizeof(buf), "'%s' not declared", $2);
 			yyerror(buf);
 			$$ = -1;
 			}
@@ -2503,7 +2502,7 @@ addressof:
 		if (!fun)	/* See if the symbol is a function */
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "'%s' is not a function", $2);
+			snprintf(buf, sizeof(buf), "'%s' is not a function", $2);
 			yyerror(buf);
 			$$ = -1;
 			}
@@ -2521,7 +2520,7 @@ addressof:
 			if (value < 0)
 				{
 				char buf[150];
-				snprintf(buf, array_size(buf),
+				snprintf(buf, sizeof(buf),
 						"'struct<%s>::%s' is not a valid structure member",
 						$4->get_name(), $7);
 				yyerror(buf);
@@ -2565,12 +2564,12 @@ primary:
 			char buf[150];
 			if (is_int_32bit($1))
 				{
-				snprintf(buf, array_size(buf), "Literal integer '%d' cannot be represented as 16-bit integer. Assuming '(long)' cast.",
+				snprintf(buf, sizeof(buf), "Literal integer '%d' cannot be represented as 16-bit integer. Assuming '(long)' cast.",
 						$1);
 				op = UC_PUSHI32;
 				}
 			else
-				snprintf(buf, array_size(buf), "Interpreting integer '%d' as the signed 16-bit integer '%d'. If this is incorrect, use '(long)' cast.",
+				snprintf(buf, sizeof(buf), "Interpreting integer '%d' as the signed 16-bit integer '%d'. If this is incorrect, use '(long)' cast.",
 						$1, static_cast<short>($1));
 			yywarning(buf);
 			}
@@ -2593,7 +2592,7 @@ primary:
 			if (offset < 0)
 				{
 				char buf[150];
-				snprintf(buf, array_size(buf), "'%s' does not belong to struct '%s'",
+				snprintf(buf, sizeof(buf), "'%s' does not belong to struct '%s'",
 						$1->name, base->get_name());
 				yyerror(buf);
 				$$ = new Uc_int_expression(0);
@@ -2619,7 +2618,7 @@ primary:
 		if ($1->get_cls())
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "Can't convert class '%s' into non-class",
+			snprintf(buf, sizeof(buf), "Can't convert class '%s' into non-class",
 					$1->get_name());
 			yyerror(buf);
 			$$ = new Uc_arrayelem_expression($1, $3);
@@ -2794,12 +2793,12 @@ int_literal:				/* A const. integer value.	*/
 			char buf[150];
 			if (is_int_32bit($1))
 				{
-				snprintf(buf, array_size(buf), "Literal integer '%d' cannot be represented as 16-bit integer. Assuming '(long)' cast.",
+				snprintf(buf, sizeof(buf), "Literal integer '%d' cannot be represented as 16-bit integer. Assuming '(long)' cast.",
 						$1);
 				op = UC_PUSHI32;
 				}
 			else
-				snprintf(buf, array_size(buf), "Interpreting integer '%d' as the signed 16-bit integer '%d'. If this is incorrect, use '(long)' cast.",
+				snprintf(buf, sizeof(buf), "Interpreting integer '%d' as the signed 16-bit integer '%d'. If this is incorrect, use '(long)' cast.",
 						$1, static_cast<short>($1));
 			yywarning(buf);
 			}
@@ -2814,7 +2813,7 @@ int_literal:				/* A const. integer value.	*/
 		if (!sym)
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "'%s' is not a const int", $1->get_name());
+			snprintf(buf, sizeof(buf), "'%s' is not a const int", $1->get_name());
 			yyerror(buf);
 			$$ = nullptr;
 			}
@@ -2851,7 +2850,7 @@ declared_var_value:
 		if (!$$)
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "Can't use '%s' here", $1->get_name());
+			snprintf(buf, sizeof(buf), "Can't use '%s' here", $1->get_name());
 			yyerror(buf);
 			$$ = new Uc_int_expression(0);
 			}
@@ -2865,9 +2864,9 @@ declared_var:
 		if (!var)
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "'%s' not a 'var'", $1->get_name());
+			snprintf(buf, sizeof(buf), "'%s' not a 'var'", $1->get_name());
 			yyerror(buf);
-			snprintf(buf, array_size(buf), "%s_needvar", $1->get_name());
+			snprintf(buf, sizeof(buf), "%s_needvar", $1->get_name());
 			var = cur_fun->add_symbol(buf, false);
 			}
 		$$ = var;
@@ -2881,7 +2880,7 @@ declared_sym:
 		if (!sym)
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "'%s' not declared", $1);
+			snprintf(buf, sizeof(buf), "'%s' not declared", $1);
 			yyerror(buf);
 			sym = cur_fun->add_symbol($1, false);
 			}
@@ -2902,7 +2901,7 @@ defined_struct:
 		if (!sym)
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "'%s' not found, or is not a struct.", $1);
+			snprintf(buf, sizeof(buf), "'%s' not found, or is not a struct.", $1);
 			yyerror(buf);
 			$$ = nullptr;
 			}
@@ -2968,7 +2967,7 @@ static Uc_class *Find_class
 	if (!csym)
 		{
 		char buf[150];
-		snprintf(buf, array_size(buf), "'%s' not found, or is not a class.", nm);
+		snprintf(buf, sizeof(buf), "'%s' not found, or is not a class.", nm);
 		yyerror(buf);
 		return nullptr;
 		}
@@ -3000,7 +2999,7 @@ static bool Incompatible_classes_error(Uc_class *src, Uc_class *trg)
 	if (!src->is_class_compatible(trg->get_name()))
 		{
 		char buf[180];
-		snprintf(buf, array_size(buf), "Class '%s' can't be converted into class '%s'",
+		snprintf(buf, sizeof(buf), "Class '%s' can't be converted into class '%s'",
 				src->get_name(), trg->get_name());
 		yyerror(buf);
 		return true;
@@ -3020,7 +3019,7 @@ static Uc_call_expression *cls_method_call
 	if (!curcls)
 		{
 		char buf[150];
-		snprintf(buf, array_size(buf), "'%s' requires a class object", nm);
+		snprintf(buf, sizeof(buf), "'%s' requires a class object", nm);
 		yyerror(buf);
 		return nullptr;
 		}
@@ -3032,7 +3031,7 @@ static Uc_call_expression *cls_method_call
 	if (!sym)
 		{
 		char buf[150];
-		snprintf(buf, array_size(buf), "Function '%s' is not declared in class '%s'",
+		snprintf(buf, sizeof(buf), "Function '%s' is not declared in class '%s'",
 				nm, clsscope->get_name());
 		yyerror(buf);
 		return nullptr;
@@ -3042,7 +3041,7 @@ static Uc_call_expression *cls_method_call
 	if (!fun)
 		{
 		char buf[150];
-		snprintf(buf, array_size(buf), "'%s' is not a function", nm);
+		snprintf(buf, sizeof(buf), "'%s' is not a function", nm);
 		yyerror(buf);
 		return nullptr;
 		}
@@ -3073,14 +3072,14 @@ static bool Uc_is_valid_calle
 		if (ths && !ths->is_class())
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "'%s' is not an object or shape function", nm);
+			snprintf(buf, sizeof(buf), "'%s' is not an object or shape function", nm);
 			yyerror(buf);
 			return false;
 			}
 		else if (ths)
 			{
 			char buf[150];
-			snprintf(buf, array_size(buf), "'%s' is not a member of class '%s'",
+			snprintf(buf, sizeof(buf), "'%s' is not a member of class '%s'",
 					nm, ths->get_cls()->get_name());
 			yyerror(buf);
 			return false;
@@ -3091,7 +3090,7 @@ static bool Uc_is_valid_calle
 		if (!ths)
 			{
 			char buf[180];
-			snprintf(buf, array_size(buf), "'%s' expects an itemref, but none was supplied; using current itemref", nm);
+			snprintf(buf, sizeof(buf), "'%s' expects an itemref, but none was supplied; using current itemref", nm);
 			ths = new Uc_item_expression();
 			yywarning(buf);
 			return true;
@@ -3163,7 +3162,7 @@ static Uc_call_expression *cls_function_call
 	if (!sym)
 		{
 		char buf[150];
-		snprintf(buf, array_size(buf), "'%s' not declared", nm);
+		snprintf(buf, sizeof(buf), "'%s' not declared", nm);
 		yyerror(buf);
 		return nullptr;
 		}

--- a/usecode/compiler/ucstmt.cc
+++ b/usecode/compiler/ucstmt.cc
@@ -30,7 +30,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <cstdio>
 #include <cassert>
 
-#include "array_size.h"
 #include "ucstmt.h"
 #include "ucexpr.h"
 #include "ucsym.h"
@@ -209,7 +208,7 @@ void Uc_trycatch_statement::gen(
 	// Generate a temp variable for error if needed
 	if (!catch_var) {
 		char buf[50];
-		snprintf(buf, array_size(buf), "_tmperror_%d", cnt++);
+		snprintf(buf, sizeof(buf), "_tmperror_%d", cnt++);
 		// Create a 'tmp' variable.
 		catch_var = fun->add_symbol(buf, true);
 		assert(catch_var != nullptr);
@@ -519,11 +518,11 @@ void Uc_arrayloop_statement_base::finish(
 ) {
 	char buf[100];
 	if (index == nullptr) {       // Create vars. if not given.
-		snprintf(buf, array_size(buf), "_%s_index", array->get_name());
+		snprintf(buf, sizeof(buf), "_%s_index", array->get_name());
 		index = fun->add_symbol(buf, true);
 	}
 	if (array_len == nullptr) {
-		snprintf(buf, array_size(buf), "_%s_size", array->get_name());
+		snprintf(buf, sizeof(buf), "_%s_size", array->get_name());
 		array_len = fun->add_symbol(buf, true);
 	}
 }
@@ -631,7 +630,7 @@ void Uc_arrayloop_attend_statement::gen(
 	auto it = labels.find(label);
 	if (it == labels.end()) {
 		char buf[255];
-		snprintf(buf, 255, "Undeclared label: '%s'", label.c_str());
+		snprintf(buf, sizeof(buf), "Undeclared label: '%s'", label.c_str());
 		error(buf);
 		return;
 	}
@@ -764,7 +763,7 @@ void Uc_goto_statement::gen(
 		blocks.push_back(curr);
 	} else {
 		char buf[255];
-		snprintf(buf, 255, "Undeclared label: '%s'", label.c_str());
+		snprintf(buf, sizeof(buf), "Undeclared label: '%s'", label.c_str());
 		error(buf);
 	}
 }
@@ -1017,7 +1016,7 @@ void Uc_converse_case_attend_statement::gen(
 	auto it = labels.find(label);
 	if (it == labels.end()) {
 		char buf[255];
-		snprintf(buf, 255, "Undeclared label: '%s'", label.c_str());
+		snprintf(buf, sizeof(buf), "Undeclared label: '%s'", label.c_str());
 		error(buf);
 		return;
 	}
@@ -1280,7 +1279,7 @@ void Uc_converse_attend_statement::gen(
 	auto it = labels.find(label);
 	if (it == labels.end()) {
 		char buf[255];
-		snprintf(buf, 255, "Undeclared label: '%s'", label.c_str());
+		snprintf(buf, sizeof(buf), "Undeclared label: '%s'", label.c_str());
 		error(buf);
 		return;
 	}
@@ -1369,7 +1368,7 @@ Uc_switch_statement::Uc_switch_statement(
 		if (stmt->is_default()) {
 			if (has_default) {
 				char buf[255];
-				snprintf(buf, 255, "switch statement already has a default case.");
+				snprintf(buf, sizeof(buf), "switch statement already has a default case.");
 				error(buf);
 			} else
 				has_default = true;

--- a/usecode/compiler/ucsym.cc
+++ b/usecode/compiler/ucsym.cc
@@ -36,7 +36,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "ucfun.h"
 #include "ucclass.h"
 #include "basic_block.h"
-#include "array_size.h"
 #include "ignore_unused_variable_warning.h"
 
 using std::strcmp;
@@ -132,20 +131,20 @@ int Uc_var_symbol::is_object_function(bool print_error) const {
 		char buf[180];
 		switch (is_obj_fun) {
 		case -2:
-			snprintf(buf, array_size(buf), "Shape # is equal to fun. ID only for shapes < 0x400; use UI_get_usecode_fun instead");
+			snprintf(buf, sizeof(buf), "Shape # is equal to fun. ID only for shapes < 0x400; use UI_get_usecode_fun instead");
 			Uc_location::yywarning(buf);
 			break;
 		case 1:
-			snprintf(buf, array_size(buf), "Var '%s' contains fun. not declared as 'shape#' or 'object#'",
+			snprintf(buf, sizeof(buf), "Var '%s' contains fun. not declared as 'shape#' or 'object#'",
 			        name.c_str());
 			Uc_location::yyerror(buf);
 			break;
 		case 2:
-			snprintf(buf, array_size(buf), "Var '%s' contains a negative number", name.c_str());
+			snprintf(buf, sizeof(buf), "Var '%s' contains a negative number", name.c_str());
 			Uc_location::yyerror(buf);
 			break;
 		case 3:
-			snprintf(buf, array_size(buf), "Return of intrinsics are generally not fun. IDs");
+			snprintf(buf, sizeof(buf), "Return of intrinsics are generally not fun. IDs");
 			Uc_location::yyerror(buf);
 			break;
 		}
@@ -220,7 +219,7 @@ bool Uc_struct_symbol::is_dup(
 	const int index = search(nm);
 	if (index >= 0) {       // Already declared?
 		char msg[180];
-		snprintf(msg, array_size(msg), "Symbol '%s' already declared", nm);
+		snprintf(msg, sizeof(msg), "Symbol '%s' already declared", nm);
 		Uc_location::yyerror(msg);
 		return true;
 	}
@@ -245,7 +244,7 @@ Uc_class_symbol *Uc_class_symbol::create(
 	Uc_symbol *sym = Uc_function::search_globals(nm);
 	if (sym) {
 		char buf[256];
-		snprintf(buf, array_size(buf), "Class name '%s' already exists.", nm);
+		snprintf(buf, sizeof(buf), "Class name '%s' already exists.", nm);
 		Uc_location::yyerror(buf);
 	}
 	auto *csym = new Uc_class_symbol(nm, c);
@@ -403,20 +402,20 @@ Uc_function_symbol *Uc_function_symbol::create(
 		num = -1;
 		if (kind == shape_fun) {
 			char buf[180];
-			snprintf(buf, array_size(buf), "Shape number cannot be negative");
+			snprintf(buf, sizeof(buf), "Shape number cannot be negative");
 			Uc_location::yyerror(buf);
 		}
 	} else if (num < 0x400) {
 		if (kind == utility_fun) {
 			char buf[180];
-			snprintf(buf, array_size(buf), "Treating function '%s' as being a 'shape#()' function.", nm);
+			snprintf(buf, sizeof(buf), "Treating function '%s' as being a 'shape#()' function.", nm);
 			Uc_location::yywarning(buf);
 			kind = shape_fun;
 		}
 	} else if (num < 0x800) {
 		if (kind == utility_fun) {
 			char buf[180];
-			snprintf(buf, array_size(buf), "Treating function '%s' as being an 'object#()' function.", nm);
+			snprintf(buf, sizeof(buf), "Treating function '%s' as being an 'object#()' function.", nm);
 			Uc_location::yywarning(buf);
 			kind = object_fun;
 		}
@@ -460,7 +459,7 @@ Uc_function_symbol *Uc_function_symbol::create(
 		} else if (scope) {
 			if (!sym->is_inherited()) {
 				char buf[256];
-				snprintf(buf, array_size(buf), "Duplicate declaration of function '%s'.", nm);
+				snprintf(buf, sizeof(buf), "Duplicate declaration of function '%s'.", nm);
 				Uc_location::yyerror(buf);
 			}
 		} else if (sym->is_externed() || is_extern)
@@ -475,14 +474,14 @@ Uc_function_symbol *Uc_function_symbol::create(
 				num = -1;
 		else {
 			char buf[256];
-			snprintf(buf, array_size(buf), "Duplicate declaration of function '%s'.", nm);
+			snprintf(buf, sizeof(buf), "Duplicate declaration of function '%s'.", nm);
 			Uc_location::yyerror(buf);
 		}
 	}
 
 	if (num < 0 && !new_auto_num) {
 		char buf[256];
-		snprintf(buf, array_size(buf),
+		snprintf(buf, sizeof(buf),
 		        "Auto-numbering function '%s', but '#autonumber' directive not used.",
 		        nm);
 		Uc_location::yywarning(buf);
@@ -507,7 +506,7 @@ Uc_function_symbol *Uc_function_symbol::create(
 	sym = it->second;
 	if (sym->name != nm || sym->get_num_parms() != p.size()) {
 		char buf[256];
-		snprintf(buf, array_size(buf),
+		snprintf(buf, sizeof(buf),
 		        "Function 0x%x already used for '%s' with %zu params.",
 		        ucnum, sym->get_name(), sym->get_num_parms());
 		Uc_location::yyerror(buf);
@@ -543,14 +542,14 @@ int Uc_function_symbol::gen_call(
 	size_t parmcnt = aparms->gen_values(out);   // Want to push parm. values.
 	parmcnt += (method_num >= 0);       // Count 'this'.
 	if (parmcnt != parms.size()) {
-		snprintf(buf, array_size(buf),
+		snprintf(buf, sizeof(buf),
 		        "# parms. passed (%zu) doesn't match '%s' count (%zu)",
 		        parmcnt, get_name(), parms.size());
 		Uc_location::yyerror(buf);
 	}
 	// See if expecting a return value from a function that has none.
 	if (retvalue && !has_ret()) {
-		snprintf(buf, array_size(buf),
+		snprintf(buf, sizeof(buf),
 		        "Function '%s' does not have a return value",
 		        get_name());
 		Uc_location::yyerror(buf);
@@ -571,7 +570,7 @@ int Uc_function_symbol::gen_call(
 				itemref = tsym->create_expression();
 		}
 		if (!itemref) {
-			snprintf(buf, array_size(buf),
+			snprintf(buf, sizeof(buf),
 			        "Class method '%s' requires a 'this'.", get_name());
 			Uc_location::yyerror(buf);
 		} else
@@ -609,7 +608,7 @@ int Uc_function_symbol::gen_call(
 		// Generate the code to pop the result off the stack.
 		static int cnt = 0;
 		char buf[50];
-		snprintf(buf, array_size(buf), "_tmpretval_%d", cnt++);
+		snprintf(buf, sizeof(buf), "_tmpretval_%d", cnt++);
 		// Create a 'tmp' variable.
 		Uc_var_symbol *var = fun->add_symbol(buf, true);
 		if (!var)
@@ -682,13 +681,13 @@ int Uc_scope::add_function_symbol(
 	if (fun2 == fun)        // The case for an EXTERN.
 		return 1;
 	else if (!fun2) {       // Non-function name.
-		snprintf(buf, array_size(buf), "'%s' already declared", nm);
+		snprintf(buf, sizeof(buf), "'%s' already declared", nm);
 		Uc_location::yyerror(buf);
 	} else if (fun->get_num_parms() != fun2->get_num_parms()) {
 		if (fun2->is_inherited())
-			snprintf(buf, array_size(buf), "Decl. of virtual member function '%s' doesn't match decl. from base class", nm);
+			snprintf(buf, sizeof(buf), "Decl. of virtual member function '%s' doesn't match decl. from base class", nm);
 		else
-			snprintf(buf, array_size(buf), "Decl. of '%s' doesn't match previous decl", nm);
+			snprintf(buf, sizeof(buf), "Decl. of '%s' doesn't match previous decl", nm);
 		Uc_location::yyerror(buf);
 	} else if (fun->usecode_num != fun2->usecode_num) {
 		if (fun2->externed || fun->externed || fun2->is_inherited()) {
@@ -696,7 +695,7 @@ int Uc_scope::add_function_symbol(
 			        Uc_function_symbol::last_num == fun->usecode_num)
 				--Uc_function_symbol::last_num;
 		} else {
-			snprintf(buf, array_size(buf), "Decl. of '%s' has different usecode #.",
+			snprintf(buf, sizeof(buf), "Decl. of '%s' has different usecode #.",
 			        nm);
 			Uc_location::yyerror(buf);
 		}
@@ -716,7 +715,7 @@ bool Uc_scope::is_dup(
 	Uc_symbol *sym = search(nm);
 	if (sym) {          // Already in scope?
 		char msg[180];
-		snprintf(msg, array_size(msg), "Symbol '%s' already declared", nm);
+		snprintf(msg, sizeof(msg), "Symbol '%s' already declared", nm);
 		Uc_location::yyerror(msg);
 		return true;
 	}

--- a/usecode/ucinternal.cc
+++ b/usecode/ucinternal.cc
@@ -2508,7 +2508,7 @@ int Usecode_internal::run() {
 					//              if (locals[offset].get_int_value() != 0) {
 					if (frame->locals[offset].get_int_value() >= 0) {
 						char buf[20];
-						snprintf(buf, 20, "%ld",
+						snprintf(buf, sizeof(buf), "%ld",
 						         frame->locals[offset].get_int_value());
 						append_string(buf);
 					}

--- a/win32/exconfig.cc
+++ b/win32/exconfig.cc
@@ -397,7 +397,7 @@ extern "C" {
 		// Check all the IFIX files
 		//for (i = 0; i < 144; i++) {
 		//  char num[4];
-		//  std::snprintf(num, array_size(num), "%02X", i);
+		//  std::snprintf(num, sizeof(num), "%02X", i);
 		//
 		//  string s(U7IFIX);
 		//  s += num;
@@ -436,7 +436,7 @@ extern "C" {
 		// Check all the IFIX files
 		//for (i = 0; i < 144; i++) {
 		//  char num[4];
-		//  std::snprintf(num, array_size(num), "%02X", i);
+		//  std::snprintf(num, sizeof(num), "%02X", i);
 		//
 		//  string s(U7IFIX);
 		//  s += num;


### PR DESCRIPTION
Ensure that all `(v)snprintf` 

- Set their size parameter to always an identifier or the `sizeof` of the receiving buffer,
- Are not followed by a store of a caution 00 byte at the end of the buffer, since `(v)snprintf` warrants the trailing 00.

Silence warnings about NULL in ICU on macOS in `mapedit/studio.cc`.