### PR TITLE
Fix missing std::copy_n with GCC 14

### DIFF
--- a/audio/midi_drivers/ALSAMidiDriver.cpp
+++ b/audio/midi_drivers/ALSAMidiDriver.cpp
@@ -29,6 +29,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef USE_ALSA_MIDI
 #	include "ALSAMidiDriver.h"
 
+#	include <algorithm>
 #	include <array>
 #	include <string_view>
 

--- a/shapes/vgafile.cc
+++ b/shapes/vgafile.cc
@@ -32,6 +32,7 @@
 #include "ibuf8.h"
 #include "palette.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <map>


### PR DESCRIPTION
Switching from GCC 13 to GCC 14, Exult fails to compile with undefined `std::copy_n` which has been moved off to `algorithm`.

- Add `#include <algorithm>` to `audio/midi_drivers/ALSAMidiDriver.cpp` and `shapes/vgafile.cc`