### PR TITLE
Rework Issue SFX #498 Fix, Silence Compiler warnings

### DIFF
--- a/gamewin.cc
+++ b/gamewin.cc
@@ -184,7 +184,7 @@ void Background_noise::handle_event(unsigned long curtime, uintptr udata) {
 	const bool play_bg_tracks
 			= player && (player->get_ogg_enabled() || player->is_mt32());
 
-	if (player || play_bg_tracks) {
+	if (player && play_bg_tracks) {
 		delay = 1000;    // Quickly get back to this function check
 		const int curr_track = player->get_current_track();
 		if ((curr_track == -1 || laststate != currentstate)
@@ -242,7 +242,7 @@ void Background_noise::handle_event(unsigned long curtime, uintptr udata) {
 	Main_actor* ava = gwin->get_main_actor();
 	// Testing. When outside play birds during daytime or crickets at night
 	if (ava && !gwin->is_main_actor_inside() && currentstate != Dungeon) {
-        int                        sound = 0;    // SFX #.
+		int                        sound     = -1;    // SFX #.
 		static const unsigned char bgnight[] = {61, 61, 255};
 		static const unsigned char bgday[]   = {82, 85, 85};
 		if (repeats > 0) {    // Repeating?
@@ -256,14 +256,18 @@ void Background_noise::handle_event(unsigned long curtime, uintptr udata) {
 			}
 			last_sound = sound;
 		}
-		Audio::get_ptr()->play_sound_effect(
-				Audio::game_sfx(sound), AUDIO_MAX_VOLUME - 200);
-		repeats++;    // Count it.
-		if (rand() % (repeats + 1) == 0) {
-			// Repeat.
-			delay = 500 + rand() % 1000;
+		if (sound >= 0) {
+			Audio::get_ptr()->play_sound_effect(
+					Audio::game_sfx(sound), AUDIO_MAX_VOLUME - 64);
+			repeats++;    // Count it.
+			if (rand() % (repeats + 1) == 0) {
+				// Repeat.
+				delay = 500 + rand() % 1000;
+			} else {
+				delay   = 4000 + rand() % 3000;
+				repeats = 0;
+			}
 		} else {
-			delay   = 4000 + rand() % 3000;
 			repeats = 0;
 		}
 	}

--- a/objs/egg.cc
+++ b/objs/egg.cc
@@ -190,11 +190,12 @@ public:
 		}
 	}
 
-	virtual bool can_unhatch() {
+	bool can_unhatch() override {
 		return true;
 	}
 
 	bool unhatch_now(Game_object* obj, bool must) override {
+		ignore_unused_variable_warning(obj, must);
 		MyMidiPlayer* player = Audio::get_ptr()->get_midi();
 		// only do anything if the currently playing track is ours
 		if (player && player->get_current_track() == score) {
@@ -240,6 +241,7 @@ public:
 	}
 
 	 void handle_event(unsigned long curtime, uintptr udata) override {
+		ignore_unused_variable_warning(curtime, udata);
 		MyMidiPlayer* player = Audio::get_ptr()->get_midi();
 		// only do anything if the currently playing track is ours
 		if (player && player->get_current_track() == score) {
@@ -350,7 +352,8 @@ public:
 	}
 
 	bool unhatch_now(Game_object* obj, bool must) override {
-		//  Might want to do somnething here to stop repeating sounds like
+		ignore_unused_variable_warning(obj, must);
+		//  Might want to do something here to stop repeating sounds like
 		//  Jukebox_egg
 		return false;
 	}


### PR DESCRIPTION
To Silence the compilers :

- `objs/egg.cc` : Replace a `virtual` keyword by an `override`, add a few `ignore_unused_variable_warning` macros.
- `gamewin.cc` : Set default SFX value to -1.

To rework SFX #498 : 

- `gamewin.cc` : Fix if test, Do not emit SFX if left to -1 and do not prepare a repeat,  Increase SFX volume to MAX - 64

For discussion in issues #503 and #510