### PR TITLE
Bump smooth and mockup to SDL 2

### DIFF
--- a/mapedit/tools/mockup/Makefile
+++ b/mapedit/tools/mockup/Makefile
@@ -3,4 +3,10 @@ CC=gcc
 all: mockup
 
 mockup: main.c main.h defs.h
-	${CC} main.c -o mockup `sdl-config --libs --cflags` -lSDL_image -Wall
+	${CC} main.c -o mockup `pkg-config --libs --cflags sdl2 SDL2_image` -Wall -Wextra
+
+tests: mockup map.png mappings.txt
+	./mockup map.png mappings.txt
+
+clean:
+	rm -f u7map mockup

--- a/mapedit/tools/smooth/INSTALL
+++ b/mapedit/tools/smooth/INSTALL
@@ -1,10 +1,11 @@
 Under linux:
-normally, a simple "make && make install" should do. It will prompt
+Normally, a simple "make && make install" should do. It will prompt
 you for the root password for make install so be prepared to pass it
 (files are copied to /usr/lib/).
+To use clang instead of the default gcc, use "make CC=clang".
 
 Under windows:
-use the binary package available at si-french.sf.net/tools/
+Use the binary package available at si-french.sf.net/tools/
 If you insist on compiling on Windows, contact Ryan (see AUTHORS).
 
 Under anything else:

--- a/mapedit/tools/smooth/Makefile
+++ b/mapedit/tools/smooth/Makefile
@@ -1,0 +1,21 @@
+CC=gcc
+
+all: smooth libsmooth_randomize.so libsmooth_stream.so libsmooth_smooth.so
+
+smooth: config.c config.h globals.h image.c image.h linked.c linked.h param.c param.h plugin.c plugin.h smooth.c smooth.h
+	${CC} -o smooth smooth.c config.c image.c linked.c param.c plugin.c      `pkg-config --libs --cflags sdl2 SDL2_image` -lm -Wall -Wextra
+
+libsmooth_randomize.so: plugins/plugin_randomize.c
+	${CC} -o libsmooth_randomize.so plugins/plugin_randomize.c -fPIC -shared `pkg-config --libs --cflags sdl2 SDL2_image` -lm -Wall -Wextra
+
+libsmooth_stream.so: plugins/plugin_stream.c
+	${CC} -o libsmooth_stream.so plugins/plugin_stream.c -fPIC -shared       `pkg-config --libs --cflags sdl2 SDL2_image` -lm -Wall -Wextra
+
+libsmooth_smooth.so: plugins/plugin_smooth.c
+	${CC} -o libsmooth_smooth.so plugins/plugin_smooth.c -fPIC -shared       `pkg-config --libs --cflags sdl2 SDL2_image` -lm -Wall -Wextra
+
+tests: smooth libsmooth_randomize.so libsmooth_stream.so libsmooth_smooth.so rough.bmp
+	LD_LIBRARY_PATH=. ./smooth -d 4
+
+clean:
+	rm -f smooth libsmooth_randomize.so libsmooth_stream.so libsmooth_smooth.so

--- a/mapedit/tools/smooth/config.c
+++ b/mapedit/tools/smooth/config.c
@@ -79,7 +79,7 @@ int read_config(FILE* f) {
 					printf("\nsection %s", line);
 					fflush(stdout);
 				}
-				const size_t namelen = (13 + line_length) * sizeof(char);
+				const size_t namelen = (16 + line_length) * sizeof(char);
 				pluginname           = (char*)malloc(namelen);
 				// what's between the '[' and the ']'
 				memmove(line, line + 1, line_length - 3);
