### PR TITLE
Client - Server protocol : limit strings to 4G

### DIFF
--- a/server/objserial.cc
+++ b/server/objserial.cc
@@ -36,10 +36,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *  Write out a string.
  */
 Serial_out& Serial_out::operator<<(std::string& s) {
-	const char*  str = s.c_str();
-	const size_t len = std::strlen(str);    // Get length.
-	*this << len;                           // First the length.
-	std::memcpy(buf, str, len);             // Then the bytes.
+	const char*    str = s.c_str();
+	const uint32_t len = std::strlen(str);    // Get length.
+	*this << len;                             // First the length.
+	std::memcpy(buf, str, len);               // Then the bytes.
 	buf += len;
 	return *this;
 }
@@ -48,7 +48,7 @@ Serial_out& Serial_out::operator<<(std::string& s) {
  *  Read in a string.
  */
 Serial_in& Serial_in::operator<<(std::string& s) {
-	size_t len;
+	uint32_t len;
 	(*this) << len;                                       // Get length.
 	s.assign(reinterpret_cast<const char*>(buf), len);    // Set string.
 	buf += len;

--- a/server/objserial.h
+++ b/server/objserial.h
@@ -30,7 +30,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include <string>
 
-
 class Serial_out {
 	unsigned char*& buf;
 


### PR DESCRIPTION
To fix issue  #458 :  
-  `server/objserial.cc` : Replace the `size_t` string length by an `uint32_t` in `Serial_in + out::operator<<(string)`.

No longer any need to alter the Keyring `combo.flx`.