### PR TITLE
Keep the := assignment in the mods Makefiles

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_CONFIG_SRCDIR([exult.cc])
 AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([-Wno-portability])
 AC_DEFINE_UNQUOTED(PACKAGE, "$PACKAGE", [Package Name])
 AC_DEFINE_UNQUOTED(VERSION, "$VERSION", [Package Version])
 
@@ -1202,22 +1202,22 @@ AM_CONDITIONAL(CROSS_COMPILING, test $cross_compiling = yes)
 
 AS_IF([ test $cross_compiling = yes ], [
 	if test x$enable_data = xyes; then
-		AC_PATH_PROG(EXPACK, expack, no)
+		AC_PATH_PROG(EXPACK_PROG, expack, no)
 		echo "While cross compiling you need to have a build system native"
 		echo "expack in your path to generate Exult's data files."
 		echo "After you natively compiled Exult you will find expack in the tools subfolder."
-		if test x$EXPACK = xno; then
+		if test x$EXPACK_PROG = xno; then
 			AC_MSG_ERROR([Could not find expack in your path, cannot generate data files.])
 		fi
 	fi
 
 	if test x$enable_tools = xyes; then
-		AC_PATH_PROG(HEAD2DATA, head2data, no)
+		AC_PATH_PROG(HEAD2DATA_PROG, head2data, no)
 		echo "While cross compiling you need to have a build system native"
 		echo "head2data in your path to build part of Exult's tools."
 		echo "After you natively compiled Exult you will find head2data"
 		echo "in the usecode/ucxt subfolder."
-		if test x$HEAD2DATA = xno; then
+		if test x$HEAD2DATA_PROG = xno; then
 			AC_MSG_ERROR([Could not find head2data in your path, cannot generate data files for tools.])
 		fi
 	fi
@@ -1411,10 +1411,10 @@ if test ${cross_compiling} = yes; then
 	echo
 	echo Cross Compiling for $host
 	if test x$enable_data = xyes; then
-		echo expack path................ : $EXPACK
+		echo expack path................ : $EXPACK_PROG
 	fi
 	if test x$enable_tools = xyes; then
-		echo head2data path............. : $HEAD2DATA
+		echo head2data path............. : $HEAD2DATA_PROG
 	fi
 fi
 echo

--- a/content/bg/Makefile.am
+++ b/content/bg/Makefile.am
@@ -2,11 +2,11 @@
 # Instead, run makefile_builder.sh from the parent directory.
 
 # Base of the exult source
-UCCDIR=$(top_srcdir)/usecode/compiler
-UCC=$(UCCDIR)/ucc
+UCCDIR:=$(top_srcdir)/usecode/compiler
+UCC:=$(UCCDIR)/ucc
 
-EXPACKDIR=$(top_srcdir)/tools
-EXPACK=$(EXPACKDIR)/expack
+EXPACKDIR:=$(top_srcdir)/tools
+EXPACK:=$(EXPACKDIR)/expack
 
 USECODE_OBJECTS :=	\
 	usecode.uc

--- a/content/bgkeyring/Makefile.am
+++ b/content/bgkeyring/Makefile.am
@@ -2,11 +2,11 @@
 # Instead, run makefile_builder.sh from the parent directory.
 
 # Base of the exult source
-UCCDIR=$(top_srcdir)/usecode/compiler
-UCC=$(UCCDIR)/ucc
+UCCDIR:=$(top_srcdir)/usecode/compiler
+UCC:=$(UCCDIR)/ucc
 
-EXPACKDIR=$(top_srcdir)/tools
-EXPACK=$(EXPACKDIR)/expack
+EXPACKDIR:=$(top_srcdir)/tools
+EXPACK:=$(EXPACKDIR)/expack
 
 USECODE_OBJECTS :=	\
 	src/headers/array_functions.uc	\

--- a/content/islefaq/Makefile.am
+++ b/content/islefaq/Makefile.am
@@ -2,11 +2,11 @@
 # Instead, run makefile_builder.sh from the parent directory.
 
 # Base of the exult source
-UCCDIR=$(top_srcdir)/usecode/compiler
-UCC=$(UCCDIR)/ucc
+UCCDIR:=$(top_srcdir)/usecode/compiler
+UCC:=$(UCCDIR)/ucc
 
-EXPACKDIR=$(top_srcdir)/tools
-EXPACK=$(EXPACKDIR)/expack
+EXPACKDIR:=$(top_srcdir)/tools
+EXPACK:=$(EXPACKDIR)/expack
 
 USECODE_OBJECTS :=	\
 	src/usecode.uc

--- a/content/makefile_builder.sh
+++ b/content/makefile_builder.sh
@@ -73,11 +73,11 @@ find . -mindepth 2 -iname "*.cfg" | while read -r cfgfile; do
 # Instead, run makefile_builder.sh from the parent directory.
 
 # Base of the exult source
-UCCDIR=\$(top_srcdir)/usecode/compiler
-UCC=\$(UCCDIR)/ucc
+UCCDIR:=\$(top_srcdir)/usecode/compiler
+UCC:=\$(UCCDIR)/ucc
 
-EXPACKDIR=\$(top_srcdir)/tools
-EXPACK=\$(EXPACKDIR)/expack
+EXPACKDIR:=\$(top_srcdir)/tools
+EXPACK:=\$(EXPACKDIR)/expack
 " >> "$modmakefile_am"
 
 	# Boilerplate for Makefile.mingw:

--- a/content/si/Makefile.am
+++ b/content/si/Makefile.am
@@ -2,11 +2,11 @@
 # Instead, run makefile_builder.sh from the parent directory.
 
 # Base of the exult source
-UCCDIR=$(top_srcdir)/usecode/compiler
-UCC=$(UCCDIR)/ucc
+UCCDIR:=$(top_srcdir)/usecode/compiler
+UCC:=$(UCCDIR)/ucc
 
-EXPACKDIR=$(top_srcdir)/tools
-EXPACK=$(EXPACKDIR)/expack
+EXPACKDIR:=$(top_srcdir)/tools
+EXPACK:=$(EXPACKDIR)/expack
 
 USECODE_OBJECTS :=	\
 	usecode.uc

--- a/content/sifixes/Makefile.am
+++ b/content/sifixes/Makefile.am
@@ -2,11 +2,11 @@
 # Instead, run makefile_builder.sh from the parent directory.
 
 # Base of the exult source
-UCCDIR=$(top_srcdir)/usecode/compiler
-UCC=$(UCCDIR)/ucc
+UCCDIR:=$(top_srcdir)/usecode/compiler
+UCC:=$(UCCDIR)/ucc
 
-EXPACKDIR=$(top_srcdir)/tools
-EXPACK=$(EXPACKDIR)/expack
+EXPACKDIR:=$(top_srcdir)/tools
+EXPACK:=$(EXPACKDIR)/expack
 
 USECODE_OBJECTS :=	\
 	src/cutscenes/fawn_storm.uc	\

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -220,7 +220,7 @@ EXTRA_DIST = flx.in $(EXULT_FLX_OBJECTS) $(EXULT_BG_FLX_OBJECTS) \
 	$(EXULT_BG_PAPERDOL_VGA_OBJECTS) $(EXULT_BG_MR_FACES_VGA_OBJECTS)
 
 if CROSS_COMPILING
-expack = $(EXPACK)
+expack = $(EXPACK_PROG)
 else
 expack = $(top_builddir)/tools/expack$(EXEEXT)
 endif

--- a/usecode/ucxt/data/Makefile.am
+++ b/usecode/ucxt/data/Makefile.am
@@ -2,7 +2,7 @@ ucxtdir = $(datadir)/exult
 
 if BUILD_TOOLS
 if CROSS_COMPILING
-head2data = $(HEAD2DATA)
+head2data = $(HEAD2DATA_PROG)
 else
 head2data = $(top_builddir)/usecode/ucxt/head2data
 endif


### PR DESCRIPTION
Relates to commit cc626937

The `EXPACK` variable in the mods Makefiles were not properly set because there was also an `EXPACK` variable in `configure.ac`.

Changes : 

- `configure.ac` , `data/Makefile.am`, `usecode/ucxt/data/Makefile.am`: Change variables `EXPACK` and `HEAD2DATA` to `EXPACK_PROG` and `HEAD2DATA_PROG`,
- `configure.ac` : Silence Automake warnings for the use of `:=` assignments with `-Wno-portability`,
- `content/bg + bgkeyring + islefaq + si + sifixes/Makefile.am`, `content/makefile_builder.sh` : Revert assignments to `EXPACK`, `EXPACKDIR`, `UCC` and `UCC(DIR)` to `:=`.