### PR TITLE
Switch Exult to clang-format version 18

### DIFF
--- a/audio/Midi.cc
+++ b/audio/Midi.cc
@@ -157,7 +157,8 @@ void MyMidiPlayer::start_music(int num, bool repeat, std::string flex) {
 		// No midi driver or bg track and we can't play it properly so don't
 		// fall through
 		if (!midi_driver
-			|| (!is_mt32() && Game_window::get_instance()->is_background_track(num)
+			|| (!is_mt32()
+				&& Game_window::get_instance()->is_background_track(num)
 				&& flex == MAINMUS)) {
 			return;
 		}

--- a/audio/midi_drivers/ALSAMidiDriver.cpp
+++ b/audio/midi_drivers/ALSAMidiDriver.cpp
@@ -160,8 +160,7 @@ int ALSAMidiDriver::open() {
 			pout << clt_id << ":" << prt_id << " : [ " << clt_name << " : "
 				 << prt_name
 				 << (prt_write_use > 0 ? " ], in use, " : " ], available, ")
-				 << prt_midi_channels << " channels"
-				 << ", RW capability"
+				 << prt_midi_channels << " channels" << ", RW capability"
 				 << ((prt_capability & SND_SEQ_PORT_CAP_READ) != 0u ? " R" : "")
 				 << ((prt_capability & SND_SEQ_PORT_CAP_WRITE) != 0u ? " W"
 																	 : "")
@@ -198,9 +197,8 @@ int ALSAMidiDriver::open() {
 			pout << std::endl;
 			return 0;
 		}
-		perr << "ALSAMidiDriver: "
-			 << "Can't subscribe to default MIDI port [" << seq_client << ":"
-			 << seq_port << "]";
+		perr << "ALSAMidiDriver: " << "Can't subscribe to default MIDI port ["
+			 << seq_client << ":" << seq_port << "]";
 		if (identify_port(seq_client, seq_port)) {
 			perr << " [ " << clt_name << " : " << prt_name << " ]";
 		}
@@ -231,9 +229,8 @@ int ALSAMidiDriver::open() {
 					>= 0) {
 					pout << "ALSAMidiDriver: "
 						 << "ALSA client initialised on MIDI port ["
-						 << seq_client << ":" << seq_port << "]"
-						 << " [ " << clt_name << " : " << prt_name << " ]"
-						 << std::endl;
+						 << seq_client << ":" << seq_port << "]" << " [ "
+						 << clt_name << " : " << prt_name << " ]" << std::endl;
 					return 0;
 				}
 			}

--- a/audio/midi_drivers/FMOplMidiDriver.cpp
+++ b/audio/midi_drivers/FMOplMidiDriver.cpp
@@ -46,9 +46,9 @@ const MidiDriver::MidiDriverDesc FMOplMidiDriver::desc
 const FMOplMidiDriver::xinstrument
 		FMOplMidiDriver::midi_fm_instruments_table[128]
 		= {
-  /* This set of GM instrument patches was provided by Jorrit
-  * Rouwe...
-  */
+				/* This set of GM instrument patches was provided by Jorrit
+				 * Rouwe...
+				 */
 				{0x21, 0x21, 0x8f, 0x0c, 0xf2, 0xf2, 0x45, 0x76, 0x00, 0x00,
 				 0x08, 0x80}, /* Acoustic Grand */
 				{0x31, 0x21, 0x4b, 0x09, 0xf2, 0xf2, 0x54, 0x56, 0x00, 0x00,

--- a/audio/midi_drivers/LowLevelMidiDriver.cpp
+++ b/audio/midi_drivers/LowLevelMidiDriver.cpp
@@ -1527,7 +1527,7 @@ void LowLevelMidiDriver::extractTimbreLibrary(XMidiEventList* eventlist) {
 
 				// Allocate memory
 				if (!mt32_timbre_banks[2]) {
-					mt32_timbre_banks[2] = new MT32Timbre* [128] {};
+					mt32_timbre_banks[2] = new MT32Timbre*[128]{};
 				}
 				if (!mt32_timbre_banks[2][start]) {
 					mt32_timbre_banks[2][start] = new MT32Timbre;
@@ -1926,14 +1926,14 @@ void LowLevelMidiDriver::loadXMidiTimbreLibrary(IDataSource* ds) {
 
 		// Allocate memory
 		if (!mt32_timbre_banks[bank]) {
-			mt32_timbre_banks[bank] = new MT32Timbre* [128] {};
+			mt32_timbre_banks[bank] = new MT32Timbre*[128]{};
 		}
 		if (!mt32_timbre_banks[bank][patch]) {
 			mt32_timbre_banks[bank][patch] = new MT32Timbre;
 		}
 
 		if (!mt32_patch_banks[bank]) {
-			mt32_patch_banks[bank] = new MT32Patch* [128] {};
+			mt32_patch_banks[bank] = new MT32Patch*[128]{};
 		}
 		if (!mt32_patch_banks[bank][patch]) {
 			mt32_patch_banks[bank][patch] = new MT32Patch;

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -251,7 +251,9 @@ void Background_noise::handle_event(unsigned long curtime, uintptr udata) {
 			if (nighttime) {
 				sound = bgnight[rand() % sizeof(bgnight)];
 				// only play daytime sfx when no music track is playing
-			} else if (!play_bg_tracks && (!player || player->get_current_track() == -1)) {
+			} else if (
+					!play_bg_tracks
+					&& (!player || player->get_current_track() == -1)) {
 				sound = bgday[rand() % sizeof(bgday)];
 			}
 			last_sound = sound;
@@ -1464,7 +1466,9 @@ void Game_window::read_gwin() {
 	if (!is_background_track(track_num)
 		|| (midi && (midi->get_ogg_enabled() || midi->is_mt32()))) {
 		Audio::get_ptr()->start_music(track_num, repeat & 0x1);
-		if (midi) midi->set_egg_count(static_cast<uint16>(repeat >> 16));
+		if (midi) {
+			midi->set_egg_count(static_cast<uint16>(repeat >> 16));
+		}
 	}
 	armageddon = gin.read1() == 1;
 	if (!gin.good()) {

--- a/gamewin.h
+++ b/gamewin.h
@@ -444,9 +444,10 @@ public:
 		return clock;
 	}
 
-	bool      is_background_track(int num) const;    // ripped out of Background_noise
-	Game_map* get_map(int num);              // Read in additional map.
-	void      set_map(int num);              // Make map #num the current map.
+	bool is_background_track(
+			int num) const;        // ripped out of Background_noise
+	Game_map* get_map(int num);    // Read in additional map.
+	void      set_map(int num);    // Make map #num the current map.
 	/*
 	 *  ExultStudio support:
 	 */

--- a/msvcstuff/vs2019/msvc_include.h
+++ b/msvcstuff/vs2019/msvc_include.h
@@ -33,7 +33,7 @@
 #define USE_FMOPL_MIDI   1
 #define USE_WINDOWS_MIDI 1
 // #define USE_MT32EMU_MIDI 1
-#define HAVE_STDIO_H 1
+#define HAVE_STDIO_H     1
 #define HAVE_ZIP_SUPPORT 1
 
 #if _MSC_VER <= 1938

--- a/objs/chunks.cc
+++ b/objs/chunks.cc
@@ -736,9 +736,9 @@ void Map_chunk::set_terrain(Chunk_terrain* ter) {
 				const Game_object_shared obj
 						= info.is_animated()
 								  ? std::make_shared<Animated_object>(
-										  shapenum, framenum, tilex, tiley)
+											shapenum, framenum, tilex, tiley)
 								  : std::make_shared<Terrain_game_object>(
-										  shapenum, framenum, tilex, tiley);
+											shapenum, framenum, tilex, tiley);
 				add(obj.get());
 			}
 		}
@@ -1394,9 +1394,9 @@ void Map_chunk::setup_dungeon_levels() {
 			const TileRect area
 					= (shinf.has_translucency() && each->get_framenum() == 0)
 							  ? TileRect(
-									  cx * c_tiles_per_chunk,
-									  cy * c_tiles_per_chunk, c_tiles_per_chunk,
-									  c_tiles_per_chunk)
+										cx * c_tiles_per_chunk,
+										cy * c_tiles_per_chunk,
+										c_tiles_per_chunk, c_tiles_per_chunk)
 							  : each->get_footprint();
 
 			// Go through interesected chunks.

--- a/objs/chunks.h
+++ b/objs/chunks.h
@@ -134,7 +134,7 @@ private:
 	void unhatch_eggs(
 			Game_object* obj, Map_chunk* chunk, int tx, int ty, int tz,
 			int from_tx, int from_ty, bool now) {
-				// unhatch needs eggbits at from location not to location
+		// unhatch needs eggbits at from location not to location
 		const unsigned short eggbits
 				= eggs[(from_ty % c_tiles_per_chunk) * c_tiles_per_chunk
 					   + (from_tx % c_tiles_per_chunk)];

--- a/objs/egg.cc
+++ b/objs/egg.cc
@@ -240,7 +240,7 @@ public:
 		return true;
 	}
 
-	 void handle_event(unsigned long curtime, uintptr udata) override {
+	void handle_event(unsigned long curtime, uintptr udata) override {
 		ignore_unused_variable_warning(curtime, udata);
 		MyMidiPlayer* player = Audio::get_ptr()->get_midi();
 		// only do anything if the currently playing track is ours

--- a/shapeid.cc
+++ b/shapeid.cc
@@ -262,12 +262,13 @@ void Shape_manager::load() {
 	{
 		const auto& blendsflexspec
 				= GAME_BG ? File_spec(
-						  BUNDLE_CHECK(BUNDLE_EXULT_BG_FLX, EXULT_BG_FLX),
-						  EXULT_BG_FLX_BLENDS_DAT)
+									BUNDLE_CHECK(
+											BUNDLE_EXULT_BG_FLX, EXULT_BG_FLX),
+									EXULT_BG_FLX_BLENDS_DAT)
 						  : File_spec(
-								  BUNDLE_CHECK(
-										  BUNDLE_EXULT_SI_FLX, EXULT_SI_FLX),
-								  EXULT_SI_FLX_BLENDS_DAT);
+									BUNDLE_CHECK(
+											BUNDLE_EXULT_SI_FLX, EXULT_SI_FLX),
+									EXULT_SI_FLX_BLENDS_DAT);
 		const U7multiobject in(BLENDS, blendsflexspec, PATCH_BLENDS, 0);
 		size_t              len;
 		ptr = in.retrieve(len);


### PR DESCRIPTION
This completes the replacement of `clang-format` version 17, used up to mid-April 2024, by `clang-format` version 18, by agreement in Issue #514.

**For reviewers :** The one change that I feel funny is `new MT32Timbre* [128] {};` packed into `new MT32Timbre*[128]{};`.

I can obtain  `new MT32Timbre*[128] {};` instead with `SpaceBeforeCpp11BracedList: true` instead of `false` in `.clang-format`.

- But then all brace initializers get a new space like `const std::array frames{` becoming `const std::array frames {` or `actions = new Actor_action*[5]{` becoming `actions = new Actor_action*[5] {` in `actions.cc`. In total this makes more that 500 changes in more than 60 files.
- Also in `actions.cc` there are initializers with parentheses and initializers with braces. With this spacing the lookout becomes inconsistent, I get `: frames {f}, index(0), speed(spd), obj(weak_from_obj(o)) {` where the braced initializer gets a space but the parenthesized initializers do not.

