### PR TITLE
Cleanup for libpng and silence some warnings in NetBSD

### DIFF
--- a/.github/workflows/ci-freebsd.yml
+++ b/.github/workflows/ci-freebsd.yml
@@ -123,14 +123,8 @@ jobs:
           pkg install -y babl libX11 libXext
         run: |
           autoreconf -v -i
-          ./configure \
-           --enable-exult-studio --enable-exult-studio-support \
-           --enable-alsa --enable-fluidsynth --enable-mt32emu --enable-midi-sfx \
-           --enable-gimp-plugin --enable-gnome-shp-thumbnailer \
-           --enable-mods --enable-data --enable-zip-support \
-           --enable-compiler --with-usecode-debugger=yes --enable-usecode-container \
-           --enable-nonreadied-objects \
-           --disable-static --enable-shared \
-           --enable-pedantic-errors --with-debug=extreme \
-           CXX=clang++
+          ./configure --with-debug=extreme --enable-exult-studio --enable-exult-studio-support --enable-compiler --enable-gimp-plugin \
+            --enable-zip-support --enable-shared --enable-midi-sfx --enable-gnome-shp-thumbnailer --enable-data --enable-mods \
+            --with-usecode-debugger=yes --enable-usecode-container --enable-nonreadied-objects --disable-oggtest --disable-vorbistest \
+            CXX=clang++ CC=clang
           make -j 2

--- a/audio/OggAudioSample.h
+++ b/audio/OggAudioSample.h
@@ -26,7 +26,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
 #	pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-#	if defined(__llvm__) || defined(__clang__)
+#	if !defined(__llvm__) && !defined(__clang__)
+#		pragma GCC diagnostic ignored "-Wunused-variable"
+#	else
 #		if __clang_major__ >= 16
 #			pragma GCC diagnostic ignored "-Wcast-function-type-strict"
 #		endif

--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ case "$host_os" in
 		# NetBSD, placeholder.
 		WINDOWING_SYSTEM="-DXWIN"
 		AC_MSG_RESULT([X11 (NetBSD)])
-		CXXFLAGS="$CXXFLAGS -I/usr/X11R6/include -pthread"
+		CXXFLAGS="$CXXFLAGS -pthread"
 		;;
 	solaris*)
 		# Solaris, placeholder.

--- a/exult.cc
+++ b/exult.cc
@@ -87,9 +87,16 @@ static const Uint32 EXSDL_TOUCH_MOUSEID = SDL_TOUCH_MOUSEID;
 #	pragma GCC diagnostic pop
 #endif    // __GNUC__
 
+#ifdef __GNUC__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wvariadic-macros"
+#endif    // __GNUC__
 #define Font _XFont_
 #include <SDL_syswm.h>
 #undef Font
+#ifdef __GNUC__
+#	pragma GCC diagnostic pop
+#endif    // __GNUC__
 
 #ifdef USE_EXULTSTUDIO /* Only needed for communication with exult studio */
 #	if HAVE_SYS_TIME_H

--- a/imagewin/Makefile.am
+++ b/imagewin/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I$(top_srcdir)/headers -I$(top_srcdir) -I$(top_srcdir)/files $(SDL_CFLAGS) $(INCDIRS) $(WINDOWING_SYSTEM) \
+AM_CPPFLAGS = -I$(top_srcdir)/headers -I$(top_srcdir) -I$(top_srcdir)/files $(SDL_CFLAGS) $(PNG_CFLAGS) $(INCDIRS) $(WINDOWING_SYSTEM) \
 		-I$(top_srcdir)/conf \
 		$(DEBUG_LEVEL) $(OPT_LEVEL) $(WARNINGS) $(CPPFLAGS)
 

--- a/shapes/Makefile.am
+++ b/shapes/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(top_srcdir)/headers -I$(top_srcdir) -I$(top_srcdir)/files \
 	-I$(top_srcdir)/imagewin -I$(top_srcdir)/audio -I$(top_srcdir)/shapes/shapeinf \
 	-I$(top_srcdir)/data -I$(top_srcdir)/usecode -I$(top_srcdir)/objs \
-	$(SDL_CFLAGS) $(FREETYPE2_INCLUDES) \
+	$(SDL_CFLAGS) $(PNG_CFLAGS) $(FREETYPE2_INCLUDES) \
 	$(INCDIRS) $(WINDOWING_SYSTEM) $(DEBUG_LEVEL) $(OPT_LEVEL) $(WARNINGS) $(CPPFLAGS)
 
 if BUILD_SHAPES


### PR DESCRIPTION
Some more fixes

- `.github/workflows/ci-freebsd.yml` : Align `./configure` with the other `./configure` in the workflows that use it,
- `audio/OggAudioSample.h` : Silence `vorbisfile.h` with GCC when Vorbis is not in `/usr/include`
- `exult.cc` : Silence `SDL_syswm.h` when SDL is not in `/usr/include`
- `imagewin/Makefile.am` + `shapes/Makefile.am` : Missing `$(PNG_CFLAGS)` when libPNG is not in `/usr/include`
- `configure.ac` : Remove `/usr/X11R6/include` from NetBSD build, NetBSD is at `X11R7` anyway.