### PR TITLE
Replace GTK TRUE+FALSE by C++ true+false, widget show+hide by set visible

### DIFF
--- a/mapedit/bargeedit.cc
+++ b/mapedit/bargeedit.cc
@@ -71,7 +71,7 @@ C_EXPORT gboolean on_barge_window_delete_event(
 		GtkWidget* widget, GdkEvent* event, gpointer user_data) {
 	ignore_unused_variable_warning(widget, event, user_data);
 	ExultStudio::get_instance()->close_barge_window();
-	return TRUE;
+	return true;
 }
 
 /*
@@ -99,7 +99,7 @@ void ExultStudio::open_barge_window(
 		}
 	} else if (first_time) {    // Init. empty dialog first time.
 	}
-	gtk_widget_show(bargewin);
+	gtk_widget_set_visible(bargewin, true);
 }
 
 /*
@@ -108,7 +108,7 @@ void ExultStudio::open_barge_window(
 
 void ExultStudio::close_barge_window() {
 	if (bargewin) {
-		gtk_widget_hide(bargewin);
+		gtk_widget_set_visible(bargewin, false);
 	}
 }
 

--- a/mapedit/chunklst.cc
+++ b/mapedit/chunklst.cc
@@ -324,7 +324,7 @@ gint Chunk_chooser::configure(
 		chooser->enable_drop();    // Can drop chunks here.
 	}
 
-	return TRUE;
+	return true;
 }
 
 void Chunk_chooser::setup_info(bool savepos    // Try to keep current position.
@@ -376,7 +376,7 @@ gint Chunk_chooser::expose(
 			ZoomDown(area.x), ZoomDown(area.y), ZoomDown(area.width),
 			ZoomDown(area.height));
 	chooser->set_graphic_context(nullptr);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -412,10 +412,10 @@ gint Chunk_chooser::mouse_press(
 #endif
 	if (event->button == 4) {
 		chooser->scroll(true);
-		return TRUE;
+		return true;
 	} else if (event->button == 5) {
 		chooser->scroll(false);
-		return TRUE;
+		return true;
 	}
 
 	// int old_selected = chooser->selected;
@@ -426,7 +426,7 @@ gint Chunk_chooser::mouse_press(
 					ZoomDown(static_cast<int>(event->y)))) {
 			// Found the box?
 			//			if (i == old_selected)
-			//				return TRUE;
+			//				return true;
 			// Indicate we can dra.
 			chooser->selected  = i;
 			chooser->locate_cx = chooser->locate_cy = -1;
@@ -445,7 +445,7 @@ gint Chunk_chooser::mouse_press(
 				GTK_MENU(chooser->create_popup()),
 				reinterpret_cast<GdkEvent*>(event));
 	}
-	return TRUE;
+	return true;
 }
 
 /*
@@ -503,9 +503,9 @@ gint Chunk_chooser::drag_begin(
 	cout << "In DRAG_BEGIN of Chunk" << endl;
 	auto* chooser = static_cast<Chunk_chooser*>(data);
 	if (chooser->selected < 0) {
-		return FALSE;    // ++++Display a halt bitmap.
+		return false;    // ++++Display a halt bitmap.
 	}
-	return TRUE;
+	return true;
 }
 
 /*
@@ -723,22 +723,22 @@ Chunk_chooser::Chunk_chooser(
 
 	// Put things in a vert. box.
 	GtkWidget* vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(vbox), FALSE);
+	gtk_box_set_homogeneous(GTK_BOX(vbox), false);
 	set_widget(vbox);    // This is our "widget"
-	gtk_widget_show(vbox);
+	gtk_widget_set_visible(vbox, true);
 
 	GtkWidget* hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(hbox), FALSE);
-	gtk_widget_show(hbox);
-	gtk_box_pack_start(GTK_BOX(vbox), hbox, TRUE, TRUE, 0);
+	gtk_box_set_homogeneous(GTK_BOX(hbox), false);
+	gtk_widget_set_visible(hbox, true);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox, true, true, 0);
 
 	// A frame looks nice.
 	GtkWidget* frame = gtk_frame_new(nullptr);
 	gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_IN);
 	widget_set_margins(
 			frame, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(frame);
-	gtk_box_pack_start(GTK_BOX(hbox), frame, TRUE, TRUE, 0);
+	gtk_widget_set_visible(frame, true);
+	gtk_box_pack_start(GTK_BOX(hbox), frame, true, true, 0);
 
 	// NOTE:  draw is in Shape_draw.
 	// Indicate the events we want.
@@ -769,37 +769,37 @@ Chunk_chooser::Chunk_chooser(
 	widget_set_margins(
 			draw, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
 	gtk_widget_set_size_request(draw, w, h);
-	gtk_widget_show(draw);
+	gtk_widget_set_visible(draw, true);
 	// Want a scrollbar for the chunks.
 	GtkAdjustment* chunk_adj = GTK_ADJUSTMENT(
 			gtk_adjustment_new(0, 0, (128 + border) * num_chunks, 1, 4, 1.0));
 	vscroll = gtk_scrollbar_new(
 			GTK_ORIENTATION_VERTICAL, GTK_ADJUSTMENT(chunk_adj));
-	gtk_box_pack_start(GTK_BOX(hbox), vscroll, FALSE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox), vscroll, false, true, 0);
 	// Set scrollbar handler.
 	g_signal_connect(
 			G_OBJECT(chunk_adj), "value-changed", G_CALLBACK(scrolled), this);
-	gtk_widget_show(vscroll);
+	gtk_widget_set_visible(vscroll, true);
 	// Scroll events.
 	enable_draw_vscroll(draw);
 
 	// At the bottom, status bar:
 	GtkWidget* hbox1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(hbox1), FALSE);
-	gtk_box_pack_start(GTK_BOX(vbox), hbox1, FALSE, FALSE, 0);
-	gtk_widget_show(hbox1);
+	gtk_box_set_homogeneous(GTK_BOX(hbox1), false);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox1, false, false, 0);
+	gtk_widget_set_visible(hbox1, true);
 	// At left, a status bar.
 	sbar     = gtk_statusbar_new();
 	sbar_sel = gtk_statusbar_get_context_id(GTK_STATUSBAR(sbar), "selection");
-	gtk_box_pack_start(GTK_BOX(hbox1), sbar, TRUE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox1), sbar, true, true, 0);
 	widget_set_margins(
 			sbar, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(sbar);
+	gtk_widget_set_visible(sbar, true);
 	// Add locate/move controls to bottom.
 	gtk_box_pack_start(
 			GTK_BOX(vbox),
 			create_controls(locate_controls | (!group ? move_controls : 0)),
-			FALSE, FALSE, 0);
+			false, false, 0);
 }
 
 /*

--- a/mapedit/combo.cc
+++ b/mapedit/combo.cc
@@ -73,7 +73,7 @@ void ExultStudio::open_combo_window() {
 	combowin->show(true);
 	// Set edit-mode to pick.
 	GtkWidget* mitem = get_widget("pick_for_combo1");
-	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mitem), TRUE);
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mitem), true);
 }
 
 /*
@@ -117,7 +117,7 @@ gboolean Combo_editor::on_combo_draw_expose_event(
 	gdk_cairo_get_clip_rectangle(cairo, &area);
 	combo->render_area(&area);
 	combo->set_graphic_context(nullptr);
-	return TRUE;
+	return true;
 }
 
 C_EXPORT void on_combo_remove_clicked(GtkButton* button, gpointer user_data) {
@@ -142,7 +142,7 @@ C_EXPORT void on_combo_ok_clicked(GtkButton* button, gpointer user_data) {
 	auto*      combo = static_cast<Combo_editor*>(
             g_object_get_data(G_OBJECT(win), "user_data"));
 	combo->save();
-	gtk_widget_hide(win);
+	gtk_widget_set_visible(win, false);
 }
 
 C_EXPORT void on_combo_locx_changed(GtkSpinButton* button, gpointer user_data) {
@@ -549,9 +549,9 @@ Combo_editor::~Combo_editor() {
 
 void Combo_editor::show(bool tf) {
 	if (tf) {
-		gtk_widget_show(win);
+		gtk_widget_set_visible(win, true);
 	} else {
-		gtk_widget_hide(win);
+		gtk_widget_set_visible(win, false);
 	}
 }
 
@@ -619,7 +619,7 @@ void Combo_editor::set_controls() {
 
 gint Combo_editor::mouse_press(GdkEventButton* event) {
 	if (event->button != 1) {
-		return FALSE;    // Handling left-click.
+		return false;    // Handling left-click.
 	}
 	// Get mouse position, draw dims.
 	const int mx = ZoomDown(static_cast<int>(event->x));
@@ -627,7 +627,7 @@ gint Combo_editor::mouse_press(GdkEventButton* event) {
 	selected     = combo->find(mx, my);    // Find it (or -1 if not found).
 	set_controls();
 	render();
-	return TRUE;
+	return true;
 }
 
 /*
@@ -1001,7 +1001,7 @@ gint Combo_chooser::drag_begin(
 	cout << "In DRAG_BEGIN of Combo" << endl;
 	auto* chooser = static_cast<Combo_chooser*>(data);
 	if (chooser->selected < 0) {
-		return FALSE;    // ++++Display a halt bitmap.
+		return false;    // ++++Display a halt bitmap.
 	}
 	// Get ->combo.
 	const int num   = chooser->info[chooser->selected].num;
@@ -1013,7 +1013,7 @@ gint Combo_chooser::drag_begin(
 	if (shape) {
 		chooser->set_drag_icon(context, shape);
 	}
-	return TRUE;
+	return true;
 }
 
 /*
@@ -1050,9 +1050,9 @@ static gboolean on_combo_key_press(
 	switch (event->keyval) {
 	case GDK_KEY_Delete:
 		chooser->remove();
-		return TRUE;
+		return true;
 	}
-	return FALSE;    // Let parent handle it.
+	return false;    // Let parent handle it.
 }
 
 /*
@@ -1096,22 +1096,22 @@ Combo_chooser::Combo_chooser(
 
 	// Put things in a vert. box.
 	GtkWidget* vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(vbox), FALSE);
+	gtk_box_set_homogeneous(GTK_BOX(vbox), false);
 	set_widget(vbox);    // This is our "widget"
-	gtk_widget_show(vbox);
+	gtk_widget_set_visible(vbox, true);
 
 	GtkWidget* hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(hbox), FALSE);
-	gtk_widget_show(hbox);
-	gtk_box_pack_start(GTK_BOX(vbox), hbox, TRUE, TRUE, 0);
+	gtk_box_set_homogeneous(GTK_BOX(hbox), false);
+	gtk_widget_set_visible(hbox, true);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox, true, true, 0);
 
 	// A frame looks nice.
 	GtkWidget* frame = gtk_frame_new(nullptr);
 	gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_IN);
 	widget_set_margins(
 			frame, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(frame);
-	gtk_box_pack_start(GTK_BOX(hbox), frame, TRUE, TRUE, 0);
+	gtk_widget_set_visible(frame, true);
+	gtk_box_pack_start(GTK_BOX(hbox), frame, true, true, 0);
 
 	// NOTE:  draw is in Shape_draw.
 	// Indicate the events we want.
@@ -1128,7 +1128,7 @@ Combo_chooser::Combo_chooser(
 	g_signal_connect(
 			G_OBJECT(draw), "key-press-event", G_CALLBACK(on_combo_key_press),
 			this);
-	gtk_widget_set_can_focus(GTK_WIDGET(draw), TRUE);
+	gtk_widget_set_can_focus(GTK_WIDGET(draw), true);
 	// Set mouse click handler.
 	g_signal_connect(
 			G_OBJECT(draw), "button-press-event", G_CALLBACK(mouse_press),
@@ -1148,7 +1148,7 @@ Combo_chooser::Combo_chooser(
 	widget_set_margins(
 			draw, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
 	gtk_widget_set_size_request(draw, w, h);
-	gtk_widget_show(draw);
+	gtk_widget_set_visible(draw, true);
 	// Want a scrollbar for the combos.
 	GtkAdjustment* combo_adj = GTK_ADJUSTMENT(gtk_adjustment_new(
 			0, 0, (128 + border) * combos.size(), 1, 4, 1.0));
@@ -1157,30 +1157,30 @@ Combo_chooser::Combo_chooser(
 	// Update window when it stops.
 	// (Deprecated) gtk_range_set_update_policy(GTK_RANGE(vscroll),
 	// (Deprecated)                             GTK_UPDATE_DELAYED);
-	gtk_box_pack_start(GTK_BOX(hbox), vscroll, FALSE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox), vscroll, false, true, 0);
 	// Set scrollbar handler.
 	g_signal_connect(
 			G_OBJECT(combo_adj), "value-changed", G_CALLBACK(scrolled), this);
-	gtk_widget_show(vscroll);
+	gtk_widget_set_visible(vscroll, true);
 	// Scroll events.
 	enable_draw_vscroll(draw);
 
 	// At the bottom, status bar:
 	GtkWidget* hbox1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(hbox1), FALSE);
-	gtk_box_pack_start(GTK_BOX(vbox), hbox1, FALSE, FALSE, 0);
-	gtk_widget_show(hbox1);
+	gtk_box_set_homogeneous(GTK_BOX(hbox1), false);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox1, false, false, 0);
+	gtk_widget_set_visible(hbox1, true);
 	// At left, a status bar.
 	sbar     = gtk_statusbar_new();
 	sbar_sel = gtk_statusbar_get_context_id(GTK_STATUSBAR(sbar), "selection");
-	gtk_box_pack_start(GTK_BOX(hbox1), sbar, TRUE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox1), sbar, true, true, 0);
 	widget_set_margins(
 			sbar, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(sbar);
+	gtk_widget_set_visible(sbar, true);
 	// Add controls to bottom.
 	gtk_box_pack_start(
 			GTK_BOX(vbox), create_controls(find_controls | move_controls),
-			FALSE, FALSE, 0);
+			false, false, 0);
 }
 
 /*
@@ -1291,7 +1291,7 @@ gint Combo_chooser::configure(
 	chooser->Shape_draw::configure();
 	chooser->render();
 	chooser->setup_info(true);
-	return TRUE;
+	return true;
 }
 
 void Combo_chooser::setup_info(bool savepos    // Try to keep current position.
@@ -1343,7 +1343,7 @@ gint Combo_chooser::expose(
 			ZoomDown(area.x), ZoomDown(area.y), ZoomDown(area.width),
 			ZoomDown(area.height));
 	chooser->set_graphic_context(nullptr);
-	return TRUE;
+	return true;
 }
 
 gint Combo_chooser::drag_motion(
@@ -1379,10 +1379,10 @@ gint Combo_chooser::mouse_press(
 #endif
 	if (event->button == 4) {
 		chooser->scroll(true);
-		return TRUE;
+		return true;
 	} else if (event->button == 5) {
 		chooser->scroll(false);
-		return TRUE;
+		return true;
 	}
 
 	const int old_selected = chooser->selected;
@@ -1415,7 +1415,7 @@ gint Combo_chooser::mouse_press(
 				GTK_MENU(chooser->create_popup()),
 				reinterpret_cast<GdkEvent*>(event));
 	}
-	return TRUE;
+	return true;
 }
 
 /*

--- a/mapedit/compile.cc
+++ b/mapedit/compile.cc
@@ -81,7 +81,7 @@ void ExultStudio::open_compile_window() {
 				GTK_TEXT_VIEW(get_widget("compile_msgs")),
 				GTK_STATUSBAR(get_widget("compile_status")), Ucc_done, nullptr);
 	}
-	gtk_widget_show(compilewin);
+	gtk_widget_set_visible(compilewin, true);
 }
 
 /*
@@ -91,7 +91,7 @@ void ExultStudio::open_compile_window() {
 void ExultStudio::close_compile_window() {
 	halt_compile();
 	if (compilewin) {
-		gtk_widget_hide(compilewin);
+		gtk_widget_set_visible(compilewin, false);
 	}
 }
 

--- a/mapedit/contedit.cc
+++ b/mapedit/contedit.cc
@@ -101,7 +101,7 @@ C_EXPORT gboolean on_cont_window_delete_event(
 		GtkWidget* widget, GdkEvent* event, gpointer user_data) {
 	ignore_unused_variable_warning(widget, event, user_data);
 	ExultStudio::get_instance()->close_cont_window();
-	return TRUE;
+	return true;
 }
 
 /*
@@ -111,7 +111,7 @@ C_EXPORT gboolean on_cont_pos_changed(
 		GtkWidget* widget, GdkEventFocus* event, gpointer user_data) {
 	ignore_unused_variable_warning(widget, event, user_data);
 	//++++Maybe later, change pos. immediately?
-	return TRUE;
+	return true;
 }
 
 /*
@@ -141,7 +141,7 @@ void ExultStudio::open_cont_window(
 	if (!init_cont_window(data, datalen)) {
 		return;
 	}
-	gtk_widget_show(contwin);
+	gtk_widget_set_visible(contwin, true);
 }
 
 /*
@@ -150,7 +150,7 @@ void ExultStudio::open_cont_window(
 
 void ExultStudio::close_cont_window() {
 	if (contwin) {
-		gtk_widget_hide(contwin);
+		gtk_widget_set_visible(contwin, false);
 	}
 }
 

--- a/mapedit/eggedit.cc
+++ b/mapedit/eggedit.cc
@@ -74,7 +74,7 @@ C_EXPORT gboolean on_egg_window_delete_event(
 		GtkWidget* widget, GdkEvent* event, gpointer user_data) {
 	ignore_unused_variable_warning(widget, event, user_data);
 	ExultStudio::get_instance()->close_egg_window();
-	return TRUE;
+	return true;
 }
 
 /*
@@ -152,7 +152,7 @@ void ExultStudio::open_egg_window(
 		set_sensitive("teleport_z", true);
 		set_sensitive("teleport_eggnum", false);
 	}
-	gtk_widget_show(eggwin);
+	gtk_widget_set_visible(eggwin, true);
 }
 
 /*
@@ -161,7 +161,7 @@ void ExultStudio::open_egg_window(
 
 void ExultStudio::close_egg_window() {
 	if (eggwin) {
-		gtk_widget_hide(eggwin);
+		gtk_widget_set_visible(eggwin, false);
 	}
 }
 

--- a/mapedit/execbox.cc
+++ b/mapedit/execbox.cc
@@ -100,7 +100,7 @@ static gboolean Read_from_child(
 	ignore_unused_variable_warning(condition);
 	auto* ex = static_cast<Exec_process*>(data);
 	ex->read_from_child(g_io_channel_unix_get_fd(source));
-	return TRUE;
+	return true;
 }
 
 void Exec_process::read_from_child(int id    // Pipe to read from.

--- a/mapedit/exult_studio.glade
+++ b/mapedit/exult_studio.glade
@@ -9384,7 +9384,7 @@ Coordinates</property>
                 <property name="image">cancel_img40</property>
                 <property name="use-underline">True</property>
                 <property name="always-show-image">True</property>
-                <signal name="clicked" handler="gtk_widget_hide" object="schedule_dialog" swapped="yes"/>
+                <signal name="clicked" handler="exult_widget_hide" object="schedule_dialog" swapped="yes"/>
               </object>
               <packing>
                 <property name="position">0</property>
@@ -25247,7 +25247,7 @@ Coordinates</property>
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Exult New Shape</property>
     <property name="modal">True</property>
-    <signal name="delete-event" handler="gtk_widget_hide_on_delete" swapped="no"/>
+    <signal name="delete-event" handler="exult_widget_hide" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox28">
         <property name="visible">True</property>
@@ -25648,7 +25648,7 @@ Coordinates</property>
                 <property name="image">cancel_img12</property>
                 <property name="use-underline">True</property>
                 <property name="always-show-image">True</property>
-                <signal name="clicked" handler="gtk_widget_hide" object="new_shape_window" swapped="yes"/>
+                <signal name="clicked" handler="exult_widget_hide" object="new_shape_window" swapped="yes"/>
               </object>
               <packing>
                 <property name="position">1</property>
@@ -25666,7 +25666,7 @@ Coordinates</property>
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Exult Tiles</property>
     <property name="modal">True</property>
-    <signal name="delete-event" handler="gtk_widget_hide_on_delete" swapped="no"/>
+    <signal name="delete-event" handler="exult_widget_hide" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox29">
         <property name="visible">True</property>
@@ -25909,7 +25909,7 @@ Coordinates</property>
                 <property name="image">cancel_img10</property>
                 <property name="use-underline">True</property>
                 <property name="always-show-image">True</property>
-                <signal name="clicked" handler="gtk_widget_hide" object="export_tiles_window" swapped="yes"/>
+                <signal name="clicked" handler="exult_widget_hide" object="export_tiles_window" swapped="yes"/>
               </object>
               <packing>
                 <property name="position">1</property>
@@ -25926,7 +25926,7 @@ Coordinates</property>
   <object class="GtkWindow" id="combo_win">
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Exult Combo-Builder</property>
-    <signal name="delete-event" handler="gtk_widget_hide" swapped="no"/>
+    <signal name="delete-event" handler="exult_widget_hide" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox31">
         <property name="visible">True</property>
@@ -26349,7 +26349,7 @@ Coordinates</property>
                     <property name="image">cancel_img8</property>
                     <property name="use-underline">True</property>
                     <property name="always-show-image">True</property>
-                    <signal name="clicked" handler="gtk_widget_hide" object="combo_win" swapped="yes"/>
+                    <signal name="clicked" handler="exult_widget_hide" object="combo_win" swapped="yes"/>
                   </object>
                   <packing>
                     <property name="position">2</property>
@@ -26368,7 +26368,7 @@ Coordinates</property>
   <object class="GtkWindow" id="msg_win">
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Exult Messages</property>
-    <signal name="delete-event" handler="gtk_widget_hide" swapped="no"/>
+    <signal name="delete-event" handler="exult_widget_hide" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox33">
         <property name="visible">True</property>
@@ -26432,7 +26432,7 @@ Coordinates</property>
                 <property name="image">close_img37</property>
                 <property name="use-underline">True</property>
                 <property name="always-show-image">True</property>
-                <signal name="clicked" handler="gtk_widget_hide" object="msg_win" swapped="yes"/>
+                <signal name="clicked" handler="exult_widget_hide" object="msg_win" swapped="yes"/>
               </object>
               <packing>
                 <property name="position">0</property>
@@ -26449,7 +26449,7 @@ Coordinates</property>
   <object class="GtkWindow" id="compile_win">
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Exult:  Compiling</property>
-    <signal name="delete-event" handler="gtk_widget_hide" swapped="no"/>
+    <signal name="delete-event" handler="exult_widget_hide" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox34">
         <property name="visible">True</property>
@@ -26686,7 +26686,7 @@ Coordinates</property>
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Exult:  New map</property>
     <property name="type-hint">dialog</property>
-    <signal name="close" handler="gtk_widget_hide" swapped="no"/>
+    <signal name="close" handler="exult_widget_hide" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
@@ -26748,7 +26748,7 @@ Coordinates</property>
                 <property name="image">cancel_img5</property>
                 <property name="use-underline">True</property>
                 <property name="always-show-image">True</property>
-                <signal name="clicked" handler="gtk_widget_hide" object="newmap_dialog" swapped="yes"/>
+                <signal name="clicked" handler="exult_widget_hide" object="newmap_dialog" swapped="yes"/>
               </object>
               <packing>
                 <property name="position">1</property>
@@ -27062,7 +27062,7 @@ Coordinates</property>
   <object class="GtkWindow" id="barge_window">
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Exult Barge</property>
-    <signal name="delete-event" handler="gtk_widget_hide" swapped="no"/>
+    <signal name="delete-event" handler="exult_widget_hide" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox40">
         <property name="visible">True</property>
@@ -28037,7 +28037,7 @@ Coordinates</property>
     <property name="default-width">600</property>
     <property name="default-height">300</property>
     <property name="type-hint">dialog</property>
-    <signal name="close" handler="gtk_widget_hide" swapped="no"/>
+    <signal name="close" handler="exult_widget_hide" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox4">
         <property name="visible">True</property>
@@ -28099,7 +28099,7 @@ Coordinates</property>
                 <property name="image">cancel_img30</property>
                 <property name="use-underline">True</property>
                 <property name="always-show-image">True</property>
-                <signal name="clicked" handler="gtk_widget_hide" object="game_selection" swapped="yes"/>
+                <signal name="clicked" handler="exult_widget_hide" object="game_selection" swapped="yes"/>
               </object>
               <packing>
                 <property name="position">1</property>
@@ -28754,7 +28754,7 @@ will be added automatically</property>
     <property name="title" translatable="yes">Set Game Information</property>
     <property name="modal">True</property>
     <property name="type-hint">dialog</property>
-    <signal name="delete-event" handler="gtk_widget_hide" swapped="no"/>
+    <signal name="delete-event" handler="exult_widget_hide" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox115">
         <property name="visible">True</property>
@@ -28984,7 +28984,7 @@ will be added automatically</property>
                 <property name="image">cancel_img28</property>
                 <property name="use-underline">True</property>
                 <property name="always-show-image">True</property>
-                <signal name="clicked" handler="gtk_widget_hide" object="game_information" swapped="yes"/>
+                <signal name="clicked" handler="exult_widget_hide" object="game_information" swapped="yes"/>
               </object>
               <packing>
                 <property name="position">1</property>

--- a/mapedit/locator.cc
+++ b/mapedit/locator.cc
@@ -71,7 +71,7 @@ C_EXPORT gboolean on_loc_window_delete_event(
 	auto* loc = static_cast<Locator*>(
 			g_object_get_data(G_OBJECT(widget), "user_data"));
 	loc->show(false);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -87,7 +87,7 @@ C_EXPORT gboolean on_loc_draw_configure_event(
 			G_OBJECT(gtk_widget_get_toplevel(GTK_WIDGET(widget))),
 			"user_data"));
 	loc->configure(widget);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -105,7 +105,7 @@ gboolean Locator::on_loc_draw_expose_event(
 	gdk_cairo_get_clip_rectangle(cairo, &area);
 	loc->render(&area);
 	loc->set_graphic_context(nullptr);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -201,10 +201,10 @@ Locator::~Locator() {
 
 void Locator::show(bool tf) {
 	if (tf) {
-		gtk_widget_show(win);
+		gtk_widget_set_visible(win, true);
 		query_location();    // Get Exult's loc.
 	} else {
-		gtk_widget_hide(win);
+		gtk_widget_set_visible(win, false);
 	}
 }
 
@@ -504,7 +504,7 @@ void Locator::goto_mouse(
 gboolean Locator::mouse_press(GdkEventButton* event) {
 	dragging = false;
 	if (event->button != 1) {
-		return FALSE;    // Handling left-click.
+		return false;    // Handling left-click.
 	}
 	// Get mouse position, draw dims.
 	const int mx = static_cast<int>(event->x);
@@ -512,18 +512,18 @@ gboolean Locator::mouse_press(GdkEventButton* event) {
 	// Double-click?
 	if (reinterpret_cast<GdkEvent*>(event)->type == GDK_2BUTTON_PRESS) {
 		goto_mouse(mx, my);
-		return TRUE;
+		return true;
 	}
 	// On (or close to) view box?
 	if (mx < viewbox.x - 3 || my < viewbox.y - 3
 		|| mx > viewbox.x + viewbox.width + 6
 		|| my > viewbox.y + viewbox.height + 6) {
-		return FALSE;
+		return false;
 	}
 	dragging  = true;
 	drag_relx = mx - viewbox.x;    // Save rel. pos.
 	drag_rely = my - viewbox.y;
-	return TRUE;
+	return true;
 }
 
 /*
@@ -533,7 +533,7 @@ gboolean Locator::mouse_press(GdkEventButton* event) {
 gboolean Locator::mouse_release(GdkEventButton* event) {
 	ignore_unused_variable_warning(event);
 	dragging = false;
-	return TRUE;
+	return true;
 }
 
 /*
@@ -548,9 +548,9 @@ gboolean Locator::mouse_motion(GdkEventMotion* event) {
 	my    = static_cast<int>(event->y);
 	state = static_cast<GdkModifierType>(event->state);
 	if (!dragging || !(state & GDK_BUTTON1_MASK)) {
-		return FALSE;    // Not dragging with left button.
+		return false;    // Not dragging with left button.
 	}
 	// Delay sending location to Exult.
 	goto_mouse(mx - drag_relx, my - drag_rely, true);
-	return TRUE;
+	return true;
 }

--- a/mapedit/maps.cc
+++ b/mapedit/maps.cc
@@ -86,7 +86,7 @@ void ExultStudio::new_map_dialog() {
 	set_toggle("newmap_copy_flats", false);
 	set_toggle("newmap_copy_fixed", false);
 	set_toggle("newmap_copy_ireg", false);
-	gtk_widget_show(win);
+	gtk_widget_set_visible(win, true);
 }
 
 /*
@@ -165,7 +165,7 @@ C_EXPORT void on_newmap_ok_clicked(GtkMenuItem* menuitem, gpointer user_data) {
 		}
 	}
 	studio->setup_maps_list();
-	gtk_widget_hide(win);
+	gtk_widget_set_visible(win, false);
 }
 
 /*
@@ -189,7 +189,7 @@ void ExultStudio::setup_maps_list() {
 			group = gtk_radio_menu_item_get_group(GTK_RADIO_MENU_ITEM(item));
 			g_object_set_data(G_OBJECT(item), "user_data", nullptr);
 			if (curmap == 0) {
-				gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), TRUE);
+				gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), true);
 			}
 			break;
 		}
@@ -210,7 +210,7 @@ void ExultStudio::setup_maps_list() {
                 maps, name, G_CALLBACK(on_map_activate), ptrnum, group);
 		g_object_set_data(G_OBJECT(item), "user_data", ptrnum);
 		if (curmap == num) {
-			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), TRUE);
+			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), true);
 		}
 		group = gtk_radio_menu_item_get_group(GTK_RADIO_MENU_ITEM(item));
 	}

--- a/mapedit/npcedit.cc
+++ b/mapedit/npcedit.cc
@@ -98,7 +98,7 @@ C_EXPORT gboolean on_npc_window_delete_event(
 		GtkWidget* widget, GdkEvent* event, gpointer user_data) {
 	ignore_unused_variable_warning(widget, event, user_data);
 	ExultStudio::get_instance()->close_npc_window();
-	return TRUE;
+	return true;
 }
 
 /*
@@ -250,7 +250,7 @@ void ExultStudio::open_npc_window(
 	} else {
 		init_new_npc();
 	}
-	gtk_widget_show(npcwin);
+	gtk_widget_set_visible(npcwin, true);
 }
 
 /*
@@ -259,7 +259,7 @@ void ExultStudio::open_npc_window(
 
 void ExultStudio::close_npc_window() {
 	if (npcwin) {
-		gtk_widget_hide(npcwin);
+		gtk_widget_set_visible(npcwin, false);
 	}
 }
 
@@ -648,7 +648,7 @@ void ExultStudio::schedule_btn_clicked(
 	gtk_label_set_text(
 			label, num >= 0 && num < 32 ? sched_names[num] : "-----");
 	cout << "Chose schedule " << num << endl;
-	gtk_widget_hide(studio->get_widget("schedule_dialog"));
+	gtk_widget_set_visible(studio->get_widget("schedule_dialog"), false);
 }
 
 /*
@@ -687,7 +687,7 @@ C_EXPORT void on_npc_set_sched(
 	}
 	// Store label as dialog's data.
 	g_object_set_data(G_OBJECT(schedwin), "user_data", label);
-	gtk_widget_show(schedwin);
+	gtk_widget_set_visible(schedwin, true);
 }
 
 /*

--- a/mapedit/npclst.cc
+++ b/mapedit/npclst.cc
@@ -470,7 +470,7 @@ gint Npc_chooser::configure(GdkEventConfigure* event) {
 	if (group) {          // Filtering?
 		enable_drop();    // Can drop NPCs here.
 	}
-	return TRUE;
+	return true;
 }
 
 /*
@@ -491,7 +491,7 @@ gint Npc_chooser::expose(
 			ZoomDown(area.x), ZoomDown(area.y), ZoomDown(area.width),
 			ZoomDown(area.height));
 	chooser->set_graphic_context(nullptr);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -529,10 +529,10 @@ gint Npc_chooser::mouse_press(
 		if (row0 > 0) {
 			scroll_row_vertical(row0 - 1);
 		}
-		return TRUE;
+		return true;
 	} else if (event->button == 5) {
 		scroll_row_vertical(row0 + 1);
-		return TRUE;
+		return true;
 	}
 	const int      old_selected = selected;
 	int            new_selected = -1;
@@ -569,7 +569,7 @@ gint Npc_chooser::mouse_press(
 		gtk_menu_popup_at_pointer(
 				GTK_MENU(create_popup()), reinterpret_cast<GdkEvent*>(event));
 	}
-	return TRUE;
+	return true;
 }
 
 /*
@@ -602,7 +602,7 @@ C_EXPORT gboolean on_npc_draw_key_press(
 		GtkEntry* entry, GdkEventKey* event, gpointer user_data) {
 	ignore_unused_variable_warning(entry, event, user_data);
 	// Npc_chooser *chooser = static_cast<Npc_chooser *>(user_data);
-	return FALSE;    // Let parent handle it.
+	return false;    // Let parent handle it.
 }
 
 /*
@@ -682,17 +682,17 @@ gint Npc_chooser::drag_begin(
 	cout << "In DRAG_BEGIN of Npc" << endl;
 	auto* chooser = static_cast<Npc_chooser*>(data);
 	if (chooser->selected < 0) {
-		return FALSE;    // ++++Display a halt bitmap.
+		return false;    // ++++Display a halt bitmap.
 	}
 	// Get ->npc.
 	const int          npcnum = chooser->info[chooser->selected].npcnum;
 	const Estudio_npc& npc    = chooser->get_npcs()[npcnum];
 	Shape_frame*       shape  = chooser->ifile->get_shape(npc.shapenum, 0);
 	if (!shape) {
-		return FALSE;
+		return false;
 	}
 	chooser->set_drag_icon(context, shape);    // Set icon for dragging.
-	return TRUE;
+	return true;
 }
 
 /*
@@ -943,9 +943,9 @@ void Npc_chooser::all_frames_toggled(GtkToggleButton* btn, gpointer data) {
 	const bool on        = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	chooser->frames_mode = on;
 	if (on) {    // Frame => show horiz. scrollbar.
-		gtk_widget_show(chooser->hscroll);
+		gtk_widget_set_visible(chooser->hscroll, true);
 	} else {
-		gtk_widget_hide(chooser->hscroll);
+		gtk_widget_set_visible(chooser->hscroll, false);
 	}
 	// The old index is no longer valid, so we need to remember the shape.
 	int       indx    = chooser->selected >= 0
@@ -1071,22 +1071,22 @@ Npc_chooser::Npc_chooser(
 
 	// Put things in a vert. box.
 	GtkWidget* vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(vbox), FALSE);
+	gtk_box_set_homogeneous(GTK_BOX(vbox), false);
 	set_widget(vbox);    // This is our "widget"
-	gtk_widget_show(vbox);
+	gtk_widget_set_visible(vbox, true);
 
 	GtkWidget* hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(hbox), FALSE);
-	gtk_widget_show(hbox);
-	gtk_box_pack_start(GTK_BOX(vbox), hbox, TRUE, TRUE, 0);
+	gtk_box_set_homogeneous(GTK_BOX(hbox), false);
+	gtk_widget_set_visible(hbox, true);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox, true, true, 0);
 
 	// A frame looks nice.
 	GtkWidget* frame = gtk_frame_new(nullptr);
 	gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_IN);
 	widget_set_margins(
 			frame, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(frame);
-	gtk_box_pack_start(GTK_BOX(hbox), frame, TRUE, TRUE, 0);
+	gtk_widget_set_visible(frame, true);
+	gtk_box_pack_start(GTK_BOX(hbox), frame, true, true, 0);
 
 	// NOTE:  draw is in Shape_draw.
 	// Indicate the events we want.
@@ -1104,7 +1104,7 @@ Npc_chooser::Npc_chooser(
 	g_signal_connect(
 			G_OBJECT(draw), "key-press-event",
 			G_CALLBACK(on_npc_draw_key_press), this);
-	gtk_widget_set_can_focus(GTK_WIDGET(draw), TRUE);
+	gtk_widget_set_can_focus(GTK_WIDGET(draw), true);
 	// Set mouse click handler.
 	g_signal_connect(
 			G_OBJECT(draw), "button-press-event", G_CALLBACK(Mouse_press),
@@ -1124,70 +1124,71 @@ Npc_chooser::Npc_chooser(
 	widget_set_margins(
 			draw, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
 	gtk_widget_set_size_request(draw, w, h);
-	gtk_widget_show(draw);
+	gtk_widget_set_visible(draw, true);
 	// Want vert. scrollbar for the shapes.
 	GtkAdjustment* shape_adj = GTK_ADJUSTMENT(
 			gtk_adjustment_new(0, 0, std::ceil(get_count() / 4.0), 1, 1, 1));
 	vscroll = gtk_scrollbar_new(
 			GTK_ORIENTATION_VERTICAL, GTK_ADJUSTMENT(shape_adj));
-	gtk_box_pack_start(GTK_BOX(hbox), vscroll, FALSE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox), vscroll, false, true, 0);
 	// Set scrollbar handler.
 	g_signal_connect(
 			G_OBJECT(shape_adj), "value-changed", G_CALLBACK(vscrolled), this);
-	gtk_widget_show(vscroll);
+	gtk_widget_set_visible(vscroll, true);
 	// Horizontal scrollbar.
 	shape_adj = GTK_ADJUSTMENT(gtk_adjustment_new(0, 0, 1600, 8, 16, 16));
 	hscroll   = gtk_scrollbar_new(
             GTK_ORIENTATION_HORIZONTAL, GTK_ADJUSTMENT(shape_adj));
-	gtk_box_pack_start(GTK_BOX(vbox), hscroll, FALSE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(vbox), hscroll, false, true, 0);
 	// Set scrollbar handler.
 	g_signal_connect(
 			G_OBJECT(shape_adj), "value-changed", G_CALLBACK(hscrolled), this);
-	//++++  gtk_widget_hide(hscroll);   // Only shown in 'frames' mode.
+	//++++  gtk_widget_set_visible(hscroll, false);   // Only shown in 'frames'
+	// mode.
 	// Scroll events.
 	enable_draw_vscroll(draw);
 
 	// At the bottom, status bar & frame:
 	GtkWidget* hbox1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(hbox1), FALSE);
-	gtk_box_pack_start(GTK_BOX(vbox), hbox1, FALSE, FALSE, 0);
-	gtk_widget_show(hbox1);
+	gtk_box_set_homogeneous(GTK_BOX(hbox1), false);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox1, false, false, 0);
+	gtk_widget_set_visible(hbox1, true);
 	// At left, a status bar.
 	sbar     = gtk_statusbar_new();
 	sbar_sel = gtk_statusbar_get_context_id(GTK_STATUSBAR(sbar), "selection");
-	gtk_box_pack_start(GTK_BOX(hbox1), sbar, TRUE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox1), sbar, true, true, 0);
 	widget_set_margins(
 			sbar, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(sbar);
+	gtk_widget_set_visible(sbar, true);
 	GtkWidget* label = gtk_label_new("Frame:");
-	gtk_box_pack_start(GTK_BOX(hbox1), label, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox1), label, false, false, 0);
 	widget_set_margins(
 			label, 2 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(label);
+	gtk_widget_set_visible(label, true);
 	// A spin button for frame#.
 	frame_adj = GTK_ADJUSTMENT(gtk_adjustment_new(0, 0, 16, 1, 0, 0.0));
 	fspin     = gtk_spin_button_new(GTK_ADJUSTMENT(frame_adj), 1, 0);
 	g_signal_connect(
 			G_OBJECT(frame_adj), "value-changed", G_CALLBACK(frame_changed),
 			this);
-	gtk_box_pack_start(GTK_BOX(hbox1), fspin, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox1), fspin, false, false, 0);
 	widget_set_margins(
 			fspin, 1 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
 	gtk_widget_set_sensitive(fspin, false);
-	gtk_widget_show(fspin);
+	gtk_widget_set_visible(fspin, true);
 	// A toggle for 'All Frames'.
 	GtkWidget* allframes = gtk_toggle_button_new_with_label("Frames");
-	gtk_box_pack_start(GTK_BOX(hbox1), allframes, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox1), allframes, false, false, 0);
 	widget_set_margins(
 			allframes, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(allframes);
+	gtk_widget_set_visible(allframes, true);
 	g_signal_connect(
 			G_OBJECT(allframes), "toggled", G_CALLBACK(all_frames_toggled),
 			this);
 	// Add search controls to bottom.
 	gtk_box_pack_start(
 			GTK_BOX(vbox), create_controls(find_controls | locate_controls),
-			FALSE, FALSE, 0);
+			false, false, 0);
 	red = ExultStudio::get_instance()->find_palette_color(63, 5, 5);
 }
 

--- a/mapedit/objbrowse.cc
+++ b/mapedit/objbrowse.cc
@@ -160,7 +160,7 @@ void Create_file_selection(
 	gtk_button_set_image(GTK_BUTTON(btn), img);
 	gtk_window_set_modal(GTK_WINDOW(fsel), true);
 	if (action == GTK_FILE_CHOOSER_ACTION_SAVE) {
-		gtk_file_chooser_set_do_overwrite_confirmation(fsel, TRUE);
+		gtk_file_chooser_set_do_overwrite_confirmation(fsel, true);
 	}
 	if (path != nullptr && is_system_path_defined(path)) {
 		// Default to a writable location.
@@ -276,9 +276,9 @@ static gboolean on_find_key(
 		auto* chooser = static_cast<Object_browser*>(user_data);
 		chooser->search(
 				gtk_entry_get_text(GTK_ENTRY(chooser->get_find_text())), 1);
-		return TRUE;
+		return true;
 	}
-	return FALSE;    // Let parent handle it.
+	return false;    // Let parent handle it.
 }
 
 static void on_loc_down(GtkButton* button, gpointer user_data) {
@@ -318,14 +318,14 @@ GtkWidget* Object_browser::create_controls(
 	GtkWidget* topframe = gtk_frame_new(nullptr);
 	widget_set_margins(
 			topframe, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(topframe);
+	gtk_widget_set_visible(topframe, true);
 
 	// Everything goes in here.
 	GtkWidget* tophbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(tophbox), FALSE);
+	gtk_box_set_homogeneous(GTK_BOX(tophbox), false);
 	widget_set_margins(
 			tophbox, 1 * HMARGIN, 1 * HMARGIN, 1 * VMARGIN, 1 * VMARGIN);
-	gtk_widget_show(tophbox);
+	gtk_widget_set_visible(tophbox, true);
 	gtk_container_add(GTK_CONTAINER(topframe), tophbox);
 	/*
 	 *  The 'Find' controls.
@@ -334,40 +334,40 @@ GtkWidget* Object_browser::create_controls(
 		GtkWidget* frame = gtk_frame_new("Find");
 		widget_set_margins(
 				frame, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-		gtk_widget_show(frame);
-		gtk_box_pack_start(GTK_BOX(tophbox), frame, FALSE, FALSE, 0);
+		gtk_widget_set_visible(frame, true);
+		gtk_box_pack_start(GTK_BOX(tophbox), frame, false, false, 0);
 
 		GtkWidget* hbox2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-		gtk_box_set_homogeneous(GTK_BOX(hbox2), FALSE);
-		gtk_widget_show(hbox2);
+		gtk_box_set_homogeneous(GTK_BOX(hbox2), false);
+		gtk_widget_set_visible(hbox2, true);
 		gtk_container_add(GTK_CONTAINER(frame), hbox2);
 
 		find_text = gtk_entry_new();
-		gtk_editable_set_editable(GTK_EDITABLE(find_text), TRUE);
-		gtk_entry_set_visibility(GTK_ENTRY(find_text), TRUE);
-		gtk_widget_set_can_focus(GTK_WIDGET(find_text), TRUE);
+		gtk_editable_set_editable(GTK_EDITABLE(find_text), true);
+		gtk_entry_set_visibility(GTK_ENTRY(find_text), true);
+		gtk_widget_set_can_focus(GTK_WIDGET(find_text), true);
 		widget_set_margins(
 				find_text, 2 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-		gtk_widget_show(find_text);
-		gtk_box_pack_start(GTK_BOX(hbox2), find_text, FALSE, FALSE, 0);
+		gtk_widget_set_visible(find_text, true);
+		gtk_box_pack_start(GTK_BOX(hbox2), find_text, false, false, 0);
 		gtk_widget_set_size_request(find_text, 110, -1);
 
 		GtkWidget* hbox3 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-		gtk_box_set_homogeneous(GTK_BOX(hbox3), TRUE);
-		gtk_widget_show(hbox3);
-		gtk_box_pack_start(GTK_BOX(hbox2), hbox3, FALSE, FALSE, 0);
+		gtk_box_set_homogeneous(GTK_BOX(hbox3), true);
+		gtk_widget_set_visible(hbox3, true);
+		gtk_box_pack_start(GTK_BOX(hbox2), hbox3, false, false, 0);
 
 		GtkWidget* find_down = Create_arrow_button(
 				GTK_ARROW_DOWN, G_CALLBACK(on_find_down), this);
 		widget_set_margins(
 				find_down, 1 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-		gtk_box_pack_start(GTK_BOX(hbox3), find_down, TRUE, TRUE, 0);
+		gtk_box_pack_start(GTK_BOX(hbox3), find_down, true, true, 0);
 
 		GtkWidget* find_up = Create_arrow_button(
 				GTK_ARROW_UP, G_CALLBACK(on_find_up), this);
 		widget_set_margins(
 				find_up, 1 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-		gtk_box_pack_start(GTK_BOX(hbox3), find_up, TRUE, TRUE, 0);
+		gtk_box_pack_start(GTK_BOX(hbox3), find_up, true, true, 0);
 
 		g_signal_connect(
 				G_OBJECT(find_text), "key-press-event", G_CALLBACK(on_find_key),
@@ -380,28 +380,28 @@ GtkWidget* Object_browser::create_controls(
 		GtkWidget* frame = gtk_frame_new("Locate");
 		widget_set_margins(
 				frame, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-		gtk_widget_show(frame);
-		gtk_box_pack_start(GTK_BOX(tophbox), frame, FALSE, FALSE, 0);
+		gtk_widget_set_visible(frame, true);
+		gtk_box_pack_start(GTK_BOX(tophbox), frame, false, false, 0);
 
 		GtkWidget* lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-		gtk_box_set_homogeneous(GTK_BOX(lbox), FALSE);
-		gtk_widget_show(lbox);
+		gtk_box_set_homogeneous(GTK_BOX(lbox), false);
+		gtk_widget_set_visible(lbox, true);
 		gtk_container_add(GTK_CONTAINER(frame), lbox);
 		GtkWidget* bbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-		gtk_box_set_homogeneous(GTK_BOX(bbox), TRUE);
-		gtk_widget_show(bbox);
-		gtk_box_pack_start(GTK_BOX(lbox), bbox, TRUE, TRUE, 0);
+		gtk_box_set_homogeneous(GTK_BOX(bbox), true);
+		gtk_widget_set_visible(bbox, true);
+		gtk_box_pack_start(GTK_BOX(lbox), bbox, true, true, 0);
 
 		loc_down = Create_arrow_button(
 				GTK_ARROW_DOWN, G_CALLBACK(on_loc_down), this);
 		widget_set_margins(
 				loc_down, 2 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-		gtk_box_pack_start(GTK_BOX(bbox), loc_down, TRUE, TRUE, 0);
+		gtk_box_pack_start(GTK_BOX(bbox), loc_down, true, true, 0);
 
 		loc_up = Create_arrow_button(GTK_ARROW_UP, G_CALLBACK(on_loc_up), this);
 		widget_set_margins(
 				loc_up, 1 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-		gtk_box_pack_start(GTK_BOX(bbox), loc_up, TRUE, TRUE, 0);
+		gtk_box_pack_start(GTK_BOX(bbox), loc_up, true, true, 0);
 
 		if (controls & static_cast<int>(locate_frame)) {
 			GtkWidget* lbl = gtk_label_new(" F:");
@@ -409,17 +409,17 @@ GtkWidget* Object_browser::create_controls(
 					lbl, 0 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
 			gtk_label_set_xalign(GTK_LABEL(lbl), 0.9);
 			gtk_label_set_yalign(GTK_LABEL(lbl), 0.5);
-			gtk_box_pack_start(GTK_BOX(lbox), lbl, TRUE, TRUE, 0);
-			gtk_widget_show(lbl);
+			gtk_box_pack_start(GTK_BOX(lbox), lbl, true, true, 0);
+			gtk_widget_set_visible(lbl, true);
 
 			loc_f = gtk_entry_new();
-			gtk_editable_set_editable(GTK_EDITABLE(loc_f), TRUE);
-			gtk_entry_set_visibility(GTK_ENTRY(loc_f), TRUE);
-			gtk_widget_set_can_focus(GTK_WIDGET(loc_f), TRUE);
+			gtk_editable_set_editable(GTK_EDITABLE(loc_f), true);
+			gtk_entry_set_visibility(GTK_ENTRY(loc_f), true);
+			gtk_widget_set_can_focus(GTK_WIDGET(loc_f), true);
 			widget_set_margins(
 					loc_f, 1 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-			gtk_widget_show(loc_f);
-			gtk_box_pack_start(GTK_BOX(lbox), loc_f, TRUE, TRUE, 0);
+			gtk_widget_set_visible(loc_f, true);
+			gtk_box_pack_start(GTK_BOX(lbox), loc_f, true, true, 0);
 			gtk_widget_set_size_request(loc_f, 64, -1);
 		}
 		if (controls & static_cast<int>(locate_quality)) {
@@ -428,17 +428,17 @@ GtkWidget* Object_browser::create_controls(
 					lbl, 0 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
 			gtk_label_set_xalign(GTK_LABEL(lbl), 0.9);
 			gtk_label_set_yalign(GTK_LABEL(lbl), 0.5);
-			gtk_box_pack_start(GTK_BOX(lbox), lbl, TRUE, TRUE, 0);
-			gtk_widget_show(lbl);
+			gtk_box_pack_start(GTK_BOX(lbox), lbl, true, true, 0);
+			gtk_widget_set_visible(lbl, true);
 
 			loc_q = gtk_entry_new();
-			gtk_editable_set_editable(GTK_EDITABLE(loc_q), TRUE);
-			gtk_entry_set_visibility(GTK_ENTRY(loc_q), TRUE);
-			gtk_widget_set_can_focus(GTK_WIDGET(loc_q), TRUE);
+			gtk_editable_set_editable(GTK_EDITABLE(loc_q), true);
+			gtk_entry_set_visibility(GTK_ENTRY(loc_q), true);
+			gtk_widget_set_can_focus(GTK_WIDGET(loc_q), true);
 			widget_set_margins(
 					loc_q, 1 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-			gtk_widget_show(loc_q);
-			gtk_box_pack_start(GTK_BOX(lbox), loc_q, TRUE, TRUE, 0);
+			gtk_widget_set_visible(loc_q, true);
+			gtk_box_pack_start(GTK_BOX(lbox), loc_q, true, true, 0);
 			gtk_widget_set_size_request(loc_q, 64, -1);
 		}
 	}
@@ -449,25 +449,25 @@ GtkWidget* Object_browser::create_controls(
 		GtkWidget* frame = gtk_frame_new("Move");
 		widget_set_margins(
 				frame, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-		gtk_widget_show(frame);
-		gtk_box_pack_start(GTK_BOX(tophbox), frame, FALSE, FALSE, 0);
+		gtk_widget_set_visible(frame, true);
+		gtk_box_pack_start(GTK_BOX(tophbox), frame, false, false, 0);
 
 		GtkWidget* bbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-		gtk_box_set_homogeneous(GTK_BOX(bbox), TRUE);
-		gtk_widget_show(bbox);
+		gtk_box_set_homogeneous(GTK_BOX(bbox), true);
+		gtk_widget_set_visible(bbox, true);
 		gtk_container_add(GTK_CONTAINER(frame), bbox);
 
 		move_down = Create_arrow_button(
 				GTK_ARROW_DOWN, G_CALLBACK(on_move_down), this);
 		widget_set_margins(
 				move_down, 2 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-		gtk_box_pack_start(GTK_BOX(bbox), move_down, TRUE, TRUE, 0);
+		gtk_box_pack_start(GTK_BOX(bbox), move_down, true, true, 0);
 
 		move_up = Create_arrow_button(
 				GTK_ARROW_UP, G_CALLBACK(on_move_up), this);
 		widget_set_margins(
 				move_up, 1 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-		gtk_box_pack_start(GTK_BOX(bbox), move_up, TRUE, TRUE, 0);
+		gtk_box_pack_start(GTK_BOX(bbox), move_up, true, true, 0);
 	}
 	return topframe;
 }

--- a/mapedit/objedit.cc
+++ b/mapedit/objedit.cc
@@ -81,7 +81,7 @@ C_EXPORT gboolean on_obj_window_delete_event(
 		GtkWidget* widget, GdkEvent* event, gpointer user_data) {
 	ignore_unused_variable_warning(widget, event, user_data);
 	ExultStudio::get_instance()->close_obj_window();
-	return TRUE;
+	return true;
 }
 
 /*
@@ -91,7 +91,7 @@ C_EXPORT gboolean on_obj_pos_changed(
 		GtkWidget* widget, GdkEventFocus* event, gpointer user_data) {
 	ignore_unused_variable_warning(widget, event, user_data);
 	//++++Maybe later, change pos. immediately?
-	return TRUE;
+	return true;
 }
 
 /*
@@ -120,7 +120,7 @@ void ExultStudio::open_obj_window(
 	if (!init_obj_window(data, datalen)) {
 		return;
 	}
-	gtk_widget_show(objwin);
+	gtk_widget_set_visible(objwin, true);
 }
 
 /*
@@ -129,7 +129,7 @@ void ExultStudio::open_obj_window(
 
 void ExultStudio::close_obj_window() {
 	if (objwin) {
-		gtk_widget_hide(objwin);
+		gtk_widget_set_visible(objwin, false);
 	}
 }
 

--- a/mapedit/paledit.cc
+++ b/mapedit/paledit.cc
@@ -259,7 +259,7 @@ gint Palette_edit::configure(
 		paled->drawfg = (255 << 16) + (255 << 8);
 	}
 	paled->render();
-	return TRUE;
+	return true;
 }
 
 /*
@@ -278,7 +278,7 @@ gint Palette_edit::expose(
 	gdk_cairo_get_clip_rectangle(cairo, &area);
 	paled->show(area.x, area.y, area.width, area.height);
 	paled->set_graphic_context(nullptr);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -294,11 +294,11 @@ gint Palette_edit::mouse_press(
 	auto* paled = static_cast<Palette_edit*>(data);
 
 	if (event->button == 4 || event->button == 5) {    // mouse wheel
-		return TRUE;
+		return true;
 	}
 
 	if (paled->colorsel) {
-		return TRUE;    // Already editing a color.
+		return true;    // Already editing a color.
 	}
 	const int old_selected = paled->selected;
 	const int width        = paled->width;
@@ -340,7 +340,7 @@ gint Palette_edit::mouse_press(
 				GTK_MENU(paled->create_popup()),
 				reinterpret_cast<GdkEvent*>(event));
 	}
-	return TRUE;
+	return true;
 }
 
 /*
@@ -371,7 +371,7 @@ gint Palette_edit::drag_begin(
 	cout << "In DRAG_BEGIN of Palette" << endl;
 	// Palette_edit *paled = static_cast<Palette_edit *>(data);
 	//  Maybe someday.
-	return TRUE;
+	return true;
 }
 
 /*
@@ -441,30 +441,30 @@ GtkWidget* Palette_edit::create_controls() {
 	GtkWidget* topframe = gtk_frame_new(nullptr);
 	widget_set_margins(
 			topframe, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(topframe);
+	gtk_widget_set_visible(topframe, true);
 
 	GtkWidget* vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(vbox), FALSE);
-	gtk_widget_show(vbox);
+	gtk_box_set_homogeneous(GTK_BOX(vbox), false);
+	gtk_widget_set_visible(vbox, true);
 	gtk_container_add(GTK_CONTAINER(topframe), vbox);
 
 	GtkWidget* hbox0 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(hbox0), FALSE);
+	gtk_box_set_homogeneous(GTK_BOX(hbox0), false);
 	widget_set_margins(
 			hbox0, 1 * HMARGIN, 1 * HMARGIN, 1 * VMARGIN, 1 * VMARGIN);
-	gtk_widget_show(hbox0);
-	gtk_box_pack_start(GTK_BOX(vbox), hbox0, TRUE, TRUE, 0);
+	gtk_widget_set_visible(hbox0, true);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox0, true, true, 0);
 	/*
 	 *  The 'Edit' controls.
 	 */
 	GtkWidget* frame = gtk_frame_new("Edit");
 	widget_set_margins(
 			frame, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(frame);
-	gtk_box_pack_start(GTK_BOX(hbox0), frame, FALSE, FALSE, 0);
+	gtk_widget_set_visible(frame, true);
+	gtk_box_pack_start(GTK_BOX(hbox0), frame, false, false, 0);
 
 	GtkWidget* hbuttonbox = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
-	gtk_widget_show(hbuttonbox);
+	gtk_widget_set_visible(hbuttonbox, true);
 	gtk_container_add(GTK_CONTAINER(frame), hbuttonbox);
 	gtk_button_box_set_layout(GTK_BUTTON_BOX(hbuttonbox), GTK_BUTTONBOX_START);
 	gtk_box_set_spacing(GTK_BOX(hbuttonbox), 0);
@@ -472,16 +472,16 @@ GtkWidget* Palette_edit::create_controls() {
 	insert_btn = gtk_button_new_with_label("New");
 	widget_set_margins(
 			insert_btn, 2 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(insert_btn);
+	gtk_widget_set_visible(insert_btn, true);
 	gtk_container_add(GTK_CONTAINER(hbuttonbox), insert_btn);
-	gtk_widget_set_can_default(GTK_WIDGET(insert_btn), TRUE);
+	gtk_widget_set_can_default(GTK_WIDGET(insert_btn), true);
 
 	remove_btn = gtk_button_new_with_label("Remove");
 	widget_set_margins(
 			remove_btn, 1 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(remove_btn);
+	gtk_widget_set_visible(remove_btn, true);
 	gtk_container_add(GTK_CONTAINER(hbuttonbox), remove_btn);
-	gtk_widget_set_can_default(GTK_WIDGET(remove_btn), TRUE);
+	gtk_widget_set_can_default(GTK_WIDGET(remove_btn), true);
 
 	g_signal_connect(
 			G_OBJECT(insert_btn), "clicked", G_CALLBACK(on_insert_btn_clicked),
@@ -495,20 +495,20 @@ GtkWidget* Palette_edit::create_controls() {
 	frame = gtk_frame_new("Move");
 	widget_set_margins(
 			frame, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(frame);
-	gtk_box_pack_start(GTK_BOX(hbox0), frame, FALSE, FALSE, 0);
+	gtk_widget_set_visible(frame, true);
+	gtk_box_pack_start(GTK_BOX(hbox0), frame, false, false, 0);
 
 	GtkWidget* bbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(bbox), TRUE);
-	gtk_widget_show(bbox);
+	gtk_box_set_homogeneous(GTK_BOX(bbox), true);
+	gtk_widget_set_visible(bbox, true);
 	gtk_container_add(GTK_CONTAINER(frame), bbox);
 
 	down_btn = gtk_button_new();
 	widget_set_margins(
 			down_btn, 2 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(down_btn);
-	gtk_box_pack_start(GTK_BOX(bbox), down_btn, FALSE, FALSE, 0);
-	gtk_widget_set_can_default(GTK_WIDGET(down_btn), TRUE);
+	gtk_widget_set_visible(down_btn, true);
+	gtk_box_pack_start(GTK_BOX(bbox), down_btn, false, false, 0);
+	gtk_widget_set_can_default(GTK_WIDGET(down_btn), true);
 	GtkWidget* arrow
 			= gtk_image_new_from_icon_name("go-down", GTK_ICON_SIZE_BUTTON);
 	gtk_button_set_image(GTK_BUTTON(down_btn), arrow);
@@ -516,9 +516,9 @@ GtkWidget* Palette_edit::create_controls() {
 	up_btn = gtk_button_new();
 	widget_set_margins(
 			up_btn, 1 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(up_btn);
-	gtk_box_pack_start(GTK_BOX(bbox), up_btn, FALSE, FALSE, 0);
-	gtk_widget_set_can_default(GTK_WIDGET(up_btn), TRUE);
+	gtk_widget_set_visible(up_btn, true);
+	gtk_box_pack_start(GTK_BOX(bbox), up_btn, false, false, 0);
+	gtk_widget_set_can_default(GTK_WIDGET(up_btn), true);
 	arrow = gtk_image_new_from_icon_name("go-up", GTK_ICON_SIZE_BUTTON);
 	gtk_button_set_image(GTK_BUTTON(up_btn), arrow);
 
@@ -533,11 +533,11 @@ GtkWidget* Palette_edit::create_controls() {
 	frame = gtk_frame_new("File");
 	widget_set_margins(
 			frame, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(frame);
-	gtk_box_pack_start(GTK_BOX(hbox0), frame, FALSE, FALSE, 0);
+	gtk_widget_set_visible(frame, true);
+	gtk_box_pack_start(GTK_BOX(hbox0), frame, false, false, 0);
 
 	hbuttonbox = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
-	gtk_widget_show(hbuttonbox);
+	gtk_widget_set_visible(hbuttonbox, true);
 	gtk_container_add(GTK_CONTAINER(frame), hbuttonbox);
 	gtk_button_box_set_layout(GTK_BUTTON_BOX(hbuttonbox), GTK_BUTTONBOX_START);
 	gtk_box_set_spacing(GTK_BOX(hbuttonbox), 0);
@@ -545,16 +545,16 @@ GtkWidget* Palette_edit::create_controls() {
 	GtkWidget* importbtn = gtk_button_new_with_label("Import");
 	widget_set_margins(
 			importbtn, 2 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(importbtn);
+	gtk_widget_set_visible(importbtn, true);
 	gtk_container_add(GTK_CONTAINER(hbuttonbox), importbtn);
-	gtk_widget_set_can_default(GTK_WIDGET(importbtn), TRUE);
+	gtk_widget_set_can_default(GTK_WIDGET(importbtn), true);
 
 	GtkWidget* exportbtn = gtk_button_new_with_label("Export");
 	widget_set_margins(
 			exportbtn, 1 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(exportbtn);
+	gtk_widget_set_visible(exportbtn, true);
 	gtk_container_add(GTK_CONTAINER(hbuttonbox), exportbtn);
-	gtk_widget_set_can_default(GTK_WIDGET(exportbtn), TRUE);
+	gtk_widget_set_can_default(GTK_WIDGET(exportbtn), true);
 
 	g_signal_connect(
 			G_OBJECT(importbtn), "clicked", G_CALLBACK(on_importbtn_clicked),
@@ -591,8 +591,8 @@ void Palette_edit::enable_controls() {
 void Palette_edit::setup() {
 	// Put things in a vert. box.
 	GtkWidget* vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(vbox), FALSE);
-	gtk_widget_show(vbox);
+	gtk_box_set_homogeneous(GTK_BOX(vbox), false);
+	gtk_widget_set_visible(vbox, true);
 	set_widget(vbox);
 
 	// A frame looks nice.
@@ -600,8 +600,8 @@ void Palette_edit::setup() {
 	gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_IN);
 	widget_set_margins(
 			frame, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(frame);
-	gtk_box_pack_start(GTK_BOX(vbox), frame, TRUE, TRUE, 0);
+	gtk_widget_set_visible(frame, true);
+	gtk_box_pack_start(GTK_BOX(vbox), frame, true, true, 0);
 
 	draw = gtk_drawing_area_new();    // Create drawing area window.
 	//	gtk_widget_set_size_request(draw, w, h);
@@ -626,23 +626,23 @@ void Palette_edit::setup() {
 	gtk_container_add(GTK_CONTAINER(frame), draw);
 	widget_set_margins(
 			draw, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(draw);
+	gtk_widget_set_visible(draw, true);
 
 	// At bottom, a status bar.
 	sbar     = gtk_statusbar_new();
 	sbar_sel = gtk_statusbar_get_context_id(GTK_STATUSBAR(sbar), "selection");
 	// At the bottom, status bar & frame:
 	GtkWidget* hbox1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(hbox1), FALSE);
-	gtk_box_pack_start(GTK_BOX(vbox), hbox1, FALSE, FALSE, 0);
-	gtk_widget_show(hbox1);
-	gtk_box_pack_start(GTK_BOX(hbox1), sbar, TRUE, TRUE, 0);
+	gtk_box_set_homogeneous(GTK_BOX(hbox1), false);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox1, false, false, 0);
+	gtk_widget_set_visible(hbox1, true);
+	gtk_box_pack_start(GTK_BOX(hbox1), sbar, true, true, 0);
 	// Palette # to right of sbar.
 	GtkWidget* label = gtk_label_new("Palette #:");
 	widget_set_margins(
 			label, 2 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_box_pack_start(GTK_BOX(hbox1), label, FALSE, FALSE, 0);
-	gtk_widget_show(label);
+	gtk_box_pack_start(GTK_BOX(hbox1), label, false, false, 0);
+	gtk_widget_set_visible(label, true);
 
 	// A spin button for palette#.
 	palnum_adj = GTK_ADJUSTMENT(
@@ -653,14 +653,14 @@ void Palette_edit::setup() {
 			this);
 	widget_set_margins(
 			pspin, 1 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_box_pack_start(GTK_BOX(hbox1), pspin, FALSE, FALSE, 0);
-	gtk_widget_show(pspin);
+	gtk_box_pack_start(GTK_BOX(hbox1), pspin, false, false, 0);
+	gtk_widget_set_visible(pspin, true);
 
 	// Add edit controls to bottom.
-	gtk_box_pack_start(GTK_BOX(vbox), create_controls(), FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(vbox), create_controls(), false, false, 0);
 	widget_set_margins(
 			sbar, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(sbar);
+	gtk_widget_set_visible(sbar, true);
 	enable_controls();
 }
 

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -487,9 +487,9 @@ void Shape_single::on_shape_changed(GtkWidget* widget, gpointer user_data) {
 	if (single->hide && !(single->frame) && !(single->hide_connect)
 		&& (GTK_IS_ENTRY(widget))) {
 		if (strlen(gtk_entry_get_text(GTK_ENTRY(widget))) > 0) {
-			gtk_widget_show(single->draw);
+			gtk_widget_set_visible(single->draw, true);
 		} else {
-			gtk_widget_hide(single->draw);
+			gtk_widget_set_visible(single->draw, false);
 		}
 	}
 	single->render();
@@ -500,9 +500,9 @@ void Shape_single::on_frame_changed(GtkWidget* widget, gpointer user_data) {
 	auto* single = static_cast<Shape_single*>(user_data);
 	if (single->hide && !(single->hide_connect) && (GTK_IS_ENTRY(widget))) {
 		if (strlen(gtk_entry_get_text(GTK_ENTRY(widget))) > 0) {
-			gtk_widget_show(single->draw);
+			gtk_widget_set_visible(single->draw, true);
 		} else {
-			gtk_widget_hide(single->draw);
+			gtk_widget_set_visible(single->draw, false);
 		}
 	}
 	single->render();
@@ -513,9 +513,9 @@ void Shape_single::on_state_changed(
 	ignore_unused_variable_warning(flags);
 	auto* single = static_cast<Shape_single*>(user_data);
 	if (!(gtk_widget_get_state_flags(widget) & GTK_STATE_FLAG_INSENSITIVE)) {
-		gtk_widget_show(single->draw);
+		gtk_widget_set_visible(single->draw, true);
 	} else {
-		gtk_widget_hide(single->draw);
+		gtk_widget_set_visible(single->draw, false);
 	}
 	single->render();
 }
@@ -546,7 +546,7 @@ gboolean Shape_single::on_draw_expose_event(
 			ZoomDown(area.x), ZoomDown(area.y), ZoomDown(area.width),
 			ZoomDown(area.height));
 	single->set_graphic_context(nullptr);
-	return TRUE;
+	return true;
 }
 
 void Shape_single::on_shape_dropped(

--- a/mapedit/shapeedit.cc
+++ b/mapedit/shapeedit.cc
@@ -203,7 +203,7 @@ C_EXPORT gboolean on_equip_window_delete_event(
 		GtkWidget* widget, GdkEvent* event, gpointer user_data) {
 	ignore_unused_variable_warning(widget, event, user_data);
 	ExultStudio::get_instance()->close_equip_window();
-	return TRUE;
+	return true;
 }
 
 /*
@@ -215,7 +215,7 @@ C_EXPORT gboolean
 	const int recnum
 			= gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
 	ExultStudio::get_instance()->init_equip_window(recnum);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -238,58 +238,58 @@ static void Setup_equip(
 ) {
 	GtkGrid* table = GTK_GRID(gtk_grid_new());
 	gtk_container_add(viewport, GTK_WIDGET(table));
-	gtk_widget_show(GTK_WIDGET(table));
+	gtk_widget_set_visible(GTK_WIDGET(table), true);
 	// Labels at top:
 	GtkWidget* label = gtk_label_new("Shape");
-	gtk_widget_show(label);
+	gtk_widget_set_visible(label, true);
 	gtk_grid_attach(table, label, 0, 0, 3, 1);
 	label = gtk_label_new("Chance (%)");
-	gtk_widget_show(label);
+	gtk_widget_set_visible(label, true);
 	gtk_grid_attach(table, label, 4, 0, 1, 1);
 	label = gtk_label_new("Count");
-	gtk_widget_show(label);
+	gtk_widget_set_visible(label, true);
 	gtk_grid_attach(table, label, 6, 0, 1, 1);
 	// Separators:
 	GtkWidget* vsep = gtk_separator_new(GTK_ORIENTATION_VERTICAL);
-	gtk_widget_show(vsep);
+	gtk_widget_set_visible(vsep, true);
 	gtk_grid_attach(table, vsep, 3, 0, 1, 12);
 	gtk_widget_set_margin_start(vsep, 2);
 	gtk_widget_set_margin_end(vsep, 2);
 	gtk_widget_set_halign(vsep, GTK_ALIGN_CENTER);
-	gtk_widget_set_hexpand(vsep, TRUE);
+	gtk_widget_set_hexpand(vsep, true);
 	vsep = gtk_separator_new(GTK_ORIENTATION_VERTICAL);
-	gtk_widget_show(vsep);
+	gtk_widget_set_visible(vsep, true);
 	gtk_grid_attach(table, vsep, 5, 0, 1, 12);
 	gtk_widget_set_margin_start(vsep, 2);
 	gtk_widget_set_margin_end(vsep, 2);
 	gtk_widget_set_halign(vsep, GTK_ALIGN_CENTER);
-	gtk_widget_set_hexpand(vsep, TRUE);
+	gtk_widget_set_hexpand(vsep, true);
 	GtkWidget* hsep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
-	gtk_widget_show(hsep);
+	gtk_widget_set_visible(hsep, true);
 	gtk_grid_attach(table, hsep, 0, 1, 7, 1);
 	gtk_widget_set_halign(hsep, GTK_ALIGN_FILL);
-	gtk_widget_set_hexpand(hsep, TRUE);
+	gtk_widget_set_hexpand(hsep, true);
 	gtk_widget_set_valign(hsep, GTK_ALIGN_CENTER);
-	gtk_widget_set_vexpand(hsep, TRUE);
+	gtk_widget_set_vexpand(hsep, true);
 
 	// Create the rows.
 	for (int row = 0; row < 10; row++) {
 		// Create frame, shape drawing area.
 		GtkWidget* frame = gtk_frame_new(nullptr);
-		gtk_widget_show(frame);
+		gtk_widget_set_visible(frame, true);
 		gtk_grid_attach(table, frame, 0, row + 2, 1, 1);
 		gtk_widget_set_margin_start(frame, 3);
 		gtk_widget_set_margin_end(frame, 3);
 		gtk_widget_set_margin_top(frame, 2);
 		gtk_widget_set_margin_bottom(frame, 2);
 		gtk_widget_set_halign(frame, GTK_ALIGN_FILL);
-		gtk_widget_set_hexpand(frame, TRUE);
+		gtk_widget_set_hexpand(frame, true);
 		gtk_widget_set_valign(frame, GTK_ALIGN_FILL);
-		gtk_widget_set_hexpand(frame, TRUE);
+		gtk_widget_set_hexpand(frame, true);
 		gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_IN);
 
 		GtkWidget* drawingarea = gtk_drawing_area_new();
-		gtk_widget_show(drawingarea);
+		gtk_widget_set_visible(drawingarea, true);
 		gtk_container_add(GTK_CONTAINER(frame), drawingarea);
 		gtk_widget_set_size_request(drawingarea, 20, 40);
 		// Shape #:
@@ -298,19 +298,19 @@ static void Setup_equip(
 						gtk_adjustment_new(1, 0, c_max_shapes - 1, 1, 50, 50)),
 				1, 0);
 		rows[row].shape = spin;
-		gtk_widget_show(spin);
+		gtk_widget_set_visible(spin, true);
 		gtk_grid_attach(table, spin, 1, row + 2, 1, 1);
 		gtk_widget_set_margin_top(spin, 2);
 		gtk_widget_set_margin_bottom(spin, 2);
 		gtk_widget_set_halign(spin, GTK_ALIGN_FILL);
-		gtk_widget_set_hexpand(spin, TRUE);
+		gtk_widget_set_hexpand(spin, true);
 		// Name:
 		label          = gtk_label_new("label1");
 		rows[row].name = label;
-		gtk_widget_show(label);
+		gtk_widget_set_visible(label, true);
 		gtk_grid_attach(table, label, 2, row + 2, 1, 1);
 		gtk_widget_set_halign(label, GTK_ALIGN_FILL);
-		gtk_widget_set_hexpand(label, TRUE);
+		gtk_widget_set_hexpand(label, true);
 		gtk_label_set_justify(GTK_LABEL(label), GTK_JUSTIFY_LEFT);
 		gtk_label_set_xalign(GTK_LABEL(label), 0.2);
 		gtk_label_set_yalign(GTK_LABEL(label), 0.5);
@@ -326,23 +326,23 @@ static void Setup_equip(
 		spin = gtk_spin_button_new(
 				GTK_ADJUSTMENT(gtk_adjustment_new(1, 0, 100, 1, 10, 10)), 1, 0);
 		rows[row].chance = spin;
-		gtk_widget_show(spin);
+		gtk_widget_set_visible(spin, true);
 		gtk_grid_attach(table, spin, 4, row + 2, 1, 1);
 		gtk_widget_set_margin_top(spin, 2);
 		gtk_widget_set_margin_bottom(spin, 2);
 		gtk_widget_set_halign(spin, GTK_ALIGN_FILL);
-		gtk_widget_set_hexpand(spin, TRUE);
+		gtk_widget_set_hexpand(spin, true);
 		// Count:
 		spin = gtk_spin_button_new(
 				GTK_ADJUSTMENT(gtk_adjustment_new(1, 0, 100, 1, 10, 10)), 1, 0);
 		rows[row].count = spin;
-		gtk_widget_show(spin);
+		gtk_widget_set_visible(spin, true);
 		gtk_grid_attach(table, spin, 6, row + 2, 1, 1);
 		gtk_widget_set_margin_end(spin, 2);
 		gtk_widget_set_margin_top(spin, 2);
 		gtk_widget_set_margin_bottom(spin, 2);
 		gtk_widget_set_halign(spin, GTK_ALIGN_FILL);
-		gtk_widget_set_hexpand(spin, TRUE);
+		gtk_widget_set_hexpand(spin, true);
 	}
 }
 
@@ -412,7 +412,7 @@ void ExultStudio::open_equip_window(
 	// This will cause the data to be set:
 	set_spin("equip_recnum", recnum, 1, ecnt);
 	set_sensitive("equip_new", ecnt < 255);
-	gtk_widget_show(equipwin);
+	gtk_widget_set_visible(equipwin, true);
 }
 
 /*
@@ -421,7 +421,7 @@ void ExultStudio::open_equip_window(
 
 void ExultStudio::close_equip_window() {
 	if (equipwin) {
-		gtk_widget_hide(equipwin);
+		gtk_widget_set_visible(equipwin, false);
 	}
 }
 
@@ -469,7 +469,7 @@ C_EXPORT gboolean on_shape_window_delete_event(
 		GtkWidget* widget, GdkEvent* event, gpointer user_data) {
 	ignore_unused_variable_warning(widget, event, user_data);
 	ExultStudio::get_instance()->close_shape_window();
-	return TRUE;
+	return true;
 }
 
 /*
@@ -482,7 +482,7 @@ C_EXPORT gboolean
 	const bool   on     = sel == 0;
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_weapon_ammo_shape", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -495,7 +495,7 @@ C_EXPORT gboolean
 	const bool   on     = sel == 0;
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_weapon_proj", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -508,7 +508,7 @@ C_EXPORT gboolean
 	const bool   on     = sel == 0;
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_ammo_proj", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -532,7 +532,7 @@ C_EXPORT gboolean
 	studio->set_sensitive("shinfo_animation_rectype", on);
 	const bool recon = studio->get_toggle("shinfo_animation_rectype");
 	studio->set_sensitive("shinfo_animation_recycle", on && !recon);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -544,7 +544,7 @@ C_EXPORT gboolean on_shinfo_animation_frtype_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_animation_frcount", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -556,7 +556,7 @@ C_EXPORT gboolean on_shinfo_animation_rectype_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_animation_recycle", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -568,7 +568,7 @@ C_EXPORT gboolean on_shinfo_animation_sfxsynch_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_animation_sfxdelay", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -580,7 +580,7 @@ C_EXPORT gboolean on_shinfo_animation_freezefirst_changed(
 	const int    sel    = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_animation_freezechance", sel == 2);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -592,7 +592,7 @@ C_EXPORT gboolean on_shinfo_effhps_frame_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_effhps_frame_num", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -604,7 +604,7 @@ C_EXPORT gboolean on_shinfo_effhps_qual_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_effhps_qual_num", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -616,7 +616,7 @@ C_EXPORT gboolean on_shinfo_effhps_hp_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_effhps_hp_val", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -628,7 +628,7 @@ C_EXPORT gboolean on_shinfo_frameusecode_frame_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_frameusecode_frame_num", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -640,7 +640,7 @@ C_EXPORT gboolean on_shinfo_frameusecode_qual_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_frameusecode_qual_num", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -652,7 +652,7 @@ C_EXPORT gboolean on_shinfo_framenames_frame_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_framenames_frame_num", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -664,7 +664,7 @@ C_EXPORT gboolean on_shinfo_framenames_qual_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_framenames_qual_num", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -701,7 +701,7 @@ C_EXPORT gboolean on_shinfo_framenames_name_type_changed(
 		ot = studio->get_optmenu("shinfo_framenames_comp_msg_type");
 		studio->set_sensitive("shinfo_framenames_comp_msg_text", ot == 2);
 	}
-	return TRUE;
+	return true;
 }
 
 /*
@@ -713,7 +713,7 @@ C_EXPORT gboolean on_shinfo_framenames_comp_msg_type_changed(
 	const int    val    = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_framenames_comp_msg_text", val == 2);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -731,7 +731,7 @@ C_EXPORT gboolean on_shinfo_framenames_comp_type_changed(
 	}
 	val = studio->get_optmenu("shinfo_framenames_comp_msg_type");
 	studio->set_sensitive("shinfo_framenames_comp_msg_text", val == 2);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -743,7 +743,7 @@ C_EXPORT gboolean on_shinfo_frameflags_frame_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_frameflags_frame_num", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -755,7 +755,7 @@ C_EXPORT gboolean on_shinfo_frameflags_qual_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_frameflags_qual_num", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -767,7 +767,7 @@ C_EXPORT gboolean on_shinfo_brightness_frame_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_brightness_frame_num", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -779,7 +779,7 @@ C_EXPORT gboolean on_shinfo_warmth_frame_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_warmth_frame_num", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -791,7 +791,7 @@ C_EXPORT gboolean on_shinfo_cntrules_shape_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_cntrules_shape_num", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -803,7 +803,7 @@ C_EXPORT gboolean on_shinfo_explosion_sfx_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_explosion_sfx_number", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -1049,7 +1049,7 @@ C_EXPORT gboolean
 		studio->set_optmenu("shinfo_mountaintop_type", 0, false);
 	}
 
-	return TRUE;
+	return true;
 }
 
 /*
@@ -2053,7 +2053,7 @@ C_EXPORT gboolean on_shinfo_objpaperdoll_frame_type_toggled(
 	const bool   on     = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	ExultStudio* studio = ExultStudio::get_instance();
 	studio->set_sensitive("shinfo_objpaperdoll_wframe", on);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -2170,7 +2170,7 @@ C_EXPORT gboolean
 	ExultStudio* studio = ExultStudio::get_instance();
 	const int    ready  = studio->get_optmenu("shinfo_ready_spot");
 	Set_objpaperdoll_sensitivity(studio, spot, ready);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -2183,7 +2183,7 @@ C_EXPORT gboolean
 	ExultStudio* studio = ExultStudio::get_instance();
 	const int    spot   = studio->get_optmenu("shinfo_objpaperdoll_spot");
 	Set_objpaperdoll_sensitivity(studio, spot, ready);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -3256,7 +3256,7 @@ void ExultStudio::init_shape_notebook(
 		Set_objpaperdoll_fields();
 	}
 
-	gtk_widget_show(book);
+	gtk_widget_set_visible(book, true);
 }
 
 struct Update_hps {
@@ -4546,9 +4546,9 @@ void ExultStudio::open_shape_window(
 	if (info) {
 		init_shape_notebook(*info, notebook, shnum, frnum);
 	} else {
-		gtk_widget_hide(notebook);
+		gtk_widget_set_visible(notebook, false);
 	}
-	gtk_widget_show(shapewin);
+	gtk_widget_set_visible(shapewin, true);
 }
 
 /*
@@ -4603,6 +4603,6 @@ void ExultStudio::save_shape_window() {
 
 void ExultStudio::close_shape_window() {
 	if (shapewin) {
-		gtk_widget_hide(shapewin);
+		gtk_widget_set_visible(shapewin, false);
 	}
 }

--- a/mapedit/shapegroup.cc
+++ b/mapedit/shapegroup.cc
@@ -491,9 +491,9 @@ C_EXPORT gboolean on_groups_new_name_key_press(
 	ignore_unused_variable_warning(entry, user_data);
 	if (event->keyval == GDK_KEY_Return) {
 		ExultStudio::get_instance()->add_group();
-		return TRUE;
+		return true;
 	}
-	return FALSE;    // Let parent handle it.
+	return false;    // Let parent handle it.
 }
 
 C_EXPORT void on_open_builtin_group_clicked(
@@ -565,7 +565,7 @@ void gulong_deleter(gpointer data) {
 void ExultStudio::setup_groups() {
 	Shape_group_file* groups = curfile->get_groups();
 	if (!groups) {    // No groups?
-		set_visible("groups_frame", FALSE);
+		set_visible("groups_frame", false);
 		return;
 	}
 	GtkTreeView*  tview  = GTK_TREE_VIEW(get_widget("group_list"));
@@ -586,7 +586,7 @@ void ExultStudio::setup_groups() {
 				tview, -1, "Names", renderer, "text", GRP_FILE_COLUMN, nullptr);
 		GtkTreeViewColumn* column
 				= gtk_tree_view_get_column(tview, col_offset - 1);
-		gtk_tree_view_column_set_clickable(column, TRUE);
+		gtk_tree_view_column_set_clickable(column, true);
 		addsig = g_signal_connect(
 				G_OBJECT(model), "row-inserted",
 				G_CALLBACK(on_group_list_row_inserted), this);
@@ -620,10 +620,10 @@ void ExultStudio::setup_groups() {
 	g_signal_handler_block(model, delsig);
 	g_signal_handler_block(model, chgsig);
 	gtk_tree_store_clear(model);
-	set_visible("groups_frame", TRUE);
+	set_visible("groups_frame", true);
 	// Show builtins for shapes.vga.
 	set_visible("builtin_groups", curfile == vgafile);
-	gtk_tree_view_set_reorderable(tview, TRUE);
+	gtk_tree_view_set_reorderable(tview, true);
 	const int   cnt = groups->size();    // Add groups from file.
 	GtkTreeIter iter;
 	for (int i = 0; i < cnt; i++) {
@@ -764,7 +764,7 @@ C_EXPORT gboolean on_group_window_delete_event(
 		GtkWidget* widget, GdkEvent* event, gpointer user_data) {
 	ignore_unused_variable_warning(event, user_data);
 	ExultStudio::get_instance()->close_group_window(widget);
-	return TRUE;
+	return true;
 }
 
 C_EXPORT void on_group_up_clicked(GtkToggleButton* button, gpointer user_data) {
@@ -884,15 +884,15 @@ void ExultStudio::open_group_window(Shape_group* grp) {
 	}
 	// Attach browser.
 	GtkWidget* browser_box = get_widget(xml, "group_shapes");
-	gtk_widget_show(browser_box);
+	gtk_widget_set_visible(browser_box, true);
 	gtk_box_pack_start(
-			GTK_BOX(browser_box), chooser->get_widget(), TRUE, TRUE, 0);
+			GTK_BOX(browser_box), chooser->get_widget(), true, true, 0);
 	// Auto-connect doesn't seem to work.
 	g_signal_connect(
 			G_OBJECT(grpwin), "delete-event",
 			G_CALLBACK(on_group_window_delete_event), this);
 	group_windows.push_back(GTK_WINDOW(grpwin));
-	gtk_widget_show(grpwin);
+	gtk_widget_set_visible(grpwin, true);
 }
 
 /*
@@ -935,7 +935,7 @@ void ExultStudio::save_groups() {
 }
 
 /*
- *  Return TRUE if any groups have been modified.
+ *  Return true if any groups have been modified.
  */
 
 bool ExultStudio::groups_modified() {

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -515,7 +515,7 @@ gint Shape_chooser::configure(GdkEventConfigure* event) {
 	if (drop_callback != Shape_dropped_here) {
 		enable_drop(Shape_dropped_here, this);
 	}
-	return FALSE;
+	return false;
 }
 
 /*
@@ -536,7 +536,7 @@ gint Shape_chooser::expose(
 			ZoomDown(area.x), ZoomDown(area.y), ZoomDown(area.width),
 			ZoomDown(area.height));
 	chooser->set_graphic_context(nullptr);
-	return TRUE;
+	return true;
 }
 
 /*
@@ -574,10 +574,10 @@ gint Shape_chooser::mouse_press(
 		if (row0 > 0) {
 			scroll_row_vertical(row0 - 1);
 		}
-		return TRUE;
+		return true;
 	} else if (event->button == 5) {
 		scroll_row_vertical(row0 + 1);
-		return TRUE;
+		return true;
 	}
 	const int      old_selected = selected;
 	int            new_selected = -1;
@@ -614,7 +614,7 @@ gint Shape_chooser::mouse_press(
 		gtk_menu_popup_at_pointer(
 				GTK_MENU(create_popup()), reinterpret_cast<GdkEvent*>(event));
 	}
-	return TRUE;
+	return true;
 }
 
 /*
@@ -650,12 +650,12 @@ C_EXPORT gboolean on_draw_key_press(
 	switch (event->keyval) {
 	case GDK_KEY_Delete:
 		chooser->del_frame();
-		return TRUE;
+		return true;
 	case GDK_KEY_Insert:
 		chooser->new_frame();
-		return TRUE;
+		return true;
 	}
-	return FALSE;    // Let parent handle it.
+	return false;    // Let parent handle it.
 }
 
 const unsigned char transp = 255;
@@ -897,7 +897,7 @@ void Shape_chooser::edit_shape(
 	std::memset(&si, 0, sizeof(si));
 	si.cb         = sizeof(si);
 	const int ret = CreateProcess(
-			nullptr, &cmd[0], nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si,
+			nullptr, &cmd[0], nullptr, nullptr, false, 0, nullptr, nullptr, &si,
 			&pi);
 	if (!ret) {
 		Alert("Can't launch '%s'", studio->get_image_editor());
@@ -1476,7 +1476,7 @@ C_EXPORT void on_new_shape_okay_clicked(GtkButton* button, gpointer user_data) {
 	auto*      chooser = static_cast<Shape_chooser*>(
             g_object_get_data(G_OBJECT(win), "user_data"));
 	chooser->create_new_shape();
-	gtk_widget_hide(win);
+	gtk_widget_set_visible(win, false);
 }
 
 // Toggled 'From font' button:
@@ -1508,7 +1508,7 @@ gboolean Shape_chooser::on_new_shape_font_color_draw_expose_event(
 			(color & 255) / 255.0);
 	cairo_rectangle(cairo, area.x, area.y, area.width, area.height);
 	cairo_fill(cairo);
-	return TRUE;
+	return true;
 }
 
 C_EXPORT void on_new_shape_font_color_changed(
@@ -1610,7 +1610,7 @@ void Shape_chooser::new_shape() {
 	g_signal_connect(
 			G_OBJECT(draw), "draw",
 			G_CALLBACK(on_new_shape_font_color_draw_expose_event), this);
-	gtk_widget_show(win);
+	gtk_widget_set_visible(win, true);
 }
 
 /*
@@ -1767,17 +1767,17 @@ gint Shape_chooser::drag_begin(
 	cout << "In DRAG_BEGIN of Shape" << endl;
 	auto* chooser = static_cast<Shape_chooser*>(data);
 	if (chooser->selected < 0) {
-		return FALSE;    // ++++Display a halt bitmap.
+		return false;    // ++++Display a halt bitmap.
 	}
 	// Get ->shape.
 	const Shape_entry& shinfo = chooser->info[chooser->selected];
 	Shape_frame*       shape
 			= chooser->ifile->get_shape(shinfo.shapenum, shinfo.framenum);
 	if (!shape) {
-		return FALSE;
+		return false;
 	}
 	chooser->set_drag_icon(context, shape);    // Set icon for dragging.
-	return TRUE;
+	return true;
 }
 
 /*
@@ -1963,9 +1963,9 @@ void Shape_chooser::all_frames_toggled(GtkToggleButton* btn, gpointer data) {
 	const bool on        = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(btn));
 	chooser->frames_mode = on;
 	if (on) {    // Frame => show horiz. scrollbar.
-		gtk_widget_show(chooser->hscroll);
+		gtk_widget_set_visible(chooser->hscroll, true);
 	} else {
-		gtk_widget_hide(chooser->hscroll);
+		gtk_widget_set_visible(chooser->hscroll, false);
 	}
 	// The old index is no longer valid, so we need to remember the shape.
 	int       indx    = chooser->selected >= 0
@@ -2015,7 +2015,7 @@ void Shape_chooser::on_shapes_popup_edtiles_activate(
 	GtkAdjustment* adj = gtk_spin_button_get_adjustment(GTK_SPIN_BUTTON(spin));
 	gtk_adjustment_set_lower(adj, 1);
 	gtk_adjustment_set_upper(adj, nframes);
-	gtk_widget_show(win);
+	gtk_widget_set_visible(win, true);
 }
 
 static void on_shapes_popup_import(GtkMenuItem* item, gpointer udata) {
@@ -2086,7 +2086,7 @@ C_EXPORT void on_export_tiles_okay_clicked(
 	const int    tiles  = studio->get_spin("export_tiles_count");
 	const bool   bycol  = studio->get_toggle("tiled_by_columns");
 	chooser->edit_shape(tiles, bycol);
-	gtk_widget_hide(win);
+	gtk_widget_set_visible(win, false);
 }
 
 /*
@@ -2288,22 +2288,22 @@ Shape_chooser::Shape_chooser(
 
 	// Put things in a vert. box.
 	GtkWidget* vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(vbox), FALSE);
+	gtk_box_set_homogeneous(GTK_BOX(vbox), false);
 	set_widget(vbox);    // This is our "widget"
-	gtk_widget_show(vbox);
+	gtk_widget_set_visible(vbox, true);
 
 	GtkWidget* hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(hbox), FALSE);
-	gtk_widget_show(hbox);
-	gtk_box_pack_start(GTK_BOX(vbox), hbox, TRUE, TRUE, 0);
+	gtk_box_set_homogeneous(GTK_BOX(hbox), false);
+	gtk_widget_set_visible(hbox, true);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox, true, true, 0);
 
 	// A frame looks nice.
 	GtkWidget* frame = gtk_frame_new(nullptr);
 	gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_IN);
 	widget_set_margins(
 			frame, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(frame);
-	gtk_box_pack_start(GTK_BOX(hbox), frame, TRUE, TRUE, 0);
+	gtk_widget_set_visible(frame, true);
+	gtk_box_pack_start(GTK_BOX(hbox), frame, true, true, 0);
 
 	// NOTE:  draw is in Shape_draw.
 	// Indicate the events we want.
@@ -2321,7 +2321,7 @@ Shape_chooser::Shape_chooser(
 	g_signal_connect(
 			G_OBJECT(draw), "key-press-event", G_CALLBACK(on_draw_key_press),
 			this);
-	gtk_widget_set_can_focus(GTK_WIDGET(draw), TRUE);
+	gtk_widget_set_can_focus(GTK_WIDGET(draw), true);
 	// Set mouse click handler.
 	g_signal_connect(
 			G_OBJECT(draw), "button-press-event", G_CALLBACK(Mouse_press),
@@ -2341,63 +2341,64 @@ Shape_chooser::Shape_chooser(
 	widget_set_margins(
 			draw, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
 	gtk_widget_set_size_request(draw, w, h);
-	gtk_widget_show(draw);
+	gtk_widget_set_visible(draw, true);
 	// Want vert. scrollbar for the shapes.
 	GtkAdjustment* shape_adj = GTK_ADJUSTMENT(
 			gtk_adjustment_new(0, 0, std::ceil(get_count() / 4.0), 1, 1, 1));
 	vscroll = gtk_scrollbar_new(
 			GTK_ORIENTATION_VERTICAL, GTK_ADJUSTMENT(shape_adj));
-	gtk_box_pack_start(GTK_BOX(hbox), vscroll, FALSE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox), vscroll, false, true, 0);
 	// Set scrollbar handler.
 	g_signal_connect(
 			G_OBJECT(shape_adj), "value-changed", G_CALLBACK(vscrolled), this);
-	gtk_widget_show(vscroll);
+	gtk_widget_set_visible(vscroll, true);
 	// Horizontal scrollbar.
 	shape_adj = GTK_ADJUSTMENT(gtk_adjustment_new(0, 0, 1600, 8, 16, 16));
 	hscroll   = gtk_scrollbar_new(
             GTK_ORIENTATION_HORIZONTAL, GTK_ADJUSTMENT(shape_adj));
-	gtk_box_pack_start(GTK_BOX(vbox), hscroll, FALSE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(vbox), hscroll, false, true, 0);
 	// Set scrollbar handler.
 	g_signal_connect(
 			G_OBJECT(shape_adj), "value-changed", G_CALLBACK(hscrolled), this);
-	//++++  gtk_widget_hide(hscroll);   // Only shown in 'frames' mode.
+	//++++  gtk_widget_set_visible(hscroll, false);   // Only shown in 'frames'
+	// mode.
 	// Scroll events.
 	enable_draw_vscroll(draw);
 
 	// At the bottom, status bar & frame:
 	GtkWidget* hbox1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_box_set_homogeneous(GTK_BOX(hbox1), FALSE);
-	gtk_box_pack_start(GTK_BOX(vbox), hbox1, FALSE, FALSE, 0);
-	gtk_widget_show(hbox1);
+	gtk_box_set_homogeneous(GTK_BOX(hbox1), false);
+	gtk_box_pack_start(GTK_BOX(vbox), hbox1, false, false, 0);
+	gtk_widget_set_visible(hbox1, true);
 	// At left, a status bar.
 	sbar     = gtk_statusbar_new();
 	sbar_sel = gtk_statusbar_get_context_id(GTK_STATUSBAR(sbar), "selection");
-	gtk_box_pack_start(GTK_BOX(hbox1), sbar, TRUE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox1), sbar, true, true, 0);
 	widget_set_margins(
 			sbar, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(sbar);
+	gtk_widget_set_visible(sbar, true);
 	GtkWidget* label = gtk_label_new("Frame:");
-	gtk_box_pack_start(GTK_BOX(hbox1), label, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox1), label, false, false, 0);
 	widget_set_margins(
 			label, 2 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(label);
+	gtk_widget_set_visible(label, true);
 	// A spin button for frame#.
 	frame_adj = GTK_ADJUSTMENT(gtk_adjustment_new(0, 0, 16, 1, 0, 0.0));
 	fspin     = gtk_spin_button_new(GTK_ADJUSTMENT(frame_adj), 1, 0);
 	g_signal_connect(
 			G_OBJECT(frame_adj), "value-changed", G_CALLBACK(frame_changed),
 			this);
-	gtk_box_pack_start(GTK_BOX(hbox1), fspin, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox1), fspin, false, false, 0);
 	widget_set_margins(
 			fspin, 1 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
 	gtk_widget_set_sensitive(fspin, false);
-	gtk_widget_show(fspin);
+	gtk_widget_set_visible(fspin, true);
 	// A toggle for 'All Frames'.
 	GtkWidget* allframes = gtk_toggle_button_new_with_label("Frames");
-	gtk_box_pack_start(GTK_BOX(hbox1), allframes, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox1), allframes, false, false, 0);
 	widget_set_margins(
 			allframes, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_widget_show(allframes);
+	gtk_widget_set_visible(allframes, true);
 	g_signal_connect(
 			G_OBJECT(allframes), "toggled", G_CALLBACK(all_frames_toggled),
 			this);
@@ -2407,7 +2408,7 @@ Shape_chooser::Shape_chooser(
 			create_controls(
 					find_controls | locate_controls | locate_quality
 					| locate_frame),
-			FALSE, FALSE, 0);
+			false, false, 0);
 }
 
 /*

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -443,7 +443,7 @@ C_EXPORT gboolean on_main_window_configure_event(
 	// Configure "Hide lift" spin range.
 	studio->set_spin(
 			"hide_lift_spin", studio->get_spin("hide_lift_spin"), 1, 255);
-	return FALSE;
+	return false;
 }
 
 /*
@@ -453,9 +453,9 @@ C_EXPORT gboolean on_main_window_delete_event(
 		GtkWidget* widget, GdkEvent* event, gpointer user_data) {
 	ignore_unused_variable_warning(widget, event, user_data);
 	if (!ExultStudio::get_instance()->okay_to_close()) {
-		return TRUE;    // Can't quit.
+		return true;    // Can't quit.
 	}
-	return FALSE;
+	return false;
 }
 
 C_EXPORT void on_main_window_destroy_event(GtkWidget* widget, gpointer data) {
@@ -480,7 +480,7 @@ C_EXPORT gboolean on_main_window_focus_in_event(
 		GtkWidget* widget, GdkEventFocus* event, gpointer user_data) {
 	ignore_unused_variable_warning(widget, event, user_data);
 	Shape_chooser::check_editing_files();
-	return FALSE;
+	return false;
 }
 
 /*
@@ -534,7 +534,7 @@ ExultStudio::ExultStudio(int argc, char** argv)
 	gtk_init(&argc, &argv);
 	g_object_set(
 			gtk_settings_get_default(), "gtk-application-prefer-dark-theme",
-			TRUE, nullptr);
+			true, nullptr);
 #ifdef _WIN32
 	bool portable = false;
 #endif
@@ -878,7 +878,7 @@ ExultStudio::ExultStudio(int argc, char** argv)
 		//++++Used to work  gtk_window_set_default_size(GTK_WINDOW(app), w, h);
 		gtk_window_resize(GTK_WINDOW(app), w, h);
 	}
-	gtk_widget_show(app);
+	gtk_widget_set_visible(app, true);
 	g_signal_connect(
 			G_OBJECT(app), "key-press-event", G_CALLBACK(on_app_key_press),
 			this);
@@ -1091,10 +1091,10 @@ void ExultStudio::set_browser(const char* name, Object_browser* obj) {
 	browser = obj;
 
 	gtk_frame_set_label(GTK_FRAME(browser_frame), name);
-	gtk_widget_show(browser_box);
+	gtk_widget_set_visible(browser_box, true);
 	if (browser) {
 		gtk_box_pack_start(
-				GTK_BOX(browser_box), browser->get_widget(), TRUE, TRUE, 0);
+				GTK_BOX(browser_box), browser->get_widget(), true, true, 0);
 	}
 }
 
@@ -1313,7 +1313,7 @@ C_EXPORT void on_gameselect_ok_clicked(
 
 	studio->set_game_path(game->get_cfgname(), modtitle);
 	GtkWidget* win = studio->get_widget("game_selection");
-	gtk_widget_hide(win);
+	gtk_widget_set_visible(win, false);
 }
 
 /*
@@ -1442,7 +1442,7 @@ void ExultStudio::open_game_dialog(bool createmod) {
 			GtkTreeViewColumn* column
 					= gtk_tree_view_get_column(tree, col_offset - 1);
 			gtk_tree_view_column_set_clickable(
-					GTK_TREE_VIEW_COLUMN(column), TRUE);
+					GTK_TREE_VIEW_COLUMN(column), true);
 		}
 		gtk_tree_store_clear(model);
 	}
@@ -1458,7 +1458,7 @@ void ExultStudio::open_game_dialog(bool createmod) {
 		set_visible("modlist_frame", false);
 	}
 	fill_game_tree(GTK_TREE_VIEW(dlg_list[0]), curr_game);
-	gtk_widget_show(win);
+	gtk_widget_set_visible(win, true);
 }
 
 /*
@@ -1574,7 +1574,7 @@ void ExultStudio::set_game_path(const string& gamename, const string& modname) {
 	close_combo_window();
 	close_compile_window();
 	if (gameinfowin) {
-		gtk_widget_hide(gameinfowin);
+		gtk_widget_set_visible(gameinfowin, false);
 	}
 
 	gtk_notebook_prev_page(mainnotebook);
@@ -1749,14 +1749,14 @@ void ExultStudio::setup_file_list() {
 				FOLDER_COLUMN, nullptr);
 		column = gtk_tree_view_get_column(
 				GTK_TREE_VIEW(file_list), col_offset - 1);
-		gtk_tree_view_column_set_clickable(GTK_TREE_VIEW_COLUMN(column), TRUE);
+		gtk_tree_view_column_set_clickable(GTK_TREE_VIEW_COLUMN(column), true);
 		/* column for file names */
 		col_offset = gtk_tree_view_insert_column_with_attributes(
 				GTK_TREE_VIEW(file_list), -1, "Files", renderer, "text",
 				FILE_COLUMN, nullptr);
 		column = gtk_tree_view_get_column(
 				GTK_TREE_VIEW(file_list), col_offset - 1);
-		gtk_tree_view_column_set_clickable(GTK_TREE_VIEW_COLUMN(column), TRUE);
+		gtk_tree_view_column_set_clickable(GTK_TREE_VIEW_COLUMN(column), true);
 	}
 	gtk_tree_store_clear(model);
 	add_to_tree(
@@ -1957,7 +1957,7 @@ void ExultStudio::set_edit_terrain(gboolean terrain    // True/false
 	}
 	// Set edit-mode to paint.
 	GtkWidget* mitem = get_widget(terrain ? "paint1" : "move1");
-	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mitem), TRUE);
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mitem), true);
 }
 
 void ExultStudio::set_edit_mode(int md    // 0-2 (drag, paint, pick.
@@ -1992,7 +1992,7 @@ void ExultStudio::show_unused_shapes(
 	GtkTextView*   text    = GTK_TEXT_VIEW(get_widget("msg_text"));
 	GtkTextBuffer* buffer  = gtk_text_view_get_buffer(text);
 	gtk_text_buffer_set_text(buffer, "", 0);    // Clear out old text
-	set_visible("msg_win", TRUE);               // Show message window.
+	set_visible("msg_win", true);               // Show message window.
 	int          pos = 0;
 	GtkEditable* ed  = GTK_EDITABLE(text);
 	Insert_text(ed, "The following shapes were not found.\n", pos);
@@ -2309,14 +2309,18 @@ void ExultStudio::set_button(const char* name, const char* text) {
 /*
  *  Show/hide a widget.
  */
+C_EXPORT gboolean exult_widget_hide(GtkWidget* w) {
+	gtk_widget_set_visible(w, false);
+	return true;
+}
 
 void ExultStudio::set_visible(const char* name, bool vis) {
 	GtkWidget* widg = get_widget(name);
 	if (widg) {
 		if (vis) {
-			gtk_widget_show(widg);
+			gtk_widget_set_visible(widg, true);
 		} else {
-			gtk_widget_hide(widg);
+			gtk_widget_set_visible(widg, false);
 		}
 	}
 }
@@ -2378,8 +2382,8 @@ int ExultStudio::prompt(
 		gtk_widget_set_size_request(
 				draw, gdk_pixbuf_get_width(logo_pixbuf),
 				gdk_pixbuf_get_height(logo_pixbuf));
-		gtk_widget_show(draw);
-		gtk_box_pack_start(GTK_BOX(hbox), draw, FALSE, FALSE, 12);
+		gtk_widget_set_visible(draw, true);
+		gtk_box_pack_start(GTK_BOX(hbox), draw, false, false, 12);
 		// Make logo show to left.
 		gtk_box_reorder_child(GTK_BOX(hbox), draw, 0);
 	}
@@ -2399,11 +2403,11 @@ int ExultStudio::prompt(
 	}
 	prompt_choice = -1;
 	gtk_window_set_modal(GTK_WINDOW(dlg), true);
-	gtk_widget_show(dlg);            // Should be modal.
-	while (prompt_choice == -1) {    // Spin.
-		gtk_main_iteration();        // (Blocks).
+	gtk_widget_set_visible(dlg, true);    // Should be modal.
+	while (prompt_choice == -1) {         // Spin.
+		gtk_main_iteration();             // (Blocks).
 	}
-	gtk_widget_hide(dlg);
+	gtk_widget_set_visible(dlg, false);
 	assert(prompt_choice >= 0 && prompt_choice <= 2);
 	return prompt_choice;
 }
@@ -2457,10 +2461,10 @@ namespace EStudio {
 								   : gtk_radio_menu_item_new(group))
 						  : (label ? gtk_menu_item_new_with_label(label)
 								   : gtk_menu_item_new());
-		gtk_widget_show(mitem);
+		gtk_widget_set_visible(mitem, true);
 		gtk_menu_shell_append(GTK_MENU_SHELL(menu), mitem);
 		if (!label) {    // Want separator?
-			gtk_widget_set_sensitive(mitem, FALSE);
+			gtk_widget_set_sensitive(mitem, false);
 		}
 		if (func) {    // Function?
 			g_signal_connect(G_OBJECT(mitem), "activate", func, func_data);
@@ -2482,7 +2486,7 @@ namespace EStudio {
 				dir == GTK_ARROW_UP ? "go-up" : "go-down",
 				GTK_ICON_SIZE_BUTTON);
 		gtk_button_set_image(GTK_BUTTON(btn), img);
-		gtk_widget_show(btn);
+		gtk_widget_set_visible(btn, true);
 		g_signal_connect(G_OBJECT(btn), "clicked", clicked, func_data);
 		return btn;
 	}
@@ -2509,7 +2513,7 @@ namespace EStudio {
 
 C_EXPORT void on_prefs_cancel_clicked(GtkButton* button, gpointer user_data) {
 	ignore_unused_variable_warning(user_data);
-	gtk_widget_hide(gtk_widget_get_toplevel(GTK_WIDGET(button)));
+	gtk_widget_set_visible(gtk_widget_get_toplevel(GTK_WIDGET(button)), false);
 }
 
 C_EXPORT void on_prefs_apply_clicked(GtkButton* button, gpointer user_data) {
@@ -2520,7 +2524,7 @@ C_EXPORT void on_prefs_apply_clicked(GtkButton* button, gpointer user_data) {
 C_EXPORT void on_prefs_okay_clicked(GtkButton* button, gpointer user_data) {
 	ignore_unused_variable_warning(user_data);
 	ExultStudio::get_instance()->save_preferences();
-	gtk_widget_hide(gtk_widget_get_toplevel(GTK_WIDGET(button)));
+	gtk_widget_set_visible(gtk_widget_get_toplevel(GTK_WIDGET(button)), false);
 }
 
 /*
@@ -2532,7 +2536,7 @@ C_EXPORT void on_prefs_background_choose_clicked(
 	ignore_unused_variable_warning(button, user_data);
 	GtkColorChooserDialog* colorsel = GTK_COLOR_CHOOSER_DIALOG(
 			gtk_color_chooser_dialog_new("Background color", nullptr));
-	g_object_set(colorsel, "show-editor", TRUE, nullptr);
+	g_object_set(colorsel, "show-editor", true, nullptr);
 	gtk_window_set_modal(GTK_WINDOW(colorsel), true);
 	// Get color.
 	const guint32 c = ExultStudio::get_instance()->get_background_color();
@@ -2577,15 +2581,15 @@ gboolean ExultStudio::on_prefs_background_expose_event(
 			(color & 255) / 255.0);
 	cairo_rectangle(cairo, area.x, area.y, area.width, area.height);
 	cairo_fill(cairo);
-	return TRUE;
+	return true;
 }
 
 // X at top of window.
 C_EXPORT gboolean on_prefs_window_delete_event(
 		GtkWidget* widget, GdkEvent* event, gpointer user_data) {
 	ignore_unused_variable_warning(event, user_data);
-	gtk_widget_hide(widget);
-	return TRUE;
+	gtk_widget_set_visible(widget, false);
+	return true;
 }
 
 /*
@@ -2618,7 +2622,7 @@ void ExultStudio::open_preferences() {
 	g_signal_connect(
 			G_OBJECT(get_widget("prefs_background")), "draw",
 			G_CALLBACK(on_prefs_background_expose_event), this);
-	gtk_widget_show(win);
+	gtk_widget_set_visible(win, true);
 }
 
 /*
@@ -2695,14 +2699,14 @@ static gboolean Read_from_server(
 	ignore_unused_variable_warning(source, condition);
 	ExultStudio* studio = static_cast<ExultStudio*>(data);
 	studio->read_from_server();
-	return TRUE;
+	return true;
 }
 #else
 static gint Read_from_server(gpointer data    // ->ExultStudio.
 ) {
 	auto* studio = static_cast<ExultStudio*>(data);
 	studio->read_from_server();
-	return TRUE;
+	return true;
 }
 #endif
 
@@ -2930,7 +2934,7 @@ void ExultStudio::info_received(
 	if (edmode >= 0 && static_cast<unsigned>(edmode) < mode_names.size()) {
 		GtkWidget* mitem = get_widget(mode_names[edmode]);
 
-		gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mitem), TRUE);
+		gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mitem), true);
 	}
 }
 
@@ -3050,7 +3054,7 @@ C_EXPORT void on_gameinfo_apply_clicked(
 	}
 
 	GtkWidget* win = studio->get_widget("game_information");
-	gtk_widget_hide(win);
+	gtk_widget_set_visible(win, false);
 }
 
 C_EXPORT void on_gameinfo_charset_changed(
@@ -3158,7 +3162,7 @@ void ExultStudio::set_game_information() {
 			convertToUTF8(gameinfo->get_menu_string().c_str(), "ASCII"));
 	gtk_text_buffer_set_text(buff, title.c_str(), -1);
 
-	gtk_widget_show(gameinfowin);
+	gtk_widget_set_visible(gameinfowin, true);
 }
 
 /*
@@ -3576,15 +3580,15 @@ gboolean ExultStudio::on_app_key_press(
 		if (studio->shape_zup) {
 			g_signal_emit_by_name(G_OBJECT(studio->shape_zup), "clicked");
 		}
-		return TRUE;
+		return true;
 	case GDK_KEY_minus:
 	case GDK_KEY_KP_Subtract:
 		if (studio->shape_zdown) {
 			g_signal_emit_by_name(G_OBJECT(studio->shape_zdown), "clicked");
 		}
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 void ExultStudio::create_zoom_controls() {
@@ -3592,55 +3596,55 @@ void ExultStudio::create_zoom_controls() {
 	GtkWidget* zframe = gtk_frame_new(nullptr);
 	widget_set_margins(
 			zframe, 2 * HMARGIN, 0 * HMARGIN, 0 * VMARGIN, 0 * VMARGIN);
-	gtk_widget_show(zframe);
-	gtk_box_pack_start(GTK_BOX(zbox), zframe, FALSE, FALSE, 0);
+	gtk_widget_set_visible(zframe, true);
+	gtk_box_pack_start(GTK_BOX(zbox), zframe, false, false, 0);
 
 	GtkWidget* zbox2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 	widget_set_margins(
 			zbox2, 0 * HMARGIN, 0 * HMARGIN, 0 * VMARGIN, 0 * VMARGIN);
-	gtk_box_set_homogeneous(GTK_BOX(zbox2), FALSE);
-	gtk_widget_show(zbox2);
+	gtk_box_set_homogeneous(GTK_BOX(zbox2), false);
+	gtk_widget_set_visible(zbox2, true);
 	gtk_container_add(GTK_CONTAINER(zframe), zbox2);
 
 	GtkWidget* zname = gtk_label_new("Zoom");
-	gtk_widget_set_visible(GTK_WIDGET(zname), TRUE);
+	gtk_widget_set_visible(GTK_WIDGET(zname), true);
 	widget_set_margins(
 			zname, 4 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_box_pack_start(GTK_BOX(zbox2), zname, FALSE, FALSE, 0);
-	gtk_widget_show(zname);
+	gtk_box_pack_start(GTK_BOX(zbox2), zname, false, false, 0);
+	gtk_widget_set_visible(zname, true);
 
 	string zvalue = std::to_string(50 * shape_scale) + "%";
 	shape_zlabel  = gtk_label_new(zvalue.c_str());
-	gtk_widget_set_visible(GTK_WIDGET(shape_zlabel), TRUE);
+	gtk_widget_set_visible(GTK_WIDGET(shape_zlabel), true);
 	widget_set_margins(
 			shape_zlabel, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_box_pack_start(GTK_BOX(zbox2), shape_zlabel, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(zbox2), shape_zlabel, false, false, 0);
 	gtk_widget_set_size_request(shape_zlabel, 50, -1);
 	gtk_label_set_justify(GTK_LABEL(shape_zlabel), GTK_JUSTIFY_RIGHT);
-	gtk_widget_show(shape_zlabel);
+	gtk_widget_set_visible(shape_zlabel, true);
 
 	shape_zdown = EStudio::Create_arrow_button(
 			GTK_ARROW_DOWN, G_CALLBACK(ExultStudio::on_zoom_down), this);
 	widget_set_margins(
 			shape_zdown, 2 * HMARGIN, 1 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
 	gtk_widget_set_sensitive(shape_zdown, (shape_scale > 2 ? true : false));
-	gtk_box_pack_start(GTK_BOX(zbox2), shape_zdown, TRUE, TRUE, 0);
-	gtk_widget_show(shape_zdown);
+	gtk_box_pack_start(GTK_BOX(zbox2), shape_zdown, true, true, 0);
+	gtk_widget_set_visible(shape_zdown, true);
 
 	shape_zup = EStudio::Create_arrow_button(
 			GTK_ARROW_UP, G_CALLBACK(ExultStudio::on_zoom_up), this);
 	widget_set_margins(
 			shape_zup, 1 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
 	gtk_widget_set_sensitive(shape_zup, (shape_scale < 32 ? true : false));
-	gtk_box_pack_start(GTK_BOX(zbox2), shape_zup, TRUE, TRUE, 0);
-	gtk_widget_show(shape_zup);
+	gtk_box_pack_start(GTK_BOX(zbox2), shape_zup, true, true, 0);
+	gtk_widget_set_visible(shape_zup, true);
 
 	GtkWidget* zcheck = gtk_check_button_new_with_label("Bilinear");
 	widget_set_margins(
 			zcheck, 2 * HMARGIN, 2 * HMARGIN, 2 * VMARGIN, 2 * VMARGIN);
-	gtk_box_pack_start(GTK_BOX(zbox2), zcheck, TRUE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(zbox2), zcheck, true, true, 0);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(zcheck), shape_bilinear);
-	gtk_widget_show(zcheck);
+	gtk_widget_set_visible(zcheck, true);
 	g_signal_connect(
 			G_OBJECT(zcheck), "toggled",
 			G_CALLBACK(ExultStudio::on_zoom_bilinear), this);

--- a/mapedit/studio.h
+++ b/mapedit/studio.h
@@ -39,6 +39,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #	define GNOME_DISABLE_DEPRECATED
 #	define GTK_DISABLE_DEPRECATED
 #	define GDK_DISABLE_DEPRECATED
+#else
+#	define GDK_DISABLE_DEPRECATION_WARNINGS
+#	define GLIB_DISABLE_DEPRECATION_WARNINGS
 #endif    // USE_STRICT_GTK
 #include <gtk/gtk.h>
 #ifndef __GDK_KEYSYMS_H__

--- a/mapedit/u7shp.cc
+++ b/mapedit/u7shp.cc
@@ -34,6 +34,9 @@
 #	define GNOME_DISABLE_DEPRECATED
 #	define GTK_DISABLE_DEPRECATED
 #	define GDK_DISABLE_DEPRECATED
+#else
+#	define GDK_DISABLE_DEPRECATION_WARNINGS
+#	define GLIB_DISABLE_DEPRECATION_WARNINGS
 #endif    // USE_STRICT_GTK
 #include <gtk/gtk.h>
 #include <libgimp/gimp.h>
@@ -228,7 +231,7 @@ static void run(
 
 	GimpPDBStatusType status = GIMP_PDB_SUCCESS;
 	if (strcmp(name, "file_shp_load") == 0) {
-		gimp_ui_init("u7shp", FALSE);
+		gimp_ui_init("u7shp", false);
 		if (run_mode != GIMP_RUN_NONINTERACTIVE) {
 			choose_palette();
 		}

--- a/mapedit/ucbrowse.cc
+++ b/mapedit/ucbrowse.cc
@@ -114,7 +114,7 @@ C_EXPORT gboolean on_usecodes_dialog_delete_event(
 			g_object_get_data(G_OBJECT(widget), "user_data"));
 
 	ucb->cancel();
-	return TRUE;
+	return true;
 }
 
 /*
@@ -238,11 +238,11 @@ Usecode_browser::Usecode_browser() {
             "Type", renderer, "text", TYPE_COL, nullptr);
 	gtk_tree_view_append_column(GTK_TREE_VIEW(tree), col);
 	gtk_tree_view_column_set_sort_column_id(col, SORTID_TYPE);
-	gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(tree), TRUE);
+	gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(tree), true);
 	// Set initial sort.
 	gtk_tree_sortable_set_sort_column_id(
 			sortable, SORTID_NAME, GTK_SORT_ASCENDING);
-	gtk_widget_show(tree);
+	gtk_widget_set_visible(tree, true);
 }
 
 /*
@@ -260,9 +260,9 @@ Usecode_browser::~Usecode_browser() {
 
 void Usecode_browser::show(bool tf) {
 	if (tf) {
-		gtk_widget_show(win);
+		gtk_widget_set_visible(win, true);
 	} else {
-		gtk_widget_hide(win);
+		gtk_widget_set_visible(win, false);
 	}
 }
 
@@ -292,7 +292,7 @@ void Usecode_browser::okay() {
 		}
 		g_print("selected row is: %s\n", choice.c_str());
 	}
-	show(FALSE);
+	show(false);
 }
 
 /*


### PR DESCRIPTION
In Studio : 

- Replace GTK `TRUE` and `FALSE` by C++ `true` and `false` ( are identical ), overall in Studio
- Replace `gtk_widget_show` and `gtk_widget_hide` by `gtk_widget_set_visible`, overall in Studio, obsolescent in GTK+ 3, removed from GTK 4,
- Provide an `exult_widget_hide` in `studio.cc` for use in `exult_studio.glade` which cannot use `gtk_widget_set_visible` because of its boolean parameter,
- Add `DISABLE_DEPRECATION_WARNINGS` into the common `studio.h` and into the independent `u7shp.c` from non strict GTK.