### PR TITLE
Do not autoreconf -f for it overwrites ./INSTALL

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Run autoreconf
         run: |
           mkdir ./../build
-          autoreconf -f -v -i
+          autoreconf -v -i
       - name: Configure
         run: |
           cd ./../build

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -132,7 +132,7 @@ jobs:
         uses: actions/checkout@master
       - name: Run autoreconf
         run: |
-          autoreconf -f -v -i
+          autoreconf -v -i
       - name: Configure
         env:
           OVERRIDE_CC: ${{ matrix.cc }}

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@master
       - name: Run autoreconf
         run: |
-          autoreconf -f -v -i
+          autoreconf -v -i
       - name: Configure
         run: |
           export LDFLAGS="-L$(brew --prefix bison)/lib -L$(brew --prefix flex)/lib -L$(brew --prefix zlib)/lib"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -111,7 +111,7 @@ jobs:
             libgdk-pixbuf2.0-dev libxml2-dev bison flex timidity libgimp2.0-dev autoconf-archive
       - name: Run autoreconf
         run: |
-          autoreconf -f -v -i
+          autoreconf -v -i
       - name: Configure
         run: |
           ./configure --with-debug=extreme --enable-exult-studio --enable-exult-studio-support --enable-compiler --enable-gimp-plugin \

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run autoreconf
         if: ${{ env.EXULT_REPO_ALIVE == 'true' }}
         run: |
-          autoreconf -f -v -i
+          autoreconf -v -i
       - name: Configure
         if: ${{ env.EXULT_REPO_ALIVE == 'true' }}
         run: |

--- a/.github/workflows/snapshots-android.yml
+++ b/.github/workflows/snapshots-android.yml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ env.EXULT_REPO_ALIVE == 'true' }}
         run: |
           mkdir ./../build
-          autoreconf -f -v -i
+          autoreconf -v -i
       - name: Configure debug
         if: ${{ env.EXULT_REPO_ALIVE == 'true' }}
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
             name: "exult/exult"
             description: "Exult is an open source engine for Ultima 7 and Serpent Isle."
           notification_email: marzojr@gmail.com
-          build_command_prepend: "autoreconf -f -v -i && ./configure --with-debug=messages --disable-oggtest --disable-vorbistest --enable-exult-studio --enable-exult-studio-support --enable-mt32emu --enable-zip-support --enable-shared --enable-midi-sfx --enable-gimp-plugin --enable-gnome-shp-thumbnailer --enable-compiler --enable-mods --with-usecode-debugger=yes"
+          build_command_prepend: "autoreconf -v -i && ./configure --with-debug=messages --disable-oggtest --disable-vorbistest --enable-exult-studio --enable-exult-studio-support --enable-mt32emu --enable-zip-support --enable-shared --enable-midi-sfx --enable-gimp-plugin --enable-gnome-shp-thumbnailer --enable-compiler --enable-mods --with-usecode-debugger=yes"
           build_command:   "make"
           branch_pattern: coverity_scan
       before_script:

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -19,7 +19,7 @@ else
 	export LIBTOOLFLAGS="--silent"
 fi
 
-autoreconf -f -v -i && ./configure --with-cxx=$(which $CXX) $LIBOPTS $EXTRA_OPT	\
+autoreconf -v -i && ./configure --with-cxx=$(which $CXX) $LIBOPTS $EXTRA_OPT	\
                             --disable-oggtest --disable-vorbistest	\
                             --enable-exult-studio --enable-exult-studio-support	\
                             --enable-mt32emu --enable-zip-support	\

--- a/INSTALL
+++ b/INSTALL
@@ -41,7 +41,7 @@ Look at the top directory, and check whether configure exists.
 If it does not, then configure.ac should exist, and then you should type,
 in the top directory, to create configure,
 
-	autoreconf -f -v -i
+	autoreconf -v -i
 
 Got everything? Excellent. Now you can build your own binary of Exult.
 From the top directory type the following:
@@ -82,7 +82,7 @@ To compile Exult Studio you additionally need to install:
 Now follow the above steps to build Exult, only add the switch --enable-exult-studio
 to the configure step:
 
