### PR TITLE
Fix re-joining of invisible party members after Moonshade banquet

### DIFF
--- a/content/sifixes/Makefile.am
+++ b/content/sifixes/Makefile.am
@@ -12,6 +12,7 @@ USECODE_OBJECTS = \
 	src/cutscenes/fawn_storm.uc	\
 	src/cutscenes/fawn_trial.uc	\
 	src/cutscenes/monitor_banquet.uc	\
+	src/cutscenes/moonshade_banquet.uc	\
 	src/cutscenes/wall_of_lights.uc	\
 	src/header/constants.uc	\
 	src/header/functions.uc	\

--- a/content/sifixes/Makefile.mingw
+++ b/content/sifixes/Makefile.mingw
@@ -22,6 +22,7 @@ USECODE_OBJECTS = \
 	src/cutscenes/fawn_storm.uc	\
 	src/cutscenes/fawn_trial.uc	\
 	src/cutscenes/monitor_banquet.uc	\
+	src/cutscenes/moonshade_banquet.uc	\
 	src/cutscenes/wall_of_lights.uc	\
 	src/header/constants.uc	\
 	src/header/functions.uc	\

--- a/content/sifixes/src/cutscenes/moonshade_banquet.uc
+++ b/content/sifixes/src/cutscenes/moonshade_banquet.uc
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Copyright (C) 2024  The Exult Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+void MoonshadeBanquet shape#(0x32E)() {
+	if (FILBERCIO->get_npc_id() == 13) {
+		try {
+			MoonshadeBanquet.original();
+		} catch() {
+			if (gflags[POTHOS_RETURNED]) {
+				var joinables = getJoinableNPCNumbers();
+				for (npc in joinables) {
+					if (npc->get_npc_id() == 11
+						&& !npc->get_item_flag(IN_PARTY)) {
+						npc->add_to_party();
+					}
+				}
+			}
+			abort;
+		}
+	}
+	MoonshadeBanquet.original();
+}

--- a/content/sifixes/src/header/constants.uc
+++ b/content/sifixes/src/header/constants.uc
@@ -40,6 +40,8 @@
  *	likes of UI_path_run_usecode.
  */
 
+const int LOOP_ONCE = -1;
+
 enum events {
 	PROXIMITY		= 0,	// Object is on-screen or nearby
 							// This is called repeatedly, with a random delay

--- a/content/sifixes/src/header/si/si_gflags.uc
+++ b/content/sifixes/src/header/si/si_gflags.uc
@@ -205,10 +205,9 @@ enum Sleeping_Bull_townplot {
 	ASKED_ANDRAL_ABOUT_INN = 0xC
 };
 
-/*
 enum Moonshade_townplot {
+	FILBERCIO_BANQUET_WILL_HAPPEN = 0xDA,
 };
-*/
 
 enum Gustacios_experiment_subplot {
 	HAVE_1ST_ENERGY_GLOBE = 0x11C,

--- a/content/sifixes/src/usecode.uc
+++ b/content/sifixes/src/usecode.uc
@@ -149,6 +149,8 @@
 #include "cutscenes/fawn_trial.uc"
 // Prevents deletion of the training pikeman egg
 #include "cutscenes/monitor_banquet.uc"
+// Fix invisible party members not joining back.
+#include "cutscenes/moonshade_banquet.uc"
 // Absolutely force companions to be there and force-kills them after
 #include "cutscenes/wall_of_lights.uc"
 // Fixes gang planck blocking check


### PR DESCRIPTION
Fixes #118 SI: mage banquet breaks rejoin of partymembers if they are invisible