### PR TITLE
Fix Gorlab Swamp

### DIFF
--- a/npcnear.h
+++ b/npcnear.h
@@ -43,7 +43,7 @@ public:
 	}
 
 	// Add npc to queue.
-	void add(unsigned long curtime, Npc_actor* npc, int additional_secs = 0);
+	void add(unsigned long curtime, Npc_actor* npc, int additional_ticks = 0);
 	void remove(Npc_actor* npc);    // Remove.
 	// Run usecode function.
 	void handle_event(unsigned long curtime, uintptr udata) override;

--- a/npctime.cc
+++ b/npctime.cc
@@ -408,7 +408,8 @@ void Npc_sleep_timer::handle_event(unsigned long curtime, uintptr udata) {
 		&& (curtime >= end_time || !npc->get_flag(Obj_flags::asleep))) {
 		// Avoid waking sleeping people.
 		if (npc->get_schedule_type() == Schedule::sleep) {
-			npc->clear_sleep();
+			// This breaks Gorlab Swamp in SI/SS.
+			// npc->clear_sleep();
 		} else if (!npc->is_dead()) {
 			// Don't wake the dead.
 			npc->clear_flag(Obj_flags::asleep);

--- a/schedule.cc
+++ b/schedule.cc
@@ -1565,7 +1565,7 @@ void Talk_schedule::now_what() {
 
 Arrest_avatar_schedule::Arrest_avatar_schedule(Actor* n)
 		: Talk_schedule(
-				n, first_arrest, last_arrest, Usecode_machine::double_click) {
+				  n, first_arrest, last_arrest, Usecode_machine::double_click) {
 	npc->set_usecode(ArrestUsecode);
 }
 
@@ -2363,8 +2363,8 @@ void Sleep_schedule::ending(int new_type    // New schedule.
 	bool                     makebed = false;
 	int                      dir     = 0;
 	const Game_object_shared bed_obj = bed.lock();
-	if (bed_obj &&    // Still in bed?
-		(npc->get_framenum() & 0xf) == Actor::sleep_frame
+	// Still in bed?
+	if (bed_obj && (npc->get_framenum() & 0xf) == Actor::sleep_frame
 		&& npc->distance(bed_obj.get()) < 8) {
 		// Locate free spot.
 		if (floorloc.tx == -1) {
@@ -2386,9 +2386,9 @@ void Sleep_schedule::ending(int new_type    // New schedule.
 		floorloc = pos;
 		// Make bed.
 		const int frnum = bed_obj->get_framenum();
-		if (new_type != static_cast<int>(combat)
-			&&    // Not if going into combat
-			frnum >= spread0 && frnum <= spread1 && !(frnum % 2)
+		// Not if going into combat, or was awakened
+		if (!sleep_interrupted && new_type != static_cast<int>(combat)
+			&& frnum >= spread0 && frnum <= spread1 && !(frnum % 2)
 			&& !is_bed_occupied(
 					bed_obj.get(),
 					npc)) {    // And not if there is another occupant.
@@ -4078,7 +4078,7 @@ void Sew_schedule::now_what() {
 	case get_cloth: {
 		const Game_object_shared loom_obj = loom.lock();
 		const Tile_coord         t        = loom_obj ? Map_chunk::find_spot(
-                                     loom_obj->get_tile(), 1, 851, 0)
+                                                loom_obj->get_tile(), 1, 851, 0)
 													 : Tile_coord(-1, -1, -1);
 		if (t.tx != -1) {    // Space to create it?
 			const Game_object_shared newobj
@@ -5221,7 +5221,7 @@ void Eat_schedule::now_what() {
 				gwin->add_dirty(food);
 				food->remove_this();
 			}
-		}         // loops back to itself since npc can be pushed
+		}    // loops back to itself since npc can be pushed
 		break;    // out of their chair and not eat right away
 	}
 	case find_plate: {


### PR DESCRIPTION
- Don't make bed when being awaken from sleep
- This involves:
    1. Making sleep timer not clear sleep flag: Gorlab Swamp usecode checks for it to determine who is awake.
    2. Fixing Npc_proximity_handler::handle_event that prevents wake-up with sleep flag set due to change above.
    3. Disable party members from being woken from sleep schedule by Avatar.
    4. Make awake checks depend on frame-rate and slightly tweaking the probabilities to account for the above.

Fixes #297