### PR TITLE
Silence C++ 20 warning

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -160,7 +160,6 @@ WARNINGS := \
 	-Wall \
 	-Wextra \
 	-Wpedantic \
-	-Wc++14-compat \
 	-Wc++17-compat \
 	-Wc++20-compat \
 	-Walloc-zero \

--- a/actors.cc
+++ b/actors.cc
@@ -3173,24 +3173,21 @@ void Actor::lay_down(bool die) {
 
 	set_action(nullptr);
 	auto* scr = new Usecode_script(this);
-	(*scr) << Ucscript::finish << (Ucscript::npc_frame + Actor::standing);
+	(*scr) << Ucscript::finish << Ucscript::npc_standing_frame;
 	if (GAME_SI && get_shapenum() == 832) {    // SI Frost serpent
 		// Frames are in reversed order. This results in a
 		// strangeanimation in the original, which we fix here.
-		(*scr) << (Ucscript::npc_frame + Actor::sleep_frame)
-			   << (Ucscript::npc_frame + Actor::kneel_frame)
-			   << (Ucscript::npc_frame + Actor::bow_frame)
-			   << (Ucscript::npc_frame + Actor::sit_frame);
+		(*scr) << Ucscript::npc_sleep_frame << Ucscript::npc_kneel_frame
+			   << Ucscript::npc_bow_frame << Ucscript::npc_sit_frame;
 	} else if (get_info().has_strange_movement()) {
 		// BG Sea serpent; slimes are done elsewhere.
-		(*scr) << (Ucscript::npc_frame + Actor::bow_frame)
-			   << (Ucscript::npc_frame + Actor::kneel_frame)
-			   << (Ucscript::npc_frame + Actor::sleep_frame);
+		(*scr) << Ucscript::npc_bow_frame << Ucscript::npc_kneel_frame
+			   << Ucscript::npc_sleep_frame;
 	} else {
-		(*scr) << (Ucscript::npc_frame + Actor::kneel_frame) << Ucscript::sfx
+		(*scr) << Ucscript::npc_kneel_frame << Ucscript::sfx
 			   << Audio::game_sfx(86);
 		if (!die) {
-			(*scr) << (Ucscript::npc_frame + Actor::sleep_frame);
+			(*scr) << Ucscript::npc_sleep_frame;
 		}
 	}
 	if (die) {    // If dying, remove.
@@ -4663,9 +4660,8 @@ Actor* Actor::resurrect(Dead_body* body    // Must be this actor's body.
 		return this;
 	}
 	auto* scr = new Usecode_script(this);
-	(*scr) << (Ucscript::npc_frame + Actor::sleep_frame)
-		   << (Ucscript::npc_frame + Actor::kneel_frame)
-		   << (Ucscript::npc_frame + Actor::standing);
+	(*scr) << Ucscript::npc_sleep_frame << Ucscript::npc_kneel_frame
+		   << Ucscript::npc_standing_frame;
 	scr->start(1);
 	return this;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -135,7 +135,7 @@ AC_PROG_CXX([$cxx_compilers])
 
 AC_LANG([C++])
 
-AX_CXX_COMPILE_STDCXX([17], [noext],[mandatory])
+AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
 AC_PROG_CXXCPP
 
 AC_PROG_INSTALL
@@ -1119,7 +1119,7 @@ fi
 
 CHK_WARN="-Wall -Wextra -pedantic"
 CHK_WARN="$CHK_WARN -Walloc-zero -Walloca"
-CHK_WARN="$CHK_WARN -Wc++14-compat -Wc++17-compat -Wbool-compare -Wbool-operation"
+CHK_WARN="$CHK_WARN -Wc++17-compat -Wc++20-compat -Wbool-compare -Wbool-operation"
 CHK_WARN="$CHK_WARN -Wcatch-value=3 -Wcast-align -Wcast-align=strict -Wcast-qual -Wcast-function-type"
 CHK_WARN="$CHK_WARN -Wconditionally-supported -Wctor-dtor-privacy -Wdisabled-optimization"
 CHK_WARN="$CHK_WARN -Wduplicated-branches -Wduplicated-cond -Wextra-semi"

--- a/objs/objs.cc
+++ b/objs/objs.cc
@@ -755,7 +755,6 @@ Game_object* Game_object::find_closest(
 		// 0xb0 mask finds anything.
 		find_nearby(vec, pos, shape, dist, 0xb0);
 	}
-	const size_t cnt = vec.size();
 	if (vec.empty()) {
 		return nullptr;
 	}

--- a/schedule.cc
+++ b/schedule.cc
@@ -940,14 +940,14 @@ void Preach_schedule::now_what() {
 			auto* scr = new Usecode_script(member);
 			scr->add(Ucscript::delay_ticks, 3);
 			scr->add(Ucscript::face_dir, member->get_dir_facing());
-			scr->add(Ucscript::npc_frame + Actor::standing);
+			scr->add(Ucscript::npc_standing_frame);
 			scr->add(
 					Ucscript::say,
 					get_text_msg(
 							first_amen
 							+ rand() % (last_amen - first_amen + 1)));
 			scr->add(Ucscript::delay_ticks, 2);
-			scr->add(Ucscript::npc_frame + Actor::sit_frame);
+			scr->add(Ucscript::npc_sit_frame);
 			scr->start();    // Start next tick.
 		}
 		return;
@@ -998,15 +998,11 @@ void Preach_schedule::now_what() {
 	case pray: {
 		auto* scr = new Usecode_script(npc);
 		(*scr) << Ucscript::face_dir << 6    // Face west.
-			   << (Ucscript::npc_frame + Actor::standing)
-			   << (Ucscript::npc_frame + Actor::bow_frame)
-			   << Ucscript::delay_ticks << 3
-			   << (Ucscript::npc_frame + Actor::kneel_frame);
+			   << Ucscript::npc_standing_frame << Ucscript::npc_bow_frame
+			   << Ucscript::delay_ticks << 3 << Ucscript::npc_kneel_frame;
 		scr->add(Ucscript::say, get_text_msg(first_amen + rand() % 2));
-		(*scr) << Ucscript::delay_ticks << 5
-			   << (Ucscript::npc_frame + Actor::bow_frame)
-			   << Ucscript::delay_ticks << 3
-			   << (Ucscript::npc_frame + Actor::standing);
+		(*scr) << Ucscript::delay_ticks << 5 << Ucscript::npc_bow_frame
+			   << Ucscript::delay_ticks << 3 << Ucscript::npc_standing_frame;
 		scr->start();    // Start next tick.
 		state = find_podium;
 		npc->start(2 * gwin->get_std_delay(), 4000);
@@ -1128,7 +1124,7 @@ void Patrol_schedule::now_what() {
 			// Scripts for all actions. At worst, display standing frame
 			// once the path egg is reached.
 			auto* scr = new Usecode_script(npc);
-			(*scr) << Ucscript::npc_frame + Actor::standing;
+			(*scr) << Ucscript::npc_standing_frame;
 			// Quality = type.  (I think high bits
 			// are flags).
 			const int qual = path->get_quality();
@@ -1177,14 +1173,11 @@ void Patrol_schedule::now_what() {
 				// random, then stands up again after a while.
 				// If anyone complains enough I will add it.
 				// -- Marzo Jan 22/2013
-				(*scr) << Ucscript::delay_ticks << 2
-					   << Ucscript::npc_frame + Actor::bow_frame
+				(*scr) << Ucscript::delay_ticks << 2 << Ucscript::npc_bow_frame
 					   << Ucscript::delay_ticks << 4
-					   << Ucscript::npc_frame + Actor::kneel_frame
-					   << Ucscript::delay_ticks << 20
-					   << Ucscript::npc_frame + Actor::bow_frame
-					   << Ucscript::delay_ticks << 4
-					   << Ucscript::npc_frame + Actor::standing;
+					   << Ucscript::npc_kneel_frame << Ucscript::delay_ticks
+					   << 20 << Ucscript::npc_bow_frame << Ucscript::delay_ticks
+					   << 4 << Ucscript::npc_standing_frame;
 				delay = 36;
 				break;
 			case 6:              // Loiter.
@@ -1284,16 +1277,14 @@ void Patrol_schedule::now_what() {
 				break;
 			case 16:    // Bow to ground.
 				// Trying to differentiate this from 17, below.
-				(*scr) << Ucscript::delay_ticks << 2
-					   << Ucscript::npc_frame + Actor::bow_frame
+				(*scr) << Ucscript::delay_ticks << 2 << Ucscript::npc_bow_frame
 					   << Ucscript::delay_ticks << 2;
 				delay = 8;
 				break;
 			case 17:    // Bow from ground.
 				// Trying to differentiate this from 16, above.
-				(*scr) << Ucscript::npc_frame + Actor::bow_frame
-					   << Ucscript::delay_ticks << 2
-					   << Ucscript::npc_frame + Actor::standing;
+				(*scr) << Ucscript::npc_bow_frame << Ucscript::delay_ticks << 2
+					   << Ucscript::npc_standing_frame;
 				delay = 8;
 				break;
 			case 20:    // Ready weapon
@@ -1370,10 +1361,9 @@ void Patrol_schedule::now_what() {
 			}
 			// Standing up animation.
 			auto* scr = new Usecode_script(npc);
-			(*scr) << Ucscript::delay_ticks << 2
-				   << Ucscript::npc_frame + Actor::bow_frame
+			(*scr) << Ucscript::delay_ticks << 2 << Ucscript::npc_bow_frame
 				   << Ucscript::delay_ticks << 2
-				   << Ucscript::npc_frame + Actor::standing;
+				   << Ucscript::npc_standing_frame;
 			scr->start();    // Start next tick.
 			npc->start(speed, speed * 7);
 		}
@@ -1427,17 +1417,14 @@ void Patrol_schedule::now_what() {
 		const int repcnt = 1 + rand() % 3;
 
 		auto* scr = new Usecode_script(npc);
-		(*scr) << Ucscript::delay_ticks << 2
-			   << Ucscript::npc_frame + Actor::ready_frame
-			   << Ucscript::delay_ticks << 2
-			   << Ucscript::npc_frame + Actor::raise1_frame
+		(*scr) << Ucscript::delay_ticks << 2 << Ucscript::npc_ready_frame
+			   << Ucscript::delay_ticks << 2 << Ucscript::npc_raise1_frame
 			   << Ucscript::delay_ticks << 2 << Ucscript::sfx
-			   << Audio::game_sfx(45) << Ucscript::npc_frame + Actor::out_frame
+			   << Audio::game_sfx(45) << Ucscript::npc_out_frame
 			   << Ucscript::delay_ticks << 2 << Ucscript::repeat << -13
 			   << repcnt << Ucscript::delay_ticks << 2
-			   << Ucscript::npc_frame + Actor::ready_frame
-			   << Ucscript::delay_ticks << 2
-			   << Ucscript::npc_frame + Actor::standing;
+			   << Ucscript::npc_ready_frame << Ucscript::delay_ticks << 2
+			   << Ucscript::npc_standing_frame;
 		const int delay = 11 * (repcnt + 1) + 6;
 		scr->start();    // Start next tick.
 		state = 0;       // THEN, find next path.
@@ -2426,13 +2413,10 @@ void Sleep_schedule::ending(int new_type    // New schedule.
 		// Animation for making bed.
 		auto* scr = new Usecode_script(npc);
 		(*scr) << Ucscript::dont_halt << Ucscript::face_dir << dir
-			   << Ucscript::npc_frame + Actor::ready_frame
-			   << Ucscript::delay_ticks << 1
-			   << Ucscript::npc_frame + Actor::raise1_frame
-			   << Ucscript::delay_ticks << 1
-			   << Ucscript::npc_frame + Actor::ready_frame
-			   << Ucscript::delay_ticks << 1
-			   << Ucscript::npc_frame + Actor::standing;
+			   << Ucscript::npc_ready_frame << Ucscript::delay_ticks << 1
+			   << Ucscript::npc_raise1_frame << Ucscript::delay_ticks << 1
+			   << Ucscript::npc_ready_frame << Ucscript::delay_ticks << 1
+			   << Ucscript::npc_standing_frame;
 		scr->start();
 	}
 	gwin->set_all_dirty();    // Update all, since Av. stands up.
@@ -3648,12 +3632,10 @@ static void Prep_animation(Actor* npc, Game_object* table) {
 	auto* scr = new Usecode_script(npc);
 	(*scr) << Ucscript::face_dir << npc->get_dir_facing();
 	for (int cnt = 1 + rand() % 3; cnt; --cnt) {
-		(*scr) << (Ucscript::npc_frame + Actor::ready_frame)
-			   << Ucscript::delay_ticks << 1
-			   << (Ucscript::npc_frame + Actor::raise1_frame)
-			   << Ucscript::delay_ticks << 1;
+		(*scr) << Ucscript::npc_ready_frame << Ucscript::delay_ticks << 1
+			   << Ucscript::npc_raise1_frame << Ucscript::delay_ticks << 1;
 	}
-	(*scr) << (Ucscript::npc_frame + Actor::standing);
+	(*scr) << Ucscript::npc_standing_frame;
 	scr->start();    // Start next tick.
 	const int shapenum = table->get_shapenum();
 	// Cauldron or stove?  Animate a little.
@@ -3750,9 +3732,8 @@ void Waiter_schedule::now_what() {
 		create_customer_plate();
 		auto* scr = new Usecode_script(npc);
 		(*scr) << Ucscript::face_dir << npc->get_dir_facing()
-			   << (Ucscript::npc_frame + Actor::ready_frame)
-			   << Ucscript::delay_ticks << 2
-			   << (Ucscript::npc_frame + Actor::standing);
+			   << Ucscript::npc_ready_frame << Ucscript::delay_ticks << 2
+			   << Ucscript::npc_standing_frame;
 		scr->start();    // Start next tick.
 		state = took_order;
 		customers_ordered.push_back(customer);
@@ -3879,9 +3860,8 @@ void Waiter_schedule::now_what() {
 			}
 			auto* scr = new Usecode_script(npc);
 			(*scr) << Ucscript::face_dir << npc->get_dir_facing()
-				   << (Ucscript::npc_frame + Actor::ready_frame)
-				   << Ucscript::delay_ticks << 2
-				   << (Ucscript::npc_frame + Actor::standing);
+				   << Ucscript::npc_ready_frame << Ucscript::delay_ticks << 2
+				   << Ucscript::npc_standing_frame;
 			scr->start();    // Start next tick.
 		}
 		state = served_food;

--- a/usecode/ucscriptop.h
+++ b/usecode/ucscriptop.h
@@ -19,7 +19,7 @@
  */
 
 #ifndef USCRIPTOP_H
-#define USCRIPTOP_H
+#	define USCRIPTOP_H
 
 /*
  *  Opcodes for Usecode_script's:
@@ -71,8 +71,26 @@ namespace Ucscript {
 		face_dir       = 0x59,    // Face_dir(dir), dir=0-7, 0=north.
 		weather        = 0x5A,    // Set weather(type).
 		npc_frame      = 0x61,    // 61-70:  Set frame, but w/ cur. dir.
-		hit            = 0x78,    // Hit(hps, type).  Item attacked.
-		attack         = 0x7a,    // Attack using vals from
+		// Begin - Replicated from actors.h
+		npc_standing_frame   = 0x61 + 0,
+		npc_step_right_frame = 0x61 + 1,
+		npc_step_left_frame  = 0x61 + 2,
+		npc_ready_frame      = 0x61 + 3,    // Ready to fight?
+		npc_raise1_frame     = 0x61 + 4,    // 1-handed strikes.
+		npc_reach1_frame     = 0x61 + 5,
+		npc_strike1_frame    = 0x61 + 6,
+		npc_raise2_frame     = 0x61 + 7,    // 2-handed strikes.
+		npc_reach2_frame     = 0x61 + 8,
+		npc_strike2_frame    = 0x61 + 9,
+		npc_sit_frame        = 0x61 + 10,
+		npc_bow_frame        = 0x61 + 11,
+		npc_kneel_frame      = 0x61 + 12,
+		npc_sleep_frame      = 0x61 + 13,
+		npc_up_frame         = 0x61 + 14,    // Both hands reach up.
+		npc_out_frame        = 0x61 + 15,    // Both hands reach out.
+		// End   - Replicated from actors.h
+		hit    = 0x78,    // Hit(hps, type).  Item attacked.
+		attack = 0x7a,    // Attack using vals from
 		//   set_to_attack intrinsic.
 		/*
 		 *  These are (I think) not in the original:
@@ -81,4 +99,4 @@ namespace Ucscript {
 		resurrect = 0x81     // Parm. is body.
 	};
 }    // namespace Ucscript
-#endif
+#	endif


### PR DESCRIPTION
@marzojr, will you accept the following PR :

I tried to compile ( GCC and CLang ) with C++ 20, and I got two new warnings :

1- `arithmetic between different enumeration types ‘Ucscript::Ucscript_ops’ and ‘Actor::Frames’ is deprecated [-Wdeprecated-enum-enum-conversion]` over `actors.cc` and `schedule.cc` about `(Ucscript::npc_frame + Actor::kneel_frame)` and similar.

2- only in GCC :
```
In function 'void Write1(uint8*&, uint8)',
    inlined from 'void Write2(Dest&, uint16) [with Dest = unsigned char*]' at ../files/utils.h:309:8,
    inlined from 'static std::unique_ptr<unsigned char []> Shape_frame::encode_rle(unsigned char*, int, int, int, int, int&)' at vgafile.cc:313:8:
../files/utils.h:296:16: warning: null pointer dereference [-Wnull-dereference]
  296 |         *out++ = val;
      |         ~~~~~~~^~~~~
```

I propose to fix the first warning with the current PR as 

- Expand Ucscript::Ucscriptops npc_frame with the Actor::Frame enum in `ucscriptop.h`
- Replace `(Ucscript::npc_frame + Actor::ready_frame)` and similar by `Ucscript::npc_ready_frame` and similar in `actors.cc` and `schedule.cc`.

For the second warning, could you advise on how to convince ( and check, if possible ) the GCC compiler that a pointer _is not null_ ?