### PR TITLE
Build Exult on Solaris

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ case "$host_os" in
 		WINDOWING_SYSTEM="-DXWIN"
 		AC_MSG_RESULT([X11 (Solaris)])
 		CXXFLAGS="$CXXFLAGS -pthread"
-		SYSLIBS="-lsocket -lX11"
+		SYSLIBS="-lsocket"
 		;;
 	darwin*)
 		# MacOS as Darwin, supported.

--- a/files/utils.h
+++ b/files/utils.h
@@ -54,36 +54,36 @@ inline uint8 Read1(std::istream* in) {
 	return static_cast<uint8>(in->get());
 }
 
-inline uint8 Read1(const uint8*& in) {
-	return *in++;
-}
-
-inline uint8 Read1(uint8*& in) {
-	return *in++;
-}
-
-inline uint8 Read1(const sint8*& in) {
+inline uint8 Read1(const unsigned char*& in) {
 	return static_cast<uint8>(*in++);
 }
 
-inline uint8 Read1(sint8*& in) {
+inline uint8 Read1(unsigned char*& in) {
 	return static_cast<uint8>(*in++);
 }
 
-inline sint8 Read1s(const uint8*& in) {
+inline uint8 Read1(const signed char*& in) {
+	return static_cast<uint8>(*in++);
+}
+
+inline uint8 Read1(signed char*& in) {
+	return static_cast<uint8>(*in++);
+}
+
+inline sint8 Read1s(const unsigned char*& in) {
 	return static_cast<sint8>(*in++);
 }
 
-inline sint8 Read1s(uint8*& in) {
+inline sint8 Read1s(unsigned char*& in) {
 	return static_cast<sint8>(*in++);
 }
 
-inline sint8 Read1s(const sint8*& in) {
-	return *in++;
+inline sint8 Read1s(const signed char*& in) {
+	return static_cast<sint8>(*in++);
 }
 
-inline sint8 Read1s(sint8*& in) {
-	return *in++;
+inline sint8 Read1s(signed char*& in) {
+	return static_cast<sint8>(*in++);
 }
 
 inline uint8 Read1(const char*& in) {
@@ -289,16 +289,16 @@ inline void Write1(std::ostream* out, uint8 val) {
 	out->put(static_cast<char>(val));
 }
 
-inline void Write1(uint8*& out, uint8 val) {
-	*out++ = val;
+inline void Write1(unsigned char*& out, uint8 val) {
+	*out++ = static_cast<unsigned char>(val);
 }
 
-inline void Write1(sint8*& out, uint8 val) {
-	*out++ = static_cast<sint8>(val);
+inline void Write1(signed char*& out, uint8 val) {
+	*out++ = static_cast<signed char>(val);
 }
 
 inline void Write1(char*& out, uint8 val) {
-	*out++ = static_cast<sint8>(val);
+	*out++ = static_cast<char>(val);
 }
 
 /*

--- a/tools/wuc.cc
+++ b/tools/wuc.cc
@@ -26,7 +26,7 @@ constexpr static const std::array compiler_table{
 char     token[TOKEN_LENGTH], *token2, curlabel[256], indata;
 int      pass, offset;
 unsigned byteval, word, funcnum, datasize, codesize;
-int      extended;
+int      is_extended;
 
 char     labels[MAX_LABELS][10];
 int      offsets[MAX_LABELS];
@@ -218,7 +218,7 @@ int main(int argc, char* argv[]) {
 				indata = 0;
 				offset = 0;
 			} else if (!strcmp(token, ".data")) {
-				if (extended == 0) {
+				if (is_extended == 0) {
 					emit_word(funcnum);
 					emit_word(0);
 					emit_word(0);
@@ -239,9 +239,9 @@ int main(int argc, char* argv[]) {
 				sscanf(token, "%x", &funcnum);
 				printf("Function %04X\n", funcnum);
 				// codesize=2;
-				extended = 0;
+				is_extended = 0;
 			} else if (!strcmp(token, ".ext32")) {
-				extended = 1;
+				is_extended = 1;
 			} else if (!strcmp(token, ".msize") || !strcmp(token, ".dsize")) {
 				// Ignore either of these.
 			} else if (token[0] == '.') {
@@ -527,7 +527,7 @@ int main(int argc, char* argv[]) {
 			}
 		}
 
-		if (extended == 0) {
+		if (is_extended == 0) {
 			fseek(fo, 2, SEEK_SET);
 			indata = 0;
 			i      = codesize;


### PR DESCRIPTION
To Build Exult on Solaris derived OmniOS, because `sint8` is `char`, not `signed char` :

- `configure.ac` : Remove X11 from the SYSLIBS
- `files/utils.h` : Rework the `Read1(s)` and `Write1` functions using ((un)signed) char
- `tools/wuc.cc` : Replace the variable named `extended` by `is_extended`, reserved word