### PR TITLE
Cleanup Exult build on FreeBSD, remove /usr/local explicit references

### DIFF
--- a/.github/workflows/ci-freebsd.yml
+++ b/.github/workflows/ci-freebsd.yml
@@ -132,7 +132,5 @@ jobs:
            --enable-nonreadied-objects \
            --disable-static --enable-shared \
            --enable-pedantic-errors --with-debug=extreme \
-           CXX=clang++ \
-           CXXFLAGS="-isystem /usr/local/include" \
-           LIBS="-L/usr/local/lib"
+           CXX=clang++
           make -j 2

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,12 +5,8 @@ AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/headers -I$(srcdir)/imagewin -I$(srcdir)/s
 	-I$(srcdir)/objs -I$(srcdir)/conf -I$(srcdir)/files -I$(srcdir)/gumps \
 	-I$(srcdir)/audio -I$(srcdir)/audio/midi_drivers -I$(srcdir)/pathfinder \
 	-I$(srcdir)/usecode -I$(srcdir)/shapes/shapeinf \
-	$(SDL_CFLAGS) $(VORBIS_CFLAGS) $(OGG_CFLAGS) $(INCDIRS) $(WINDOWING_SYSTEM) \
+	$(SDL_CFLAGS) $(VORBIS_CFLAGS) $(OGG_CFLAGS) $(PNG_CFLAGS) $(INCDIRS) $(WINDOWING_SYSTEM) \
 	$(DEBUG_LEVEL) $(OPT_LEVEL) $(WARNINGS) $(CPPFLAGS) -DEXULT_DATADIR=\"$(EXULT_DATADIR)\"
-
-if HAVE_PNG
-PNG_LIBS=-lpng
-endif
 
 SUBDIRS = files conf data shapes imagewin pathfinder \
 	gamemgr flic usecode tools audio gumps objs server \

--- a/audio/OggAudioSample.h
+++ b/audio/OggAudioSample.h
@@ -26,6 +26,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#	if defined(__llvm__) || defined(__clang__)
+#		if __clang_major__ >= 16
+#			pragma GCC diagnostic ignored "-Wcast-function-type-strict"
+#		endif
+#	endif
 #endif    // __GNUC__
 #include <vorbis/vorbisfile.h>
 #ifdef __GNUC__

--- a/audio/midi_drivers/ALSAMidiDriver.h
+++ b/audio/midi_drivers/ALSAMidiDriver.h
@@ -23,7 +23,19 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef USE_ALSA_MIDI
 #	include "LowLevelMidiDriver.h"
 
+#	ifdef __GNUC__
+#		pragma GCC diagnostic push
+#		pragma GCC diagnostic ignored "-Wold-style-cast"
+#		if defined(__llvm__) || defined(__clang__)
+#			if __clang_major__ >= 16
+#				pragma GCC diagnostic ignored "-Wzero-length-array"
+#			endif
+#		endif
+#	endif    // __GNUC__
 #	include <alsa/asoundlib.h>
+#	ifdef __GNUC__
+#		pragma GCC diagnostic pop
+#	endif    // __GNUC__
 
 #	include <string>
 

--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,7 @@ case "$host_os" in
 		WINDOWING_SYSTEM="-DXWIN"
 		AC_DEFINE(FREEBSD, 1, [Using FreeBSD])
 		AC_MSG_RESULT([X11 (FreeBSD)])
-		CXXFLAGS="$CXXFLAGS -I/usr/local/include -pthread"
+		CXXFLAGS="$CXXFLAGS -pthread"
 		;;
 	netbsd*)
 		# NetBSD, placeholder.
@@ -188,11 +188,6 @@ AC_HEADER_DIRENT
 AC_CHECK_HEADERS(limits.h sys/time.h unistd.h)
 AC_CHECK_HEADERS(sys/types.h sys/socket.h netdb.h)
 AC_CHECK_HEADERS(sys/wait.h signal.h getopt.h)
-if test x$ARCH != xandroid; then
-	AC_CHECK_HEADERS(png.h, AM_CONDITIONAL(HAVE_PNG,true), AM_CONDITIONAL(HAVE_PNG, false))
-else
-	AM_CONDITIONAL(HAVE_PNG, false)
-fi
 
 # ---------------------------------------------------------------------
 # Checks for typedefs, structures, and compiler characteristics.
@@ -432,6 +427,22 @@ fi
 # ---------------------------------------------------------------------
 
 EXULT_CHECK_SDL(:,AC_MSG_ERROR([[*** SDL not found!]]))
+
+# ---------------------------------------------------------------------
+# libpng
+# ---------------------------------------------------------------------
+
+if test x$ARCH != xandroid; then
+	PKG_CHECK_MODULES(PNG, libpng, have_png=yes, have_png=no)
+else
+	have_png=no
+fi
+if test x$have_png = xyes; then
+	AM_CONDITIONAL(HAVE_PNG, true)
+	AC_DEFINE(HAVE_PNG_H, 1, [Define to 1 if you have the <png.h> header file.])
+else
+	AM_CONDITIONAL(HAVE_PNG, false)
+fi
 
 # ---------------------------------------------------------------------
 # libogg, libvorbis, libvorbisfile
@@ -715,6 +726,11 @@ if test x$enable_exult_studio = xyes; then
 		echo "Please try again, either with the ICU installed, or with '--disable-exult-studio'."
 		exit 1
 	fi
+	if test x$have_png = xno; then
+		echo "Exult Studio requires the PNG (aka the Portable Network Graphics), but it is not installed."
+		echo "Please try again, either with the PNG installed, or with '--disable-exult-studio'."
+		exit 1
+	fi
 	AM_CONDITIONAL(BUILD_STUDIO, true)
 	AM_CONDITIONAL(BUILD_SHAPES, true)
 else
@@ -827,11 +843,11 @@ if test x$enable_usecode_debugger = xconsole -o x$enable_usecode_debugger = xyes
 		AC_DEFINE(USECODE_CONSOLE_DEBUGGER, 1, [Enable Usecode debugging on console])
 	elif test x$enable_exult_studio != xyes; then
 		echo "But we are not building Exult Studio."
-		echo "Try again, either with --enable-exult-studio, or without the usecode debugger"
+		echo "Please try again, either with '--enable-exult-studio', or without the usecode debugger"
 		exit 1
 	elif test x$enable_exult_studio_support != xyes; then
 		echo "But we are not building Exult with Exult Studio support."
-		echo "Try again, either with --enable-exult-studio-support, or without the usecode debugger"
+		echo "Please try again, either with '--enable-exult-studio-support', or without the usecode debugger"
 		exit 1
 	fi
 	AC_DEFINE(USECODE_DEBUGGER, 1, [Enable Usecode debugging])
@@ -868,7 +884,12 @@ if test x$enable_gnome_shp_thumbnailer = xyes; then
 	PKG_CHECK_MODULES(GDK_PIXBUF, gdk-pixbuf-2.0, have_gdk_pixbuf=yes, have_gdk_pixbuf=no)
 	if test x$have_gdk_pixbuf = xno; then
 		echo "The Gnome shp thumbnailer requires Gdk-Pixbuf."
-		echo "Try again, either with Gdk-Pixbuf-2.0, or with --disable-gnome-shp-thumbnailer"
+		echo "Please try again, either with Gdk-Pixbuf-2.0, or with '--disable-gnome-shp-thumbnailer'."
+		exit 1
+	fi
+	if test x$have_png = xno; then
+		echo "The Gnome shp thumbnailer requires the PNG (aka the Portable Network Graphics)."
+		echo "Please try again, either with the PNG installed, or with '--disable-gnome-shp-thumbnailer'."
 		exit 1
 	fi
 	AM_CONDITIONAL(BUILD_GTHUMB, true)
@@ -1311,7 +1332,7 @@ if test x$enable_android_apk = xno; then
 		echo Ogg.........................: `$PKG_CONFIG --modversion ogg`)
 	PKG_CHECK_EXISTS(vorbis,
 		echo Vorbis......................: `$PKG_CONFIG --modversion vorbis`)
-	if test x$ac_cv_header_png_h = xyes; then
+	if test x$have_png = xyes; then
 		PKG_CHECK_EXISTS(libpng,
 			echo libpng..................... : `$PKG_CONFIG --modversion libpng`)
 	fi

--- a/mapedit/Makefile.am
+++ b/mapedit/Makefile.am
@@ -2,7 +2,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/headers -I$(top_srcdir) -I$(top_srcdir)/shapes \
 	-I$(top_srcdir)/imagewin -I$(top_srcdir)/conf -I$(top_srcdir)/gamemgr \
 	-I$(top_srcdir)/files -I$(top_srcdir)/server  -I$(top_srcdir)/usecode \
 	-I$(top_srcdir)/shapes/shapeinf \
-	$(GTK_CFLAGS) $(ICU_CFLAGS) $(INCDIRS) $(WINDOWING_SYSTEM) \
+	$(GTK_CFLAGS) $(PNG_CFLAGS) $(ICU_CFLAGS) $(INCDIRS) $(WINDOWING_SYSTEM) \
 	$(DEBUG_LEVEL) $(OPT_LEVEL) $(WARNINGS) $(CPPFLAGS) -DEXULT_DATADIR=\"$(EXULT_DATADIR)\"
 
 if GIMP_PLUGIN
@@ -21,7 +21,7 @@ u7shp_SOURCES = u7shp.cc
 
 u7shp_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/files -I$(top_srcdir)/headers \
 	-I$(top_srcdir)/shapes -I$(top_srcdir)/imagewin -I$(top_srcdir)/files \
-	$(GIMP_INCLUDES) $(GTK_CFLAGS) $(ICU_CFLAGS) $(INCDIRS) \
+	$(GIMP_INCLUDES) $(GTK_CFLAGS) $(PNG_CFLAGS) $(ICU_CFLAGS) $(INCDIRS) \
 	$(DEBUG_LEVEL) $(OPT_LEVEL) $(WARNINGS) $(CPPFLAGS) -DHAVE_CONFIG_H
 
 u7shp_LDADD = \
@@ -81,9 +81,9 @@ exult_studio_LDADD = \
 	../server/libserver.la		\
 	../usecode/libusecode.la		\
 	../shapes/shapeinf/libshapeinf.la	\
-	-lpng $(FREETYPE2_LIBS) $(SYSLIBS) $(x_libraries) $(GTK_LIBS) $(ICU_LIBS) $(ZLIB_LIBS)
+	$(PNG_LIBS) $(FREETYPE2_LIBS) $(SYSLIBS) $(x_libraries) $(GTK_LIBS) $(ICU_LIBS) $(ZLIB_LIBS)
 
-exult_studio_CFLAGS = $(GTK_CFLAGS) $(ICU_CFLAGS)
+exult_studio_CFLAGS = $(GTK_CFLAGS) $(PNG_CFLAGS) $(ICU_CFLAGS)
 exult_studio_LDFLAGS = -export-dynamic		# For Gtk+ 2.x
 
 mapeditdir = $(datadir)/exult

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(top_srcdir)/headers -I$(top_srcdir)/files -I$(top_srcdir)/usecode \
 	-I$(top_srcdir) -I$(top_srcdir)/shapes -I$(top_srcdir)/imagewin \
 	-I$(top_srcdir)/conf $(DEBUG_LEVEL) $(OPT_LEVEL) $(WARNINGS) $(CPPFLAGS) $(SDL_CFLAGS) \
-	$(GDK_PIXBUF_CFLAGS)
+	$(GDK_PIXBUF_CFLAGS) $(PNG_CFLAGS)
 
 if CROSS_COMPILING
 if BUILD_TOOLS
@@ -53,7 +53,7 @@ ipack_LDADD = \
 	../files/libu7file.la \
 	../shapes/libshapes.la \
 	../imagewin/libimagewin.la \
-	-lpng -lz $(SYSLIBS)
+	$(PNG_LIBS) $(ZLIB_LIBS) $(SYSLIBS)
 
 gnome_shp_thumbnailer_SOURCES = \
 	gnome_shp_thumbnailer.cc
@@ -62,7 +62,7 @@ gnome_shp_thumbnailer_LDADD = \
 	../shapes/libshapes.la \
 	../imagewin/libimagewin.la \
 	../files/libu7file.la \
-	-lpng -lz $(SYSLIBS) $(GDK_PIXBUF_LIBS)
+	$(PNG_LIBS) $(ZLIB_LIBS) $(SYSLIBS) $(GDK_PIXBUF_LIBS)
 
 if BUILD_GTHUMB
 ## Does not work:


### PR DESCRIPTION
To finish the port to FreeBSD and remove the spurious clauses for `/usr/local/include` and `/usr/local/lib` :

- in `configure.ac`
    - Remove `/usr/local/include`
    - Replace `AC_CHECK_HEADERS` by `PKG_CHECK_MODULES` to locate the libpng
    - Enforce the dependencies of libpng : Studio and Gnome Thumbnailer
- in `audio/OggAudioSample.h`
    - Silence warnings of `vorbisfile.h` when out of `/usr/include`
- in `audio/midi_drivers/ALSAMidiDriver.h`
    - Silence warnings of `alsa/pcm.h` when out of `/usr/include`
- in `Makefile.am` + `mapedit/Makefile.am` + `tools/Makefile.am`
    - Add `$(PNG_CFLAGS)` to the include list
    - Replace explicit `-lz` and `-lpng` by `$(ZLIB_LIBS)` and `$(PNG_LIBS)`
- in `.github/workflows/ci-freebsd.yml`
    - Remove the `/usr/local/include` and `/usr/local/lib`