-autoreconf -f -v -i
+autoreconf -v -i
 ./configure --enable-exult-studio
 make
 
@@ -117,8 +117,8 @@ to the configure step.
 Installation Instructions
 *************************
 
-   Copyright (C) 1994-1996, 1999-2002, 2004-2016 Free Software
-Foundation, Inc.
+   Copyright (C) 1994-1996, 1999-2002, 2004-2017, 2020-2021 Free
+Software Foundation, Inc.
 
    Copying and distribution of this file, with or without modification,
 are permitted in any medium without royalty provided the copyright
@@ -341,7 +341,7 @@ order to use an ANSI C compiler:
 
 and if that doesn't work, install pre-built binaries of GCC for HP-UX.
 
-   HP-UX 'make' updates targets which have the same time stamps as their
+   HP-UX 'make' updates targets which have the same timestamps as their
 prerequisites, which makes it generally unusable when shipped generated
 files such as 'configure' are involved.  Use GNU 'make' instead.
 

--- a/README.MacOSX
+++ b/README.MacOSX
@@ -59,7 +59,7 @@ If you use MacPorts:
 
 Now you are ready to compile Exult. If you are compiling from Git, the
 first thing you have to run is this:
-  autoreconf -f -v -i
+  autoreconf -v -i
 
 The next step is the same whether you compile a release version or Git:
   ./configure

--- a/android/README.md
+++ b/android/README.md
@@ -39,7 +39,7 @@ The following is a quick summary of the commands to build (assuming you are in t
 
 ```
 mkdir ./../build && cd ./../build
-$ autoreconf -f -v -i ./../exult/
+$ autoreconf -v -i ./../exult
 $ ./../exult/configure --enable-data --enable-android-apk=debug \
             --disable-exult --disable-tools --disable-timidity-midi --disable-alsa \
             --disable-fluidsynth --disable-mt32emu --disable-all-hq-scalers \
@@ -55,7 +55,7 @@ Building a release build is similar, but requires signing the binary:
 
 ```
 mkdir ./../build && cd ./../build
-$ autoreconf -f -v -i ./../exult
+$ autoreconf -v -i ./../exult
 $ ./../exult/configure --enable-data --enable-android-apk=release \
             --disable-exult --disable-tools --disable-timidity-midi --disable-alsa \
             --disable-fluidsynth --disable-mt32emu --disable-all-hq-scalers \

--- a/android/app/src/main/cpp/dependencies/exult/CMakeLists.txt.in
+++ b/android/app/src/main/cpp/dependencies/exult/CMakeLists.txt.in
@@ -7,7 +7,7 @@ ExternalProject_Add(
   @DEPENDENCY@
   SOURCE_DIR        @EXULT_SOURCE_DIR@
   INSTALL_DIR       @DEPENDENCIES_INSTALL_DIR@
-  CONFIGURE_COMMAND autoreconf -f -v -i <SOURCE_DIR>
+  CONFIGURE_COMMAND autoreconf -v -i <SOURCE_DIR>
             COMMAND . @ENVFILE@ && <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --host=@ANDROID_LLVM_TRIPLE@ --enable-libexult --enable-shared --disable-data --disable-tools --enable-zip-support --enable-midi-sfx --enable-mt32emu --disable-fluidsynth --disable-alsa --disable-timidity-midi --disable-oggtest --disable-vorbistest
   BUILD_COMMAND     make -j@NCPU@ -s LIBTOOLFLAGS="--silent"
 )

--- a/exult.spec.in
+++ b/exult.spec.in
@@ -98,7 +98,7 @@ Exult Studio: an editor for the Exult engine.
 %build
 # Needed for snapshot releases.
 if [ ! -f configure ]; then
-  autoreconf -f -v -i
+  autoreconf -v -i
 fi
 
 %configure --disable-gimp-plugin --enable-exult-studio --enable-exult-studio-support


### PR DESCRIPTION
`autoreconf -f` overwrites `./INSTALL` with its version stored in `/usr/share/automake-1.16/INSTALL`.

- Replace all occurences of `autoreconf -f -v -i` by `autoreconf -v -i`
- Bring into `INSTALL` two lines out of the `automake 1.16` version of `INSTALL`