@@ -128,28 +128,25 @@ int read_config(FILE* f) {
 				} else {
 					// extract the first colour from the line, get index from
 					// palette and populate action_table at right index with hdl
-					colour_hex col;
-					if (sscanf(line, "%6s", col) != 1
-						|| strlen(col) != 6) {    // just read 6 characters to
-												  // prevent buffer overflow
-						// problem
+					unsigned r;
+					unsigned g;
+					unsigned b;
+					if (sscanf(line, "%02x%02x%02x", &r, &g, &b) != 3) {
+						// prevent buffer overflow problem
 						fprintf(stderr,
 								"ERROR: couldn't read the slave value of %s\n",
 								line);
 						fflush(stderr);
 						return -1;
 					} else {
-						unsigned r;
-						unsigned g;
-						unsigned b;
-						sscanf(col, "%02x%02x%02x", &r, &g, &b);
-						// get index of col from palette
+						// get index of (r,g,b) from palette
 						int idx = SDL_MapRGB(
 								g_statics.image_in->format, r, g, b);
 						// some reporting
 						if (g_statics.debug > 3) {
-							printf("slave is %s (idx=%d: r=%u g=%u b=%u)\n",
-								   col, idx, r, g, b);
+							printf("slave is %02x%02x%02x "
+								   "(idx=%d: r=%u g=%u b=%u)\n",
+								   r, g, b, idx, r, g, b);
 							fflush(stdout);
 						}
 						// teach the plugin how to convert what

--- a/mapedit/tools/smooth/globals.h
+++ b/mapedit/tools/smooth/globals.h
@@ -51,9 +51,9 @@ typedef struct g_stat_struct {
 
 EXTERN glob_statics g_statics;
 
-typedef char colour_hex[8];
+typedef Uint32 colour_hex;
 
-typedef char* (*pfnPluginApply)(
+typedef colour_hex (*pfnPluginApply)(
 		colour_hex ret_col, glob_variables* g_variables);
 
 typedef struct pacman {

--- a/mapedit/tools/smooth/plugin.c
+++ b/mapedit/tools/smooth/plugin.c
@@ -95,7 +95,7 @@ int add_plugin_apply(int col_index, libhandle_t a_hdl) {
 	// insert new node at cursor->next, with handle as the pointer to
 	// plugin_apply
 
-	//  char *(*apply)(colour_hex,glob_variables *);
+	//  colour_hex(*apply)(colour_hex,glob_variables *);
 
 	// first of all, load a_hdl's apply function
 	pfnPluginApply apply;

--- a/mapedit/tools/smooth/smooth.conf
+++ b/mapedit/tools/smooth/smooth.conf
@@ -13,10 +13,10 @@
 # format: slave (master)+
 
 [randomize]
-; we are allowed to replace slave by itself
+; we are allowed to replace slave by itself, for forest green to same green, red, dark blue, lighter green
 3C9134 3C9134 931029 1B3D5F 349C1D
 
-; but we are not obligated to do so
+; but we are not obligated to do so, for water blue to yellow, dark red, dark blue, green, brown
 ;102ABC F3FF1F 932029 1C3D5F 319C3D 654F2C
 
 
@@ -35,6 +35,9 @@
 ;333333 * 601111 611112 611113 611114 611115 621111 621112 621113 621114 621115 621116 631111 631112 631113 631114 641111
 
 ;494949 * 010101 111111 212121 313131 414141 515151 616161 717171 818181 919191 A1A1A1 B1B1B1 C1C1C1 D1D1D1 E1E1E1 F1F1F1
-
+; for large road against city to dark .. light greys
 494949 878787 010101 111111 212121 313131 414141 515151 616161 717171 818181 919191 A1A1A1 B1B1B1 C1C1C1 D1D1D1 E1E1E1 F1F1F1
+
+; for periph road against background to dark .. light greens
+664747 725E0C 01FF01 11FF11 21FF21 31FF31 41FF41 51FF51 61FF61 71FF71 81FF81 91FF91 A1FFA1 B1FFB1 C1FFC1 D1FFD1 E1FFE1 F1FFF1
 # End of Config file - DO NOT REMOVE


### PR DESCRIPTION
- `mapedit/tools/mockup + smooth/Makefile` :  Create a Makefile for all, tests, clean
- `mapedit/tools/mockup + smooth/ any .c` : Migrate to SDL 2, Support paletted images with less than 8 bits per pixel,       Fix exchanged arguments to `SDL_CreateRGBSurfaceFrom`, Remove a wrong `free`, remove the corresponding `malloc`,
- `mapedit/tools/smooth/smooth.conf` : Complete the missing color transform into smoothed.bmp, 
-  `mapedit/tools/smooth` sources and plugins : Rework the logic to use `Uint32` instead of `char[7]` for colors, Handle a "*" trigger accordingly.