### PR TITLE
Adding Mouse and Touch support to Cheat screen and other cheat screen changes

### DIFF
--- a/cheat_screen.cc
+++ b/cheat_screen.cc
@@ -613,12 +613,13 @@ bool CheatScreen::SharedInput() {
 			} else {
 				CERR("event.type= " << event.type);
 				switch (event.type) {
-				case SDL_QUIT:
+				case SDL_QUIT: {
 					CERR("SDL_QUIT");
-					if (gwin->get_gump_man()->okay_to_quit()) {
+					ImageBufferPaintable screenshot;
+					if (gwin->get_gump_man()->okay_to_quit(&screenshot)) {
 						throw quit_exception();
 					}
-					break;
+				} break;
 				case SDL_FINGERDOWN: {
 					CERR("SDL_FINGERDOWN");
 					buttons_down.insert(button_down_finger);
@@ -848,7 +849,6 @@ bool CheatScreen::SharedInput() {
 					}
 				}
 			} else if (state.mode == CP_Name) {    // Want Text input
-
 				if (key.sym == SDLK_RETURN || key.sym == SDLK_KP_ENTER) {
 					state.activate = true;
 				} else if (
@@ -3490,9 +3490,9 @@ bool CheatScreen::PalEffectCheck(Actor* actor) {
 
 	case 'x':    // [X]Form
 	{
-		const char  prompttext[] = "enter XFORM Index (0-%lu)";
+		const char  prompttext[] = "enter XFORM Index (0-%zu)";
 		static char staticPrompttext[sizeof(prompttext) + 16];
-		auto        numxforms = Shape_manager::get_instance()->get_xforms_cnt();
+		size_t      numxforms = Shape_manager::get_instance()->get_xforms_cnt();
 		if (numxforms) {
 			numxforms--;
 		}
@@ -4178,14 +4178,14 @@ void CheatScreen::WaitButtonsUp() {
 
 			// const int offsety1 = 73;
 			// const int offsety2 = 55;
-			 const int offsetx1 = 160;
+			const int offsetx1 = 160;
 			// const int offsety4 = 36;
 			const int offsety5 = 72;
 #else
 			const int offsetx_start = 0;
 			// const int offsety1 = 0;
 			// const int offsety2 = 0;
-			 const int offsetx1 = 160;
+			const int offsetx1 = 160;
 			// const int offsety4 = maxy - 45;
 			const int offsety5 = maxy - 36;
 #endif    // eXit
@@ -4195,13 +4195,13 @@ void CheatScreen::WaitButtonsUp() {
 			int        offsety       = 36;
 			offsetx                  = offsetx1 - 4 * std::size(msg_waiting);
 			offsetx += font->paint_text_fixedwidth(
-							   ibuf, msg_waiting, offsetx, offsety, 8);
+					ibuf, msg_waiting, offsetx, offsety, 8);
 
 			bool first       = true;
 			int  last_button = 0;
 			for (int button : buttons_down) {
 				char        buf[80]     = {0};
-				const char* button_name = 0;
+				const char* button_name = nullptr;
 
 				// only each button once.. Standard guarantees that all keys
 				// that compare equivalent are grouped together
@@ -4220,7 +4220,6 @@ void CheatScreen::WaitButtonsUp() {
 					} else {
 						button_name = "Finger";
 					}
-
 				} break;
 
 				case 1:
@@ -4249,13 +4248,12 @@ void CheatScreen::WaitButtonsUp() {
 					if (keyname[0]
 						&& std::none_of(
 								keyname, keyname + strlen(keyname), [](char c) {
-									return c >= 128;
+									return static_cast<unsigned char>(c) >= 128;
 								})) {
 						snprintf(buf, sizeof(buf), "Key %s", keyname);
 					} else {
 						snprintf(buf, sizeof(buf), "Unknown Key #%i", button);
 					}
-
 				} break;
 				}
 

--- a/cheat_screen.cc
+++ b/cheat_screen.cc
@@ -1051,9 +1051,12 @@ void CheatScreen::NormalDisplay() {
 
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, offsety1 + 18, 8);
 
-	snprintf(
-			buf, sizeof(buf), "Exult Version %s  Rev: %s", VERSION,
-			VersionGetGitRevision(true).c_str());
+	strcpy(buf, "Exult Version " VERSION" Rev: ");
+	auto rev = VersionGetGitRevision(true);
+	int  curlen = strlen(buf);
+	rev.copy(buf + strlen(buf),rev.size());
+	// Need to null terminate after copy
+	buf[curlen + rev.size()] = 0;
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, offsety1 + 27, 8);
 
 	snprintf(

--- a/cheat_screen.cc
+++ b/cheat_screen.cc
@@ -49,6 +49,17 @@
 
 #define TEST_MOBILE 1
 
+// Disable the gcc warnig because we cannot fit it the problem is in the Macro
+// from SDL
+#if defined(__GNUC__)
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+static const Uint32 EXSDL_TOUCH_MOUSEID = SDL_TOUCH_MOUSEID;
+
+#if defined(__GNUC__)
+#	pragma GCC diagnostic pop
+#endif
 
 const char* CheatScreen::schedules[33] = {
 		"Combat",    "Hor. Pace",  "Ver. Pace",  "Talk",  "Dance",     "Eat",
@@ -616,8 +627,9 @@ bool CheatScreen::SharedInput() {
 				}
 					// Finger swiping converts to cursor keys
 				case SDL_FINGERMOTION: {
-					CERR("SDL_FINGERMOTION"  << "( dx(" << event.tfinger.dx << ") dy("
-							  << event.tfinger.dy << ")");
+					CERR("SDL_FINGERMOTION"
+						 << "( dx(" << event.tfinger.dx << ") dy("
+						 << event.tfinger.dy << ")");
 					gwin->get_win()->screen_to_game(
 							event.button.x, event.button.y,
 							gwin->get_fastmouse(), gx, gy);
@@ -638,7 +650,6 @@ bool CheatScreen::SharedInput() {
 						state.swipe_dy += event.tfinger.dy;
 						// set last swipe value to now
 						state.last_swipe = SDL_GetTicks();
-
 					}
 				} break;
 
@@ -671,8 +682,7 @@ bool CheatScreen::SharedInput() {
 					gwin->get_win()->screen_to_game(
 							event.button.x, event.button.y,
 							gwin->get_fastmouse(), gx, gy);
-					CERR("SDL_MOUSEBUTTONDOWN( " << gx << " , " << gy
-							  << " )");
+					CERR("SDL_MOUSEBUTTONDOWN( " << gx << " , " << gy << " )");
 
 					if (event.button.button == 1) {
 						simulate_key = CheckHotspots(gx, gy);
@@ -688,9 +698,8 @@ bool CheatScreen::SharedInput() {
 					if (simulate_key) {
 						break;
 					}
-					CERR("window size( " << gwin->get_width()
-							  << " , " << gwin->get_height()
-							  << " )");
+					CERR("window size( " << gwin->get_width() << " , "
+										 << gwin->get_height() << " )");
 					// Touch on the cheat screen will bring up the keyboard
 					// but not if the tap was within a 20 pixel border on the
 					// edge of the game screen)
@@ -712,8 +721,7 @@ bool CheatScreen::SharedInput() {
 				std::memset(&event, 0, sizeof(event));
 				event.type           = SDL_KEYDOWN;
 				event.key.keysym.sym = simulate_key;
-				CERR("simmulate key " << event.key.keysym.sym
-						);
+				CERR("simmulate key " << event.key.keysym.sym);
 				// Simulated keys automatically execute the command if possible
 				if (state.mode >= CP_HitKey
 					&& state.mode <= CP_WrongShapeFile) {
@@ -3432,7 +3440,7 @@ bool CheatScreen::PalEffectCheck(Actor* actor) {
 	switch (state.command) {
 	case 'r':    // [R]amp Remap
 	{
-		const char   prompttext[] = "enter From Ramp (0-%i) or 255 for all";
+		const char   prompttext[] = "enter From Ramp (0-%u) or 255 for all";
 		static char  staticPrompttext[sizeof(prompttext) + 16];
 		unsigned int numramps = 0;
 		gwin->get_pal()->get_ramps(numramps);
@@ -3452,7 +3460,7 @@ bool CheatScreen::PalEffectCheck(Actor* actor) {
 
 	case 'x':    // [X]Form
 	{
-		const char  prompttext[] = "enter XFORM Index (0-%i)";
+		const char  prompttext[] = "enter XFORM Index (0-%lu)";
 		static char staticPrompttext[sizeof(prompttext) + 16];
 		auto        numxforms = Shape_manager::get_instance()->get_xforms_cnt();
 		if (numxforms) {

--- a/cheat_screen.cc
+++ b/cheat_screen.cc
@@ -47,6 +47,9 @@
 
 #include <cstring>
 
+#define TEST_MOBILE 1
+
+
 const char* CheatScreen::schedules[33] = {
 		"Combat",    "Hor. Pace",  "Ver. Pace",  "Talk",  "Dance",     "Eat",
 		"Farm",      "Tend Shop",  "Miner",      "Hound", "Stand",     "Loiter",
@@ -131,12 +134,16 @@ const char* CheatScreen::flag_names[64] = {
 
 const char* CheatScreen::alignments[4] = {"Neutral", "Good", "Evil", "Chaotic"};
 
-static int Find_highest_map() {
+int CheatScreen::Get_highest_map() {
+	if (highest_map != INT_MIN) {
+		return highest_map;
+	}
 	int n = 0;
 	int next;
 	while ((next = Find_next_map(n + 1, 10)) != -1) {
 		n = next;
 	}
+	highest_map = n;
 	return n;
 }
 
@@ -159,7 +166,7 @@ void CheatScreen::show_screen() {
 	}
 	clock = gwin->get_clock();
 	maxx  = gwin->get_width();
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	maxy = 200;
 #else
 	maxy = gwin->get_height();
@@ -180,8 +187,33 @@ void CheatScreen::show_screen() {
 	pal.load(pal_tuple_static.str, pal_tuple_patch.str, pal_tuple_static.num);
 	pal.apply();
 
+	// std::memset(highlighttable.colors, 1, sizeof(highlighttable.colors));
+	// highlighttable.colors[0]   = 0;
+	// highlighttable.colors[255] = 255;
+	const int remaps[] = {
+			5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5 - 1,
+	};
+
+	pal.Generate_remap_xformtable(highlighttable.colors, remaps);
+
+	const int hoverremaps[] = {
+			1, 1, 1, 1, 1, 6, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 - 1,
+	};
+
+	pal.Generate_remap_xformtable(hovertable.colors, hoverremaps);
+	ClearState clear(state);
+
+	Mouse::mouse->hide();
+	Mouse::Mouse_shapes saveshape = Mouse::mouse->get_shape();
+	Mouse::mouse->set_shape(Mouse::hand);
+
 	// Start the loop
 	NormalLoop();
+
+	Mouse::mouse->set_shape(saveshape);
+	Mouse::mouse->hide();
+	gwin->paint();
+	Mouse::mouse->show();
 
 	// Resume the game clock
 	gwin->get_tqueue()->resume(SDL_GetTicks());
@@ -207,10 +239,10 @@ void CheatScreen::show_screen() {
 // Shared
 //
 
-void CheatScreen::SharedPrompt(const char* input, const Cheat_Prompt& mode) {
-	char buf[512];
+void CheatScreen::SharedPrompt() {
+	char buf[64];
 
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int prompt    = 81;
 	const int promptmes = 90;
 	const int offsetx   = 15;
@@ -222,7 +254,8 @@ void CheatScreen::SharedPrompt(const char* input, const Cheat_Prompt& mode) {
 	font->paint_text_fixedwidth(ibuf, "Select->", offsetx, prompt, 8);
 
 	// Special handling for arrows in CP_Command
-	if (mode == CP_Command && !input[1]
+	const char* input = state.input;
+	if (state.mode == CP_Command && !input[1]
 		&& (*input == '<' || *input == '>' || *input == '^' || *input == 'V')) {
 		PaintArrow(64 + offsetx, prompt, *input);
 		input = " ";
@@ -230,13 +263,14 @@ void CheatScreen::SharedPrompt(const char* input, const Cheat_Prompt& mode) {
 	if (input && std::strlen(input)) {
 		font->paint_text_fixedwidth(ibuf, input, 64 + offsetx, prompt, 8);
 		font->paint_text_fixedwidth(
-				ibuf, "_", 64 + offsetx + std::strlen(input) * 8, prompt, 8);
+				ibuf, "_", 64 + offsetx + int(std::strlen(input)) * 8, prompt,
+				8);
 	} else {
 		font->paint_text_fixedwidth(ibuf, "_", 64 + offsetx, prompt, 8);
 	}
 
 	// ...and Prompt Message
-	switch (mode) {
+	switch (state.mode) {
 	default:
 
 	case CP_Command:
@@ -325,9 +359,9 @@ void CheatScreen::SharedPrompt(const char* input, const Cheat_Prompt& mode) {
 		break;
 
 	case CP_CustomValue:
-		if (custom_prompt) {
+		if (state.custom_prompt) {
 			font->paint_text_fixedwidth(
-					ibuf, custom_prompt, offsetx, promptmes, 8);
+					ibuf, state.custom_prompt, offsetx, promptmes, 8);
 		}
 		break;
 
@@ -352,9 +386,12 @@ void CheatScreen::SharedPrompt(const char* input, const Cheat_Prompt& mode) {
 		break;
 
 	case CP_Shape:
-		font->paint_text_fixedwidth(
-				ibuf, "Enter Shape (B=Browse or ESC=Cancel)", offsetx,
-				promptmes, 8);
+		snprintf(
+				buf, std::size(buf),
+				"Enter Shape Max %i (B=Browse or ESC=Cancel)",
+				Shape_manager::get_instance()->get_shapes().get_num_shapes()
+						- 1);
+		font->paint_text_fixedwidth(ibuf, buf, offsetx, promptmes, 8);
 		break;
 
 	case CP_Activity:
@@ -383,7 +420,6 @@ void CheatScreen::SharedPrompt(const char* input, const Cheat_Prompt& mode) {
 		break;
 
 	case CP_GFlagNum: {
-		char buf[50];
 		snprintf(
 				buf, sizeof(buf), "Enter Global Flag 0-%d. (ESC to cancel)",
 				c_last_gflag);
@@ -485,40 +521,223 @@ static int SDLScanCodeToInt(SDL_Keycode sym) {
 	}
 }
 
-bool CheatScreen::SharedInput(
-		char* input, int len, int& command, Cheat_Prompt& mode,
-		bool& activate) {
-	SDL_Event event;
+static void resizeline(float& axis1, float delta1, float& axis2) {
+	float slope = axis2 / axis1;
+	axis1 += delta1;
+	axis2 = axis1 * slope;
+}
 
-	while (true) {
+bool CheatScreen::SharedInput() {
+	SDL_Event event;
+	// Do repaint after 100 ms to allow for time dependant effects. 10 FPS seems
+	// more that adequate for Cheat Screen If anyone needs to do smooth animaion
+	// the can change this
+	auto repainttime = SDL_GetTicks() + 100;
+	Mouse::mouse->hide();    // Turn off mouse.
+	std::memset(&event, 0, sizeof(event));
+
+	while (SDL_GetTicks() < repainttime) {
 		Delay();
-		while (SDL_PollEvent(&event)) {
-			// Touch on the cheat screen will bring up the keyboard
-			if (event.type == SDL_MOUSEBUTTONDOWN) {
-				if (SDL_IsTextInputActive()) {
-					SDL_StopTextInput();
+		if (state.highlighttime && state.highlighttime < SDL_GetTicks()) {
+			state.highlight     = 0;
+			state.highlighttime = 0;
+		}
+
+		// How far finger needs to move for swipe to be interpreted as an a
+		// cursor key input)
+		const float swipe_threshold = 0.075f;
+		bool        do_swipe        = std::abs(state.swipe_dx) > swipe_threshold
+						|| std::abs(state.swipe_dy) > swipe_threshold;
+
+		if (!do_swipe && state.last_swipe
+			&& ((state.last_swipe + 200) < SDL_GetTicks())) {
+			// zero out swipe state if it's been longer that 200ms since last
+			// event recieved and it's shorter than the threshold
+			state.last_swipe = 0;
+			state.swipe_dx   = 0;
+			state.swipe_dy   = 0;
+		}
+		Mouse::mouse_update = false;
+		while (do_swipe || SDL_PollEvent(&event)) {
+			int         gx, gy;
+			SDL_KeyCode simulate_key = SDLK_UNKNOWN;
+
+			//
+			if (do_swipe) {
+				float ax = 0, ay = 0;
+				ay = std::abs(state.swipe_dy);
+				ax = std::abs(state.swipe_dx);
+				CERR("Doing swipe ay: " << ay << " ax:" << ax);
+				// More vertical motion or More Horizontal
+				// perfectly diagonal motion will be treated as horizontal
+				if (ay > ax) {
+					// Vertical motion
+					if (state.swipe_dy < -swipe_threshold) {
+						simulate_key = SDLK_UP;
+						resizeline(
+								state.swipe_dy, +swipe_threshold,
+								state.swipe_dx);
+					} else if (state.swipe_dy > swipe_threshold) {
+						simulate_key = SDLK_DOWN;
+						resizeline(
+								state.swipe_dy, -swipe_threshold,
+								state.swipe_dx);
+					}
 				} else {
-					SDL_StartTextInput();
+					// horizontal motion
+					if (state.swipe_dx < -swipe_threshold) {
+						simulate_key = SDLK_LEFT;
+						resizeline(
+								state.swipe_dx, +swipe_threshold,
+								state.swipe_dy);
+					} else if (state.swipe_dx > swipe_threshold) {
+						simulate_key = SDLK_RIGHT;
+						resizeline(
+								state.swipe_dx, -swipe_threshold,
+								state.swipe_dy);
+					}
+				}
+			} else {
+				CERR("event.type= " << event.type);
+				switch (event.type) {
+				case SDL_QUIT:
+					CERR("SDL_QUIT");
+					if (gwin->get_gump_man()->okay_to_quit()) {
+						throw quit_exception();
+					}
+					break;
+				case SDL_FINGERDOWN: {
+					CERR("SDL_FINGERDOWN");
+					if ((!Mouse::use_touch_input)
+						&& (event.tfinger.fingerId != 0)) {
+						Mouse::use_touch_input = true;
+					}
+					break;
+				}
+					// Finger swiping converts to cursor keys
+				case SDL_FINGERMOTION: {
+					CERR("SDL_FINGERMOTION"  << "( dx(" << event.tfinger.dx << ") dy("
+							  << event.tfinger.dy << ")");
+					gwin->get_win()->screen_to_game(
+							event.button.x, event.button.y,
+							gwin->get_fastmouse(), gx, gy);
+
+					static int  numFingers = 0;
+					SDL_Finger* finger0
+							= SDL_GetTouchFinger(event.tfinger.touchId, 0);
+					if (finger0) {
+						numFingers
+								= SDL_GetNumTouchFingers(event.tfinger.touchId);
+					}
+					CERR("numFingers " << numFingers);
+
+					// Will allow single finger swipes
+					if (numFingers > 0) {
+						// Accuulate the deltas onto thevector
+						state.swipe_dx += event.tfinger.dx;
+						state.swipe_dy += event.tfinger.dy;
+						// set last swipe value to now
+						state.last_swipe = SDL_GetTicks();
+
+					}
+				} break;
+
+				// Mousewheel scrolling with SDL2.
+				case SDL_MOUSEWHEEL: {
+					CERR("SDL_MOUSEWHEEL");
+					if (event.wheel.y > 0) {
+						simulate_key = SDLK_LEFT;
+					} else if (event.wheel.y < 0) {
+						simulate_key = SDLK_RIGHT;
+					}
+				} break;
+				case SDL_MOUSEMOTION: {
+					CERR("SDL_MOUSEMOTION");
+					if (Mouse::use_touch_input
+						&& event.motion.which != EXSDL_TOUCH_MOUSEID) {
+						Mouse::use_touch_input = false;
+					}
+					gwin->get_win()->screen_to_game(
+							event.motion.x, event.motion.y,
+							gwin->get_fastmouse(), gx, gy);
+
+					Mouse::mouse->set_location(gx, gy);
+					Mouse::mouse_update = true;
+
+				} break;
+					// return;
+
+				case SDL_MOUSEBUTTONDOWN: {
+					gwin->get_win()->screen_to_game(
+							event.button.x, event.button.y,
+							gwin->get_fastmouse(), gx, gy);
+					CERR("SDL_MOUSEBUTTONDOWN( " << gx << " , " << gy
+							  << " )");
+
+					if (event.button.button == 1) {
+						simulate_key = CheckHotspots(gx, gy);
+
+						// Double click detection. for mouse only?
+						if (!simulate_key
+							/*&& event.button.which != EXSDL_TOUCH_MOUSEID*/
+							&& event.button.clicks >= 2) {
+							simulate_key = SDLK_RETURN;
+						}
+					}
+
+					if (simulate_key) {
+						break;
+					}
+					CERR("window size( " << gwin->get_width()
+							  << " , " << gwin->get_height()
+							  << " )");
+					// Touch on the cheat screen will bring up the keyboard
+					// but not if the tap was within a 20 pixel border on the
+					// edge of the game screen)
+					if (SDL_IsTextInputActive()) {
+						SDL_StopTextInput();
+					} else if (
+							gx > 20 && gy > 20 && gx < (gwin->get_width() - 20)
+							&& gy < (gwin->get_height() - 20)) {
+						SDL_StartTextInput();
+					}
+				} break;
+
+				default:
+					break;
 				}
 			}
 
+			if (simulate_key) {
+				std::memset(&event, 0, sizeof(event));
+				event.type           = SDL_KEYDOWN;
+				event.key.keysym.sym = simulate_key;
+				CERR("simmulate key " << event.key.keysym.sym
+						);
+				// Simulated keys automatically execute the command if possible
+				if (state.mode >= CP_HitKey
+					&& state.mode <= CP_WrongShapeFile) {
+					state.mode = CP_Command;
+				}
+			}
 			if (event.type != SDL_KEYDOWN) {
 				continue;
 			}
 			const SDL_Keysym& key = event.key.keysym;
 
 			if (key.sym == SDLK_ESCAPE) {
-				std::memset(input, 0, len);
+				std::memset(state.input, 0, sizeof(state.input));
 				// If current mode is needing to press a key return to command
-				if (mode >= CP_HitKey && mode <= CP_WrongShapeFile) {
-					command = 0;
-					mode    = CP_Command;
+				if (state.mode >= CP_HitKey
+					&& state.mode <= CP_WrongShapeFile) {
+					state.command = 0;
+					state.mode    = CP_Command;
 					return false;
 				}
 				// Escape will cancel current mode
-				else if (mode != CP_Command) {
-					command = key.sym;
-					mode    = CP_Canceled;
+				else if (state.mode != CP_Command) {
+					state.command = key.sym;
+					state.mode    = CP_Canceled;
 					return false;
 				}
 			}
@@ -529,124 +748,230 @@ bool CheatScreen::SharedInput(
 				return false;
 			}
 
-			if (mode == CP_NorthSouth) {
-				if (!input[0] && (key.sym == 'n' || key.sym == 's')) {
-					input[0] = key.sym;
-					activate = true;
+			if (state.mode == CP_NorthSouth) {
+				if (!state.input[0] && (key.sym == 'n' || key.sym == 's')) {
+					state.input[0] = char(key.sym);
+					state.activate = true;
 				}
-			} else if (mode == CP_WestEast) {
-				if (!input[0] && (key.sym == 'w' || key.sym == 'e')) {
-					input[0] = key.sym;
-					activate = true;
+			} else if (state.mode == CP_WestEast) {
+				if (!state.input[0] && (key.sym == 'w' || key.sym == 'e')) {
+					state.input[0] = char(key.sym);
+					state.activate = true;
 				}
-			} else if (mode >= CP_HexXCoord) {    // Want hex input
+			} else if (
+					state.mode >= CP_HexXCoord
+					&& state.mode <= CP_HexYCoord) {    // Want hex input
 				// Activate (if possible)
 				if (key.sym == SDLK_RETURN || key.sym == SDLK_KP_ENTER) {
-					activate = true;
+					state.activate = true;
+					// increment/decrement
+				} else if (key.sym == SDLK_LEFT || key.sym == SDLK_RIGHT) {
+					char* end   = nullptr;
+					long  value = std::strtol(state.input, &end, 16);
+
+					if (end == state.input + strlen(state.input)) {
+						if (key.sym == SDLK_LEFT && value != state.val_min) {
+							value = std::max(value - 1, state.val_min);
+						} else if (
+								key.sym == SDLK_RIGHT
+								&& value != state.val_max) {
+							value = std::min(value + 1, state.val_max);
+						}
+						if (value < 0) {
+							snprintf(
+									state.input, std::size(state.input), "-%lx",
+									-value);
+						} else {
+							snprintf(
+									state.input, std::size(state.input), "%lx",
+									value);
+						}
+					}
+
 				} else if (
 						(key.sym == '-' || key.sym == SDLK_KP_MINUS)
-						&& !input[0]) {
-					input[0] = '-';
+						&& !state.input[0]) {
+					state.input[0] = '-';
 				} else if (
 						key.sym < 256 && key.sym >= 0
 						&& std::isxdigit(key.sym)) {
-					const int curlen = std::strlen(input);
-					if (curlen < (len - 1)) {
-						input[curlen]     = std::tolower(key.sym);
-						input[curlen + 1] = 0;
+					const size_t curlen = std::strlen(state.input);
+					if (curlen < (std::size(state.input) - 1)) {
+						state.input[curlen]     = char(std::tolower(key.sym));
+						state.input[curlen + 1] = 0;
 					}
 				} else if (
 						(key.sym >= SDLK_KP_1 && key.sym <= SDLK_KP_9)
 						|| key.sym == SDLK_KP_0) {
-					const int curlen = std::strlen(input);
-					if (curlen < (len - 1)) {
-						const int sym     = SDLScanCodeToInt(key.sym);
-						input[curlen]     = sym;
-						input[curlen + 1] = 0;
+					const size_t curlen = std::strlen(state.input);
+					if (curlen < (std::size(state.input) - 1)) {
+						const int sym           = SDLScanCodeToInt(key.sym);
+						state.input[curlen]     = char(sym);
+						state.input[curlen + 1] = 0;
 					}
 				} else if (key.sym == SDLK_BACKSPACE) {
-					const int curlen = std::strlen(input);
+					const size_t curlen = std::strlen(state.input);
 					if (curlen) {
-						input[curlen - 1] = 0;
+						state.input[curlen - 1] = 0;
 					}
 				}
-			} else if (mode >= CP_Name) {    // Want Text input (len chars)
+			} else if (state.mode == CP_Name) {    // Want Text input
 
 				if (key.sym == SDLK_RETURN || key.sym == SDLK_KP_ENTER) {
-					activate = true;
+					state.activate = true;
 				} else if (
 						(key.sym < 256 && key.sym >= 0 && std::isalnum(key.sym))
 						|| key.sym == ' ') {
-					const int curlen = std::strlen(input);
-					char      chr    = key.sym;
+					const size_t curlen = std::strlen(state.input);
+					char         chr    = key.sym;
 					if (key.mod & KMOD_SHIFT) {
 						chr = static_cast<char>(
 								std::toupper(static_cast<unsigned char>(chr)));
 					}
-					if (curlen < (len - 1)) {
-						input[curlen]     = chr;
-						input[curlen + 1] = 0;
+					if (curlen < (std::size(state.input) - 1)) {
+						state.input[curlen]     = chr;
+						state.input[curlen + 1] = 0;
 					}
 				} else if (key.sym == SDLK_BACKSPACE) {
-					const int curlen = std::strlen(input);
+					const size_t curlen = std::strlen(state.input);
 					if (curlen) {
-						input[curlen - 1] = 0;
+						state.input[curlen - 1] = 0;
 					}
 				}
-			} else if (mode >= CP_ChooseNPC) {    // Need to grab numerical
-												  // input
-												  // Browse shape
-				if (mode == CP_Shape && !input[0] && key.sym == 'b') {
+			} else if (state.mode >= CP_ChooseNPC) {    // Need to grab
+														// numerical
+														// input Browse shape
+				if (state.mode == CP_Shape && !state.input[0]
+					&& key.sym == 'b') {
 					cheat.shape_browser();
-					input[0] = 'b';
-					activate = true;
+					state.input[0] = 'b';
+					state.activate = true;
 				}
 
+				if (key.sym == SDLK_LEFT || key.sym == SDLK_RIGHT) {
+					char* end   = nullptr;
+					long  value = std::strtol(state.input, &end, 10);
+
+					if (end == state.input + strlen(state.input)) {
+						if (key.sym == SDLK_LEFT && value != state.val_min) {
+							value = std::max(value - 1, state.val_min);
+						} else if (
+								key.sym == SDLK_RIGHT
+								&& value != state.val_max) {
+							value = std::min(value + 1, state.val_max);
+						}
+						snprintf(
+								state.input, std::size(state.input) - 1, "%ld",
+								value);
+					}
+				}
 				// Activate (if possible)
-				if (key.sym == SDLK_RETURN || key.sym == SDLK_KP_ENTER) {
-					activate = true;
+				else if (key.sym == SDLK_RETURN || key.sym == SDLK_KP_ENTER) {
+					state.activate = true;
 				} else if (
 						(key.sym == '-' || key.sym == SDLK_KP_MINUS)
-						&& !input[0]) {
-					input[0] = '-';
+						&& !state.input[0]) {
+					state.input[0] = '-';
 				} else if (
 						key.sym < 256 && key.sym >= 0
 						&& std::isdigit(key.sym)) {
-					const int curlen = std::strlen(input);
-					if (curlen < (len - 1)) {
-						input[curlen]     = key.sym;
-						input[curlen + 1] = 0;
+					const size_t curlen = std::strlen(state.input);
+					if (curlen < (std::size(state.input) - 1)) {
+						state.input[curlen]     = key.sym;
+						state.input[curlen + 1] = 0;
 					}
 				} else if (
 						(key.sym >= SDLK_KP_1 && key.sym <= SDLK_KP_9)
 						|| key.sym == SDLK_KP_0) {
-					const int curlen = std::strlen(input);
-					if (curlen < (len - 1)) {
-						const int sym     = SDLScanCodeToInt(key.sym);
-						input[curlen]     = sym;
-						input[curlen + 1] = 0;
+					const size_t curlen = std::strlen(state.input);
+					if (curlen < (std::size(state.input) - 1)) {
+						const int sym           = SDLScanCodeToInt(key.sym);
+						state.input[curlen]     = sym;
+						state.input[curlen + 1] = 0;
 					}
 				} else if (key.sym == SDLK_BACKSPACE) {
-					const int curlen = std::strlen(input);
+					const auto curlen = std::strlen(state.input);
 					if (curlen) {
-						input[curlen - 1] = 0;
+						state.input[curlen - 1] = 0;
 					}
 				}
-			} else if (mode) {    // Just want a key pressed
-				mode = CP_Command;
-				for (int i = 0; i < len; i++) {
-					input[i] = 0;
+			} else if (state.mode) {    // Just want a key pressed
+				state.mode = CP_Command;
+				for (size_t i = 0; i < std::size(state.input); i++) {
+					state.input[i] = 0;
 				}
-				command = 0;
+				state.command = 0;
 			} else {    // Need the key pressed
-				command = key.sym;
+				state.command       = key.sym;
+				state.highlighttime = SDL_GetTicks() + 1000;
+				state.highlight     = state.command;
 				return true;
 			}
 			return false;
 		}
-		gwin->paint_dirty();
+		gwin->rotatecolours();
+		Mouse::mouse->show();    // Re-display mouse.
+		if (gwin->show() || Mouse::mouse_update) {
+			Mouse::mouse->blit_dirty();
+		}
+		Mouse::mouse->hide();    // Need to immediately turn off here to prevent
+								 // flickering after repaint of whole screen
 	}
 	return false;
+}
+
+void CheatScreen::SharedMenu() {
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
+	const int offsetx = 15;
+	// const int offsety1 = 73;
+	// const int offsety2 = 55;
+	// const int offsetx1 = 160;
+	// const int offsety4 = 36;
+	const int offsety5 = 72;
+#else
+	const int offsetx = 0;
+	// const int offsety1 = 0;
+	// const int offsety2 = 0;
+	// const int offsetx1 = 160;
+	// const int offsety4 = maxy - 45;
+	const int offsety5 = maxy - 36;
+#endif    // eXit
+	AddMenuItem(offsetx + 160, offsety5 + 9, SDLK_ESCAPE, " Exit");
+}
+
+SDL_KeyCode CheatScreen::CheckHotspots(int mx, int my, int radius) {
+	// Find the nearest hotspot
+	SDL_KeyCode nearest     = SDLK_UNKNOWN;
+	int         nearestdist = INT_MAX;
+
+	for (auto& hs : hotspots) {
+		int dist = hs.distance(mx, my);
+		if (dist < nearestdist) {
+			nearest     = hs.keycode;
+			nearestdist = dist;
+		}
+	}
+	// Only return it if it is within the radius
+	if (nearestdist <= radius) {
+		return nearest;
+	}
+	return SDLK_UNKNOWN;
+}
+
+void CheatScreen::PaintHotspots() {
+	int mx = Mouse::mouse->get_mousex();
+	int my = Mouse::mouse->get_mousey();
+	for (const auto& hs : hotspots) {
+		if (hs) {
+			if (hs.has_point(mx, my)) {
+				// Draw mouse hover
+				ibuf->fill_translucent8(0, hs.w, hs.h, hs.x, hs.y, hovertable);
+			}
+			// Draw the box in bright yellow
+			// ibuf->draw_box(
+			//		hs.x - 2, hs.y - 2, hs.w + 4, hs.h + 4, 2, 255, 5);
+		}
+	}
 }
 
 //
@@ -656,15 +981,9 @@ bool CheatScreen::SharedInput(
 void CheatScreen::NormalLoop() {
 	bool looping = true;
 
-	// This is for the prompt message
-	Cheat_Prompt mode = CP_Command;
-
-	// This is the command
-	char input[5] = {0, 0, 0, 0, 0};
-	int  command;
-	bool activate = false;
-
+	ClearState clear(state);
 	while (looping) {
+		hotspots.clear();
 		gwin->clear_screen();
 
 		// First the display
@@ -674,27 +993,27 @@ void CheatScreen::NormalLoop() {
 		NormalMenu();
 
 		// Finally the Prompt...
-		SharedPrompt(input, mode);
+		SharedPrompt();
 
 		// Draw it!
-		gwin->get_win()->show();
+		EndFrame();
 
 		// Check to see if we need to change menus
-		if (activate) {
-			NormalActivate(input, command, mode);
-			activate = false;
+		if (state.activate) {
+			NormalActivate();
+			state.activate = false;
 			continue;
 		}
 
-		if (SharedInput(input, 5, command, mode, activate)) {
-			looping = NormalCheck(input, command, mode, activate);
+		if (SharedInput()) {
+			looping = NormalCheck();
 		}
 	}
 }
 
 void CheatScreen::NormalDisplay() {
 	char buf[512];
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx  = 15;
 	const int offsety1 = 108;
 	const int offsety2 = 54;
@@ -756,107 +1075,100 @@ void CheatScreen::NormalDisplay() {
 
 void CheatScreen::NormalMenu() {
 	char buf[512];
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx  = 15;
 	const int offsety1 = 73;
 	const int offsety2 = 55;
 	const int offsetx1 = 160;
 	const int offsety4 = 36;
-	const int offsety5 = 72;
+	// const int offsety5 = 72;
 #else
 	const int offsetx  = 0;
 	const int offsety1 = 0;
 	const int offsety2 = 0;
 	const int offsetx1 = 0;
 	const int offsety4 = maxy - 45;
-	const int offsety5 = maxy - 36;
+	// const int offsety5 = maxy - 36;
 #endif
 
 	// Left Column
 
 	// Use
-#if !defined(__IPHONEOS__) && !defined(ANDROID)
+#if !defined(__IPHONEOS__) && !defined(ANDROID) && !defined(TEST_MOBILE)
 	// Paperdolls can be toggled in the gumps, no need here for small screens
 	Shape_manager* sman = Shape_manager::get_instance();
 	if (sman->can_use_paperdolls() && sman->are_paperdolls_enabled()) {
-		snprintf(buf, sizeof(buf), "[P]aperdolls..: Yes");
+		snprintf(buf, sizeof(buf), "aperdolls..: Yes");
 	} else {
-		snprintf(buf, sizeof(buf), "[P]aperdolls..:  No");
+		snprintf(buf, sizeof(buf), "aperdolls..:  No");
 	}
-	font->paint_text_fixedwidth(ibuf, buf, 0, maxy - 99, 8);
+	AddMenuItem(offsetx, maxy - 99, SDLK_p, buf);
+
 #endif
 
 	// GodMode
 	snprintf(
-			buf, sizeof(buf), "[G]od Mode....: %3s",
+			buf, sizeof(buf), "od Mode....: %3s",
 			cheat.in_god_mode() ? "On" : "Off");
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 90, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 90, SDLK_g, buf);
 
 	// Archwizzard Mode
 	snprintf(
-			buf, sizeof(buf), "[W]izard Mode.: %3s",
+			buf, sizeof(buf), "izard Mode.: %3s",
 			cheat.in_wizard_mode() ? "On" : "Off");
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 81, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 81, SDLK_w, buf);
 
 	// Infravision
 	snprintf(
-			buf, sizeof(buf), "[I]nfravision.: %3s",
+			buf, sizeof(buf), "nfravision.: %3s",
 			cheat.in_infravision() ? "On" : "Off");
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 72, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 72, SDLK_i, buf);
 
 	// Hackmover
 	snprintf(
-			buf, sizeof(buf), "[H]ack Mover..: %3s",
+			buf, sizeof(buf), "ack Mover..: %3s",
 			cheat.in_hack_mover() ? "Yes" : "No");
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 63, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 63, SDLK_h, buf);
 
 	// Eggs
 	snprintf(
-			buf, sizeof(buf), "[E]ggs Visible: %3s",
+			buf, sizeof(buf), "ggs Visible: %3s",
 			gwin->paint_eggs ? "Yes" : "No");
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 54, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 54, SDLK_e, buf);
 
 	// Set Time
-	font->paint_text_fixedwidth(
-			ibuf, "[S]et Time", offsetx + offsetx1, offsety4, 8);
-
-#if !defined(__IPHONEOS__) && !defined(ANDROID)
-	// for small screens taking the liberty of leaving that out
-	// Time Rate
-	if (clock->get_time_rate() > 1) {
-		PaintArrow(8, maxy - 36, '<');
-	}
-	PaintArrow(17, maxy - 36, '>');
-	snprintf(buf, sizeof(buf), "[  ] Time Rate: %3i", clock->get_time_rate());
-	font->paint_text_fixedwidth(ibuf, buf, 0, maxy - 36, 8);
-#endif
+	AddMenuItem(offsetx + offsetx1, offsety4, SDLK_s, "et Time");
 
 	// Right Column
 
 	// NPC Tool
-	font->paint_text_fixedwidth(
-			ibuf, "[N]PC Tool", offsetx + 160, maxy - offsety2 - 99, 8);
+	AddMenuItem(offsetx + 160, maxy - offsety2 - 99, SDLK_n, "PC Tool");
 
 	// Global Flag Modify
-	font->paint_text_fixedwidth(
-			ibuf, "[F]lag Modifier", offsetx + 160, maxy - offsety2 - 90, 8);
+	AddMenuItem(offsetx + 160, maxy - offsety2 - 90, SDLK_f, "lag Modifier");
 
 	// Teleport
-	font->paint_text_fixedwidth(
-			ibuf, "[T]eleport", offsetx + 160, maxy - offsety2 - 81, 8);
+	AddMenuItem(offsetx + 160, maxy - offsety2 - 81, SDLK_t, "eleport");
 
-	// eXit
-	font->paint_text_fixedwidth(ibuf, "[ESC] Exit", offsetx + 160, offsety5, 8);
+#if !defined(__IPHONEOS__) && !defined(ANDROID) && !defined(TEST_MOBILE)
+	// for small screens taking the liberty of leaving that out
+	// Time Rate
+	snprintf(buf, sizeof(buf), " Time Rate:%4i", clock->get_time_rate());
+	AddLeftRightMenuItem(
+			offsetx + 160, offsety4, buf, clock->get_time_rate() > 1,
+			clock->get_time_rate() < 20, true, false);
+#endif
+
+	SharedMenu();
 }
 
-void CheatScreen::NormalActivate(
-		char* input, int& command, Cheat_Prompt& mode) {
-	const int      npc  = std::atoi(input);
+void CheatScreen::NormalActivate() {
+	const int      npc  = std::atoi(state.input);
 	Shape_manager* sman = Shape_manager::get_instance();
 
-	mode = CP_Command;
+	state.mode = CP_Command;
 
-	switch (command) {
+	switch (state.command) {
 		// God Mode
 	case 'g':
 		cheat.toggle_god();
@@ -885,7 +1197,7 @@ void CheatScreen::NormalActivate(
 
 		// Set Time
 	case 's':
-		mode = TimeSetLoop();
+		state.mode = TimeSetLoop();
 		break;
 
 		// - Time Rate
@@ -910,24 +1222,24 @@ void CheatScreen::NormalActivate(
 		// NPC Tool
 	case 'n':
 		if (npc < 0 || (npc >= 356 && npc <= 359)) {
-			mode = CP_InvalidNPC;
-		} else if (!input[0]) {
+			state.mode = CP_InvalidNPC;
+		} else if (!state.input[0]) {
 			NPCLoop(-1);
 		} else {
-			mode = NPCLoop(npc);
+			state.mode = NPCLoop(npc);
 		}
 		break;
 
 		// Global Flag Editor
 	case 'f':
 		if (npc < 0) {
-			mode = CP_InvalidValue;
+			state.mode = CP_InvalidValue;
 		} else if (npc > c_last_gflag) {
-			mode = CP_InvalidValue;
-		} else if (!input[0]) {
-			mode = CP_Canceled;
+			state.mode = CP_InvalidValue;
+		} else if (!state.input[0]) {
+			state.mode = CP_Canceled;
 		} else {
-			mode = GlobalFlagLoop(npc);
+			state.mode = GlobalFlagLoop(npc);
 		}
 		break;
 
@@ -947,17 +1259,16 @@ void CheatScreen::NormalActivate(
 		break;
 	}
 
-	input[0] = 0;
-	input[1] = 0;
-	input[2] = 0;
-	input[3] = 0;
-	command  = 0;
+	state.input[0] = 0;
+	state.input[1] = 0;
+	state.input[2] = 0;
+	state.input[3] = 0;
+	state.command  = 0;
 }
 
-// Checks the input
-bool CheatScreen::NormalCheck(
-		char* input, int& command, Cheat_Prompt& mode, bool& activate) {
-	switch (command) {
+// Checks the state.input
+bool CheatScreen::NormalCheck() {
+	switch (state.command) {
 		// Simple commands
 	case 't':    // Teleport
 	case 'g':    // God Mode
@@ -968,43 +1279,47 @@ bool CheatScreen::NormalCheck(
 	case 'h':    // Hack Mover
 	case 'c':    // Create Item
 	case 'p':    // Paperdolls
-		input[0] = command;
-		activate = true;
+		state.input[0] = state.command;
+		state.activate = true;
 		break;
 
 		// - Time
 	case SDLK_LEFT:
-		command  = '<';
-		input[0] = command;
-		activate = true;
+		state.command  = '<';
+		state.input[0] = state.command;
+		state.activate = true;
 		break;
 
 	// + Time
 	case SDLK_RIGHT:
-		command  = '>';
-		input[0] = command;
-		activate = true;
+		state.command  = '>';
+		state.input[0] = state.command;
+		state.activate = true;
 		break;
 
 		// NPC Tool
 	case 'n':
-		mode = CP_ChooseNPC;
+		state.mode    = CP_ChooseNPC;
+		state.val_min = 0;
+		state.val_max = gwin->get_num_npcs() - 1;
 		break;
 
 		// Global Flag Editor
 	case 'f':
-		mode = CP_GFlagNum;
+		state.mode    = CP_GFlagNum;
+		state.val_max = 0;
+		state.val_min = c_last_gflag;
 		break;
 
 		// X and Escape leave
 	case SDLK_ESCAPE:
-		input[0] = command;
+		state.input[0] = state.command;
 		return false;
 
 	default:
-		mode     = CP_InvalidCom;
-		input[0] = command;
-		command  = 0;
+		state.mode     = CP_InvalidCom;
+		state.input[0] = state.command;
+		state.command  = 0;
 		break;
 	}
 
@@ -1017,7 +1332,7 @@ bool CheatScreen::NormalCheck(
 
 void CheatScreen::ActivityDisplay() {
 	char buf[512];
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsety1 = 99;
 #else
 	const int offsety1 = 0;
@@ -1096,18 +1411,11 @@ void CheatScreen::PaintArrow(int offsetx, int offsety, int type) {
 //
 
 CheatScreen::Cheat_Prompt CheatScreen::TimeSetLoop() {
-	// This is for the prompt message
-	Cheat_Prompt mode = CP_Day;
-
-	// This is the command
-	char input[5] = {0, 0, 0, 0, 0};
-	int  command;
-	bool activate = false;
-
-	int day  = 0;
-	int hour = 0;
-
+	int        day  = 0;
+	int        hour = 0;
+	ClearState clear(state);
 	while (true) {
+		hotspots.clear();
 		gwin->clear_screen();
 
 		// First the display
@@ -1117,23 +1425,25 @@ CheatScreen::Cheat_Prompt CheatScreen::TimeSetLoop() {
 		NormalMenu();
 
 		// Finally the Prompt...
-		SharedPrompt(input, mode);
+		SharedPrompt();
 
 		// Draw it!
-		gwin->get_win()->show();
+		EndFrame();
 
 		// Check to see if we need to change menus
-		if (activate) {
-			const int val = std::atoi(input);
+		if (state.activate) {
+			const int val = std::atoi(state.input);
 
 			if (val < 0) {
 				return CP_InvalidTime;
-			} else if (mode == CP_Day) {
-				day  = val;
-				mode = CP_Hour;
+			} else if (state.mode == CP_Day) {
+				day           = val;
+				state.mode    = CP_Hour;
+				state.val_min = 0;
+				state.val_max = 23;
 			} else if (val > 59) {
 				return CP_InvalidTime;
-			} else if (mode == CP_Minute) {
+			} else if (state.mode == CP_Minute) {
 				clock->reset();
 				clock->set_day(day);
 				clock->set_hour(hour);
@@ -1141,22 +1451,24 @@ CheatScreen::Cheat_Prompt CheatScreen::TimeSetLoop() {
 				break;
 			} else if (val > 23) {
 				return CP_InvalidTime;
-			} else if (mode == CP_Hour) {
-				hour = val;
-				mode = CP_Minute;
+			} else if (state.mode == CP_Hour) {
+				hour          = val;
+				state.mode    = CP_Minute;
+				state.val_min = 0;
+				state.val_max = 59;
 			}
 
-			activate = false;
-			input[0] = 0;
-			input[1] = 0;
-			input[2] = 0;
-			input[3] = 0;
-			command  = 0;
+			state.activate = false;
+			state.input[0] = 0;
+			state.input[1] = 0;
+			state.input[2] = 0;
+			state.input[3] = 0;
+			state.command  = 0;
 			continue;
 		}
 
-		SharedInput(input, 5, command, mode, activate);
-		if (mode == CP_Canceled) {
+		SharedInput();
+		if (state.mode == CP_Canceled) {
 			return CP_Canceled;
 		}
 	}
@@ -1170,36 +1482,27 @@ CheatScreen::Cheat_Prompt CheatScreen::TimeSetLoop() {
 
 CheatScreen::Cheat_Prompt CheatScreen::GlobalFlagLoop(int num) {
 	bool looping = true;
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx  = 15;
 	const int offsety1 = 83;
-	const int offsety2 = 72;
+	// const int offsety2 = 72;
 #else
 	const int offsetx  = 0;
 	const int offsety1 = 0;
-	const int offsety2 = maxy - 36;
+	// const int offsety2 = maxy - 36;
 #endif
 
-	// This is for the prompt message
-	Cheat_Prompt mode = CP_Command;
-
-	// This is the command
-	char input[17];
 	int  i;
-	int  command;
-	bool activate = false;
-	char buf[512];
-
-	for (i = 0; i < 17; i++) {
-		input[i] = 0;
-	}
+	char buf[64];
 
 	Usecode_machine* usecode = Game_window::get_instance()->get_usecode();
 
+	ClearState clear(state);
 	while (looping) {
+		hotspots.clear();
 		gwin->clear_screen();
 
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 		// on small screens we want lean and mean, so begone NormalDisplay
 		font->paint_text_fixedwidth(ibuf, "Global Flags", 15, 0, 8);
 #else
@@ -1219,117 +1522,102 @@ CheatScreen::Cheat_Prompt CheatScreen::GlobalFlagLoop(int num) {
 
 		// Now the Menu Column
 		if (!usecode->get_global_flag(num)) {
-			font->paint_text_fixedwidth(
-					ibuf, "[S]et Flag", offsetx + 160, maxy - offsety1 - 99, 8);
+			AddMenuItem(offsetx + 160, maxy - offsety1 - 99, SDLK_s, "et Flag");
 		} else {
-			font->paint_text_fixedwidth(
-					ibuf, "[U]nset Flag", offsetx + 160, maxy - offsety1 - 99,
-					8);
+			AddMenuItem(
+					offsetx + 160, maxy - offsety1 - 99, SDLK_u, "nset Flag");
 		}
 
 		// Change Flag
+		AddMenuItem(offsetx, maxy - offsety1 - 72, SDLK_UP, " Change Flag");
+		AddLeftRightMenuItem(
+				offsetx, maxy - offsety1 - 63, "Scroll Flags", num > 0,
+				num < c_last_gflag, false, true);
 
-		PaintArrow(offsetx + 8, maxy - offsety1 - 72, '^');
-		font->paint_text_fixedwidth(
-				ibuf, "[ ] Change Flag", offsetx, maxy - offsety1 - 72, 8);
-		if (num > 0 && num < c_last_gflag) {
-			PaintArrow(offsetx + 8, maxy - offsety1 - 63, '<');
-			PaintArrow(offsetx + 17, maxy - offsety1 - 63, '>');
-
-			font->paint_text_fixedwidth(
-					ibuf, "[  ] Scroll Flags", offsetx, maxy - offsety1 - 63,
-					8);
-		} else if (num == 0) {
-			PaintArrow(offsetx + 8, maxy - offsety1 - 63, '<');
-			font->paint_text_fixedwidth(
-					ibuf, "[ ] Scroll Flags", offsetx, maxy - offsety1 - 63, 8);
-		} else {
-			PaintArrow(offsetx + 8, maxy - offsety1 - 63, '>');
-			font->paint_text_fixedwidth(
-					ibuf, "[ ] Scroll Flags", offsetx, maxy - offsety1 - 63, 8);
-		}
-		font->paint_text_fixedwidth(ibuf, "[ESC] Exit", offsetx, offsety2, 8);
+		SharedMenu();
 
 		// Finally the Prompt...
-		SharedPrompt(input, mode);
+		SharedPrompt();
 
 		// Draw it!
-		gwin->get_win()->show();
+		EndFrame();
 
 		// Check to see if we need to change menus
-		if (activate) {
-			mode = CP_Command;
-			if (command == '<') {    // Decrement
+		if (state.activate) {
+			state.mode = CP_Command;
+			if (state.command == '<') {    // Decrement
 				num--;
 				if (num < 0) {
 					num = 0;
 				}
-			} else if (command == '>') {    // Increment
+			} else if (state.command == '>') {    // Increment
 				num++;
 				if (num > c_last_gflag) {
 					num = c_last_gflag;
 				}
-			} else if (command == '^') {    // Change Flag
-				i = std::atoi(input);
+			} else if (state.command == '^') {    // Change Flag
+				i = std::atoi(state.input);
 				if (i < 0 || i > c_last_gflag) {
-					mode = CP_InvalidValue;
-				} else if (input[0]) {
+					state.mode = CP_InvalidValue;
+				} else if (state.input[0]) {
 					num = i;
 				}
-			} else if (command == 's') {    // Set
+			} else if (state.command == 's') {    // Set
 				usecode->set_global_flag(num, 1);
-			} else if (command == 'u') {    // Unset
+			} else if (state.command == 'u') {    // Unset
 				usecode->set_global_flag(num, 0);
 			}
 
 			for (i = 0; i < 17; i++) {
-				input[i] = 0;
+				state.input[i] = 0;
 			}
-			command  = 0;
-			activate = false;
+			state.command  = 0;
+			state.activate = false;
 			continue;
 		}
 
-		if (SharedInput(input, 17, command, mode, activate)) {
-			switch (command) {
+		if (SharedInput()) {
+			switch (state.command) {
 				// Simple commands
 			case 's':    // Set Flag
 			case 'u':    // Unset flag
-				input[0] = command;
-				activate = true;
+				state.input[0] = state.command;
+				state.activate = true;
 				break;
 
 				// Decrement
 			case SDLK_LEFT:
-				command  = '<';
-				input[0] = command;
-				activate = true;
+				state.command  = '<';
+				state.input[0] = state.command;
+				state.activate = true;
 				break;
 
 				// Increment
 			case SDLK_RIGHT:
-				command  = '>';
-				input[0] = command;
-				activate = true;
+				state.command  = '>';
+				state.input[0] = state.command;
+				state.activate = true;
 				break;
 
 				// * Change Flag
 			case SDLK_UP:
-				command  = '^';
-				input[0] = 0;
-				mode     = CP_GFlagNum;
+				state.command  = '^';
+				state.input[0] = 0;
+				state.mode     = CP_GFlagNum;
+				state.val_max  = 0;
+				state.val_min  = c_last_gflag;
 				break;
 
 				// X and Escape leave
 			case SDLK_ESCAPE:
-				input[0] = command;
-				looping  = false;
+				state.input[0] = state.command;
+				looping        = false;
 				break;
 
 			default:
-				mode     = CP_InvalidCom;
-				input[0] = command;
-				command  = 0;
+				state.mode     = CP_InvalidCom;
+				state.input[0] = state.command;
+				state.command  = 0;
 				break;
 			}
 		}
@@ -1346,20 +1634,9 @@ CheatScreen::Cheat_Prompt CheatScreen::NPCLoop(int num) {
 
 	bool looping = true;
 
-	// This is for the prompt message
-	Cheat_Prompt mode = CP_Command;
-
-	// This is the command
-	char input[17];
-	int  i;
-	int  command;
-	bool activate = false;
-
-	for (i = 0; i < 17; i++) {
-		input[i] = 0;
-	}
-
+	ClearState clear(state);
 	while (looping) {
+		hotspots.clear();
 		if (num == -1) {
 			actor = grabbed;
 		} else {
@@ -1379,20 +1656,19 @@ CheatScreen::Cheat_Prompt CheatScreen::NPCLoop(int num) {
 		NPCMenu(actor, num);
 
 		// Finally the Prompt...
-		SharedPrompt(input, mode);
-
+		SharedPrompt();
 		// Draw it!
-		gwin->get_win()->show();
+		EndFrame();
 
 		// Check to see if we need to change menus
-		if (activate) {
-			NPCActivate(input, command, mode, actor, num);
-			activate = false;
+		if (state.activate) {
+			NPCActivate(actor, num);
+			state.activate = false;
 			continue;
 		}
 
-		if (SharedInput(input, 17, command, mode, activate)) {
-			looping = NPCCheck(input, command, mode, activate, actor, num);
+		if (SharedInput()) {
+			looping = NPCCheck(actor, num);
 		}
 	}
 	return CP_Command;
@@ -1400,7 +1676,7 @@ CheatScreen::Cheat_Prompt CheatScreen::NPCLoop(int num) {
 
 void CheatScreen::NPCDisplay(Actor* actor, int& num) {
 	char buf[512];
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx  = 15;
 	const int offsety1 = 73;
 #else
@@ -1492,19 +1768,19 @@ void CheatScreen::NPCDisplay(Actor* actor, int& num) {
 
 void CheatScreen::NPCMenu(Actor* actor, int& num) {
 	ignore_unused_variable_warning(num);
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx  = 15;
 	const int offsety1 = 74;
-	const int offsetx2 = 15;
-	const int offsety2 = 72;
+	// const int offsetx2 = 15;
+	// const int offsety2 = 72;
 	const int offsetx3 = 175;
 	const int offsety3 = 63;
 	const int offsety4 = 72;
 #else
 	const int offsetx  = 0;
 	const int offsety1 = 0;
-	const int offsetx2 = 0;
-	const int offsety2 = maxy - 36;
+	// const int offsetx2 = 0;
+	// const int offsety2 = maxy - 36;
 	const int offsetx3 = offsetx + 160;
 	const int offsety3 = maxy - 45;
 	const int offsety4 = maxy - 36;
@@ -1513,106 +1789,76 @@ void CheatScreen::NPCMenu(Actor* actor, int& num) {
 
 	if (actor) {
 		// Business Activity
-		font->paint_text_fixedwidth(
-				ibuf, "[B]usiness Activity", offsetx, maxy - offsety1 - 99, 8);
+		AddMenuItem(offsetx, maxy - offsety1 - 99, SDLK_b, "usiness Activity");
 
 		// Change Shape
-		font->paint_text_fixedwidth(
-				ibuf, "[C]hange Shape", offsetx, maxy - offsety1 - 90, 8);
+		AddMenuItem(offsetx, maxy - offsety1 - 90, SDLK_c, "hange Shape");
 
 		// XP
-		font->paint_text_fixedwidth(
-				ibuf, "[E]xperience", offsetx, maxy - offsety1 - 81, 8);
+		AddMenuItem(offsetx, maxy - offsety1 - 81, SDLK_e, "xperience");
 
 		// NPC Flags
-		font->paint_text_fixedwidth(
-				ibuf, "[N]pc Flags", offsetx, maxy - offsety1 - 72, 8);
+		AddMenuItem(offsetx, maxy - offsety1 - 72, SDLK_n, "pc Flags");
 
 		// Name
-		font->paint_text_fixedwidth(
-				ibuf, "[1] Name", offsetx, maxy - offsety1 - 63, 8);
+		AddMenuItem(offsetx, maxy - offsety1 - 63, SDLK_1, " Name");
 	}
 
-	// eXit
-	font->paint_text_fixedwidth(ibuf, "[ESC] Exit", offsetx2, offsety2, 8);
+	SharedMenu();
 
 	// Right Column
 
 	if (actor) {
 		// Stats
-		font->paint_text_fixedwidth(
-				ibuf, "[S]tats", offsetx + 160, maxy - offsety1 - 99, 8);
-
-		// Training Points
-		font->paint_text_fixedwidth(
-				ibuf, "[2] Training Points", offsetx + 160,
-				maxy - offsety1 - 90, 8);
+		AddMenuItem(offsetx + 160, maxy - offsety1 - 99, SDLK_s, "tats");
 
 		// Teleport
-		font->paint_text_fixedwidth(
-				ibuf, "[T]eleport", offsetx + 160, maxy - offsety1 - 81, 8);
+		AddMenuItem(
+				offsetx + 160, maxy - offsety1 - 81, SDLK_t, "eleport to NPC");
 
 		// Palette Effect
-		font->paint_text_fixedwidth(
-				ibuf, "[P]alete Effect", offsetx + 160, maxy - offsety1 - 72,
-				8);
-
-		// Change NPC
-
-		PaintArrow(offsetx3 + 8, offsety3, '^');
-
-		font->paint_text_fixedwidth(
-				ibuf, "[ ] Change NPC", offsetx3, offsety3, 8);
+		AddMenuItem(
+				offsetx + 160, maxy - offsety1 - 72, SDLK_p, "alette Effect");
 	}
 
 	// Change NPC
-	int num_arrows = 0;
-	if (num > 0) {
-		PaintArrow(offsetx3 + 8, offsety4, '<');
-		num_arrows++;
-	}
-	if (num < gwin->get_num_npcs()) {
-		PaintArrow(offsetx3 + 9 + num_arrows * 8, offsety4, '>');
-		num_arrows++;
-	}
 
-	if (num_arrows == 2) {
-		font->paint_text_fixedwidth(
-				ibuf, "[  ] Scroll NPCs", offsetx3, offsety4, 8);
-	} else {
-		font->paint_text_fixedwidth(
-				ibuf, "[ ]  Scroll NPCs", offsetx3, offsety4, 8);
-	}
+	AddMenuItem(offsetx3, offsety3, SDLK_UP, " Change NPC");
+
+	// Scroll NPCs
+
+	AddLeftRightMenuItem(
+			offsetx3, offsety4, "Scroll NPCs", num > 0,
+			num < gwin->get_num_npcs(), false, true);
 }
 
-void CheatScreen::NPCActivate(
-		char* input, int& command, Cheat_Prompt& mode, Actor* actor, int& num) {
-	int       i = std::atoi(input);
+void CheatScreen::NPCActivate(Actor* actor, int& num) {
+	int       i = std::atoi(state.input);
 	const int nshapes
 			= Shape_manager::get_instance()->get_shapes().get_num_shapes();
 
-	mode = CP_Command;
+	state.mode = CP_Command;
 
-	if (command == '<') {
+	if (state.command == '<') {
 		num--;
 		if (num < 0) {
 			num = 0;
 		} else if (num >= 356 && num <= 359) {
 			num = 355;
 		}
-	} else if (command == '>') {
+	} else if (state.command == '>') {
 		num++;
 		if (num >= 356 && num <= 359) {
 			num = 360;
 		}
-	} else if (command == '^') {    // Change NPC
+	} else if (state.command == '^') {    // Change NPC
 		if (i < 0 || (i >= 356 && i <= 359)) {
-			mode = CP_InvalidNPC;
-		} else if (input[0]) {
+			state.mode = CP_InvalidNPC;
+		} else if (state.input[0]) {
 			num = i;
 		}
 	} else if (actor) {
-		switch (command) {
+		switch (state.command) {
 		case 'b':    // Business
 			BusinessLoop(actor);
 			break;
@@ -1636,7 +1882,7 @@ void CheatScreen::NPCActivate(
 
 		case 'e':    // Experience
 			if (i < 0) {
-				mode = CP_Canceled;
+				state.mode = CP_Canceled;
 			} else {
 				actor->set_property(Actor::exp, i);
 			}
@@ -1644,41 +1890,41 @@ void CheatScreen::NPCActivate(
 
 		case '2':    // Training Points
 			if (i < 0) {
-				mode = CP_Canceled;
+				state.mode = CP_Canceled;
 			} else {
 				actor->set_property(Actor::training, i);
 			}
 			break;
 
-		case 'c':                     // Change shape
-			if (input[0] == 'b') {    // Browser
+		case 'c':                           // Change shape
+			if (state.input[0] == 'b') {    // Browser
 				int n;
 				if (!cheat.get_browser_shape(i, n)) {
-					mode = CP_WrongShapeFile;
+					state.mode = CP_WrongShapeFile;
 					break;
 				}
 			}
 
 			if (i < 0) {
-				mode = CP_InvalidShape;
+				state.mode = CP_InvalidShape;
 			} else if (i >= nshapes) {
-				mode = CP_InvalidShape;
-			} else if (input[0]) {
+				state.mode = CP_InvalidShape;
+			} else if (state.input[0]) {
 				if (actor->get_npc_num() != 0) {
 					actor->set_shape(i);
 				} else {
 					actor->set_polymorph(i);
 				}
-				mode = CP_ShapeSet;
+				state.mode = CP_ShapeSet;
 			}
 			break;
 
 		case '1':    // Name
-			if (!std::strlen(input)) {
-				mode = CP_Canceled;
+			if (!std::strlen(state.input)) {
+				state.mode = CP_Canceled;
 			} else {
-				actor->set_npc_name(input);
-				mode = CP_NameSet;
+				actor->set_npc_name(state.input);
+				state.mode = CP_NameSet;
 			}
 			break;
 
@@ -1687,17 +1933,15 @@ void CheatScreen::NPCActivate(
 		}
 	}
 	for (i = 0; i < 17; i++) {
-		input[i] = 0;
+		state.input[i] = 0;
 	}
-	command = 0;
+	state.command = 0;
 }
 
-// Checks the input
-bool CheatScreen::NPCCheck(
-		char* input, int& command, Cheat_Prompt& mode, bool& activate,
-		Actor* actor, int& num) {
+// Checks the state.input
+bool CheatScreen::NPCCheck(Actor* actor, int& num) {
 	ignore_unused_variable_warning(num);
-	switch (command) {
+	switch (state.command) {
 		// Simple commands
 	case 'a':    // Attack mode
 	case 'b':    // BUsiness
@@ -1706,11 +1950,11 @@ bool CheatScreen::NPCCheck(
 	case 's':    // stats
 	case 'z':    // Target
 	case 't':    // Teleport
-		input[0] = command;
+		state.input[0] = state.command;
 		if (!actor) {
-			mode = CP_InvalidCom;
+			state.mode = CP_InvalidCom;
 		} else {
-			activate = true;
+			state.activate = true;
 		}
 		break;
 
@@ -1718,69 +1962,77 @@ bool CheatScreen::NPCCheck(
 	case 'e':    // Experience
 	case '2':    // Training Points
 		if (!actor) {
-			mode = CP_InvalidCom;
+			state.mode = CP_InvalidCom;
 		} else {
-			mode = CP_EnterValue;
+			state.mode    = CP_EnterValue;
+			state.val_min = 255;
 		}
 		break;
 
 		// Palette Effect
 	case 'p':
 		if (!actor) {
-			mode = CP_InvalidCom;
+			state.mode = CP_InvalidCom;
 		} else {
-			activate = true;
+			state.activate = true;
 		}
 		break;
 
 		// Change shape
 	case 'c':
 		if (!actor) {
-			mode = CP_InvalidCom;
+			state.mode = CP_InvalidCom;
 		} else {
-			mode = CP_Shape;
+			state.mode    = CP_Shape;
+			state.val_min = 0;
+			state.val_max = Shape_manager::get_instance()
+									->get_shapes()
+									.get_num_shapes()
+							- 1;
 		}
 		break;
 
 		// Name
 	case '1':
 		if (!actor) {
-			mode = CP_InvalidCom;
+			state.mode = CP_InvalidCom;
 		} else {
-			mode = CP_Name;
+			state.mode = CP_Name;
 		}
 		break;
 
 		// - NPC
 	case SDLK_LEFT:
-		command  = '<';
-		input[0] = command;
-		activate = true;
+		state.command  = '<';
+		state.input[0] = state.command;
+		state.activate = true;
 		break;
 
 		// + NPC
 	case SDLK_RIGHT:
-		command  = '>';
-		input[0] = command;
-		activate = true;
+		state.command  = '>';
+		state.input[0] = state.command;
+		state.activate = true;
 		break;
 
 		// * Change NPC
 	case SDLK_UP:
-		command  = '^';
-		input[0] = 0;
-		mode     = CP_ChooseNPC;
+		state.command  = '^';
+		state.input[0] = 0;
+		state.mode     = CP_ChooseNPC;
+		state.val_min  = 0;
+		state.val_max  = gwin->get_num_npcs() - 1;
 		break;
 
 		// X and Escape leave
 	case SDLK_ESCAPE:
-		input[0] = command;
+		state.input[0] = state.command;
 		return false;
 
 	default:
-		mode     = CP_InvalidCom;
-		input[0] = command;
-		command  = 0;
+		state.mode     = CP_InvalidCom;
+		state.input[0] = state.command;
+		state.command  = 0;
 		break;
 	}
 
@@ -1792,28 +2044,17 @@ bool CheatScreen::NPCCheck(
 //
 
 void CheatScreen::FlagLoop(Actor* actor) {
-#if !defined(__IPHONEOS__) && !defined(ANDROID)
+#if !defined(__IPHONEOS__) && !defined(ANDROID) && !defined(TEST_MOBILE)
 	int num = actor->get_npc_num();
 #endif
 	bool looping = true;
 
-	// This is for the prompt message
-	Cheat_Prompt mode = CP_Command;
-
-	// This is the command
-	char input[17];
-	int  i;
-	int  command;
-	bool activate = false;
-
-	for (i = 0; i < 17; i++) {
-		input[i] = 0;
-	}
-
+	ClearState clear(state);
 	while (looping) {
+		hotspots.clear();
 		gwin->clear_screen();
 
-#if !defined(__IPHONEOS__) && !defined(ANDROID)
+#if !defined(__IPHONEOS__) && !defined(ANDROID) && !defined(TEST_MOBILE)
 		// First the display
 		NPCDisplay(actor, num);
 #endif
@@ -1822,27 +2063,27 @@ void CheatScreen::FlagLoop(Actor* actor) {
 		FlagMenu(actor);
 
 		// Finally the Prompt...
-		SharedPrompt(input, mode);
+		SharedPrompt();
 
 		// Draw it!
-		gwin->get_win()->show();
+		EndFrame();
 
 		// Check to see if we need to change menus
-		if (activate) {
-			FlagActivate(input, command, mode, actor);
-			activate = false;
+		if (state.activate) {
+			FlagActivate(actor);
+			state.activate = false;
 			continue;
 		}
 
-		if (SharedInput(input, 17, command, mode, activate)) {
-			looping = FlagCheck(input, command, mode, activate, actor);
+		if (SharedInput()) {
+			looping = FlagCheck(actor);
 		}
 	}
 }
 
 void CheatScreen::FlagMenu(Actor* actor) {
 	char buf[512];
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx  = 10;
 	const int offsetx1 = 6;
 	const int offsety1 = 92;
@@ -1856,222 +2097,196 @@ void CheatScreen::FlagMenu(Actor* actor) {
 
 	// Asleep
 	snprintf(
-			buf, sizeof(buf), "[A] Asleep.%c",
+			buf, sizeof(buf), " Asleep.%c",
 			actor->get_flag(Obj_flags::asleep) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 108, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 108, SDLK_a, buf);
 
 	// Charmed
 	snprintf(
-			buf, sizeof(buf), "[B] Charmd.%c",
+			buf, sizeof(buf), " Charmd.%c",
 			actor->get_flag(Obj_flags::charmed) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 99, 8);
+
+	AddMenuItem(offsetx, maxy - offsety1 - 99, SDLK_b, buf);
 
 	// Cursed
 	snprintf(
-			buf, sizeof(buf), "[C] Cursed.%c",
+			buf, sizeof(buf), " Cursed.%c",
 			actor->get_flag(Obj_flags::cursed) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 90, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 90, SDLK_c, buf);
 
 	// Paralyzed
 	snprintf(
-			buf, sizeof(buf), "[D] Prlyzd.%c",
+			buf, sizeof(buf), " Prlyzd.%c",
 			actor->get_flag(Obj_flags::paralyzed) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 81, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 81, SDLK_d, buf);
 
 	// Poisoned
 	snprintf(
-			buf, sizeof(buf), "[E] Poisnd.%c",
+			buf, sizeof(buf), " Poisnd.%c",
 			actor->get_flag(Obj_flags::poisoned) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 72, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 72, SDLK_e, buf);
 
 	// Protected
 	snprintf(
-			buf, sizeof(buf), "[F] Prtctd.%c",
+			buf, sizeof(buf), " Prtctd.%c",
 			actor->get_flag(Obj_flags::protection) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 63, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 63, SDLK_f, buf);
 
+	// Tournament (Original is SI only -- allowing for BG in Exult)
+	snprintf(
+			buf, sizeof(buf), " Tourna.%c",
+			actor->get_flag(Obj_flags::tournament) ? 'Y' : 'N');
+	AddMenuItem(offsetx, maxy - offsety1 - 54, SDLK_g, buf);
+
+	// Polymorph
+	snprintf(
+			buf, sizeof(buf), " Polymo.%c",
+			actor->get_flag(Obj_flags::polymorph) ? 'Y' : 'N');
+	AddMenuItem(offsetx, maxy - offsety1 - 45, SDLK_h, buf);
 	// Advanced Editor
-	PaintArrow(offsetx + 8, maxy - offsety1 - 45, '^');
-	font->paint_text_fixedwidth(
-			ibuf, "[ ] Advanced", offsetx, maxy - offsety1 - 45, 8);
 
-	// Exit
-	font->paint_text_fixedwidth(
-			ibuf, "[ESC] Exit", offsetx, maxy - offsety1 - 36, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 36, SDLK_UP, "Advanced");
+
+	SharedMenu();
 
 	// Center Column
 
 	// Party
 	snprintf(
-			buf, sizeof(buf), "[I] Party..%c",
+			buf, sizeof(buf), " Party..%c",
 			actor->get_flag(Obj_flags::in_party) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 104, maxy - offsety1 - 108, 8);
+	AddMenuItem(offsetx1 + 104, maxy - offsety1 - 108, SDLK_i, buf);
 
 	// Invisible
 	snprintf(
-			buf, sizeof(buf), "[J] Invsbl.%c",
+			buf, sizeof(buf), " Invsbl.%c",
 			actor->get_flag(Obj_flags::invisible) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 104, maxy - offsety1 - 99, 8);
+	AddMenuItem(offsetx1 + 104, maxy - offsety1 - 99, SDLK_j, buf);
 
 	// Fly
 	snprintf(
-			buf, sizeof(buf), "[K] Fly....%c",
+			buf, sizeof(buf), " Fly....%c",
 			actor->get_type_flag(Actor::tf_fly) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 104, maxy - offsety1 - 90, 8);
+	AddMenuItem(offsetx1 + 104, maxy - offsety1 - 90, SDLK_k, buf);
 
 	// Walk
 	snprintf(
-			buf, sizeof(buf), "[L] Walk...%c",
+			buf, sizeof(buf), " Walk...%c",
 			actor->get_type_flag(Actor::tf_walk) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 104, maxy - offsety1 - 81, 8);
+	AddMenuItem(offsetx1 + 104, maxy - offsety1 - 81, SDLK_l, buf);
 
 	// Swim
 	snprintf(
-			buf, sizeof(buf), "[M] Swim...%c",
+			buf, sizeof(buf), " Swim...%c",
 			actor->get_type_flag(Actor::tf_swim) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 104, maxy - offsety1 - 72, 8);
+	AddMenuItem(offsetx1 + 104, maxy - offsety1 - 72, SDLK_m, buf);
 
 	// Ethereal
 	snprintf(
-			buf, sizeof(buf), "[N] Ethrel.%c",
+			buf, sizeof(buf), " Ethrel.%c",
 			actor->get_type_flag(Actor::tf_ethereal) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 104, maxy - offsety1 - 63, 8);
+	AddMenuItem(offsetx1 + 104, maxy - offsety1 - 63, SDLK_n, buf);
 
 	// Protectee
-	snprintf(buf, sizeof(buf), "[O] Prtcee.%c", '?');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 104, maxy - offsety1 - 54, 8);
+	snprintf(buf, sizeof(buf), " Prtcee.%c", '?');
+	AddMenuItem(offsetx1 + 104, maxy - offsety1 - 54, SDLK_o, buf);
 
 	// Conjured
 	snprintf(
-			buf, sizeof(buf), "[P] Conjrd.%c",
+			buf, sizeof(buf), " Conjrd.%c",
 			actor->get_type_flag(Actor::tf_conjured) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 104, maxy - offsety1 - 45, 8);
-
-	// Tournament (Original is SI only -- allowing for BG in Exult)
-	snprintf(
-			buf, sizeof(buf), "[3] Tourna.%c",
-			actor->get_flag(Obj_flags::tournament) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 104, maxy - offsety1 - 36, 8);
+	AddMenuItem(offsetx1 + 104, maxy - offsety1 - 45, SDLK_p, buf);
 
 	// Naked (AV ONLY)
 	if (!actor->get_npc_num()) {
 		snprintf(
-				buf, sizeof(buf), "[7] Naked..%c",
+				buf, sizeof(buf), " Naked..%c",
 				actor->get_flag(Obj_flags::naked) ? 'Y' : 'N');
-		font->paint_text_fixedwidth(
-				ibuf, buf, offsetx1 + 104, maxy - offsety1 - 27, 8);
+		AddMenuItem(offsetx1 + 104, maxy - offsety1 - 36, SDLK_7, buf);
 	}
 
 	// Right Column
 
 	// Summoned
 	snprintf(
-			buf, sizeof(buf), "[Q] Summnd.%c",
+			buf, sizeof(buf), " Summnd.%c",
 			actor->get_type_flag(Actor::tf_summonned) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 208, maxy - offsety1 - 108, 8);
+	AddMenuItem(offsetx1 + 208, maxy - offsety1 - 108, SDLK_q, buf);
 
 	// Bleeding
 	snprintf(
-			buf, sizeof(buf), "[R] Bleedn.%c",
+			buf, sizeof(buf), " Bleedn.%c",
 			actor->get_type_flag(Actor::tf_bleeding) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 208, maxy - offsety1 - 99, 8);
+	AddMenuItem(offsetx1 + 208, maxy - offsety1 - 99, SDLK_r, buf);
 
 	if (!actor->get_npc_num()) {    // Avatar
 		// Sex
 		snprintf(
-				buf, sizeof(buf), "[S] Sex....%c",
+				buf, sizeof(buf), " Sex....%c",
 				actor->get_type_flag(Actor::tf_sex) ? 'F' : 'M');
-		font->paint_text_fixedwidth(
-				ibuf, buf, offsetx1 + 208, maxy - offsety1 - 90, 8);
+		AddMenuItem(offsetx1 + 208, maxy - offsety1 - 90, SDLK_s, buf);
 
 		// Skin
-		snprintf(buf, sizeof(buf), "[1] Skin...%d", actor->get_skin_color());
-		font->paint_text_fixedwidth(
-				ibuf, buf, offsetx1 + 208, maxy - offsety1 - 81, 8);
+		snprintf(buf, sizeof(buf), " Skin...%d", actor->get_skin_color());
+		AddMenuItem(offsetx1 + 208, maxy - offsety1 - 81, SDLK_1, buf);
 
 		// Read
 		snprintf(
-				buf, sizeof(buf), "[4] Read...%c",
+				buf, sizeof(buf), " Read...%c",
 				actor->get_flag(Obj_flags::read) ? 'Y' : 'N');
-		font->paint_text_fixedwidth(
-				ibuf, buf, offsetx1 + 208, maxy - offsety1 - 72, 8);
+		AddMenuItem(offsetx1 + 208, maxy - offsety1 - 72, SDLK_4, buf);
 	} else {    // Not Avatar
 		// Met
 		snprintf(
-				buf, sizeof(buf), "[T] Met....%c",
+				buf, sizeof(buf), " Met....%c",
 				actor->get_flag(Obj_flags::met) ? 'Y' : 'N');
-		font->paint_text_fixedwidth(
-				ibuf, buf, offsetx1 + 208, maxy - offsety1 - 90, 8);
+		AddMenuItem(offsetx1 + 208, maxy - offsety1 - 90, SDLK_t, buf);
 
 		// NoCast
 		snprintf(
-				buf, sizeof(buf), "[U] NoCast.%c",
+				buf, sizeof(buf), " NoCast.%c",
 				actor->get_flag(Obj_flags::no_spell_casting) ? 'Y' : 'N');
-		font->paint_text_fixedwidth(
-				ibuf, buf, offsetx1 + 208, maxy - offsety1 - 81, 8);
+		AddMenuItem(offsetx1 + 208, maxy - offsety1 - 81, SDLK_u, buf);
 
 		// ID
-		snprintf(buf, sizeof(buf), "[V] ID#:%02i", actor->get_ident());
-		font->paint_text_fixedwidth(
-				ibuf, buf, offsetx1 + 208, maxy - offsety1 - 72, 8);
+		snprintf(buf, sizeof(buf), " ID#:%02i", actor->get_ident());
+		AddMenuItem(offsetx1 + 208, maxy - offsety1 - 72, SDLK_v, buf);
 	}
 
 	// Freeze
 	snprintf(
-			buf, sizeof(buf), "[W] Freeze.%c",
+			buf, sizeof(buf), " Freeze.%c",
 			actor->get_flag(Obj_flags::freeze) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 208, maxy - offsety1 - 63, 8);
+	AddMenuItem(offsetx1 + 208, maxy - offsety1 - 63, SDLK_w, buf);
 
 	// Party
 	if (actor->is_in_party()) {
 		// Temp
-		snprintf(buf, sizeof(buf), "[Y] Temp: %02i", actor->get_temperature());
-		font->paint_text_fixedwidth(
-				ibuf, buf, offsetx1 + 208, maxy - offsety1 - 54, 8);
+		snprintf(buf, sizeof(buf), " Temp: %02i", actor->get_temperature());
+		AddMenuItem(offsetx1 + 208, maxy - offsety1 - 54, SDLK_y, buf);
 
-		// Conjured
+		// Warmth
 		snprintf(buf, sizeof(buf), "Warmth: %04i", actor->figure_warmth());
 		font->paint_text_fixedwidth(
 				ibuf, buf, offsetx1 + 208, maxy - offsety1 - 45, 8);
 	}
 
-	// Polymorph
-	snprintf(
-			buf, sizeof(buf), "[2] Polymo.%c",
-			actor->get_flag(Obj_flags::polymorph) ? 'Y' : 'N');
-	font->paint_text_fixedwidth(
-			ibuf, buf, offsetx1 + 208, maxy - offsety1 - 36, 8);
-
 	// Petra (AV SI ONLY)
 	if (!actor->get_npc_num()) {
 		snprintf(
-				buf, sizeof(buf), "[5] Petra..%c",
+				buf, sizeof(buf), " Petra..%c",
 				actor->get_flag(Obj_flags::petra) ? 'Y' : 'N');
-		font->paint_text_fixedwidth(
-				ibuf, buf, offsetx1 + 208, maxy - offsety1 - 27, 8);
+		AddMenuItem(offsetx1 + 208, maxy - offsety1 - 36, SDLK_5, buf);
 	}
 }
 
-void CheatScreen::FlagActivate(
-		char* input, int& command, Cheat_Prompt& mode, Actor* actor) {
-	int       i = std::atoi(input);
+void CheatScreen::FlagActivate(Actor* actor) {
+	int       i = std::atoi(state.input);
 	const int nshapes
 			= Shape_manager::get_instance()->get_shapes().get_num_shapes();
 
-	mode = CP_Command;
-	switch (command) {
+	state.mode = CP_Command;
+	switch (state.command) {
 		// Everyone
 
 		// Toggles
@@ -2269,13 +2484,13 @@ void CheatScreen::FlagActivate(
 		// Value
 	case 'v':    // ID
 		if (i < 0) {
-			mode = CP_InvalidValue;
+			state.mode = CP_InvalidValue;
 		} else if (i > 63) {
-			mode = CP_InvalidValue;
-		} else if (i == -1 || !input[0]) {
-			mode = CP_Canceled;
+			state.mode = CP_InvalidValue;
+		} else if (i == -1 || !state.input[0]) {
+			state.mode = CP_Canceled;
 		} else {
-			actor->set_ident(i);
+			actor->set_ident(unsigned(i));
 		}
 		break;
 
@@ -2285,7 +2500,7 @@ void CheatScreen::FlagActivate(
 				Shape_manager::get_instance()->have_si_shapes()));
 		break;
 
-	case '3':    // Tournament
+	case 'g':    // Tournament
 		if (actor->get_flag(Obj_flags::tournament)) {
 			actor->clear_flag(Obj_flags::tournament);
 		} else {
@@ -2295,17 +2510,17 @@ void CheatScreen::FlagActivate(
 
 	case 'y':    // Warmth
 		if (i < -1) {
-			mode = CP_InvalidValue;
+			state.mode = CP_InvalidValue;
 		} else if (i > 63) {
-			mode = CP_InvalidValue;
-		} else if (i == -1 || !input[0]) {
-			mode = CP_Canceled;
+			state.mode = CP_InvalidValue;
+		} else if (i == -1 || !state.input[0]) {
+			state.mode = CP_Canceled;
 		} else {
 			actor->set_temperature(i);
 		}
 		break;
 
-	case '2':    // Polymorph
+	case 'h':    // Polymorph
 
 		// Clear polymorph
 		if (actor->get_polymorph() != -1) {
@@ -2313,23 +2528,24 @@ void CheatScreen::FlagActivate(
 			break;
 		}
 
-		if (input[0] == 'b') {    // Browser
+		if (state.input[0] == 'b') {    // Browser
 			int n;
 			if (!cheat.get_browser_shape(i, n)) {
-				mode = CP_WrongShapeFile;
+				state.mode = CP_WrongShapeFile;
 				break;
 			}
 		}
 
 		if (i == -1) {
-			mode = CP_Canceled;
+			state.mode = CP_Canceled;
 		} else if (i < 0) {
-			mode = CP_InvalidShape;
+			state.mode = CP_InvalidShape;
 		} else if (i >= nshapes) {
-			mode = CP_InvalidShape;
-		} else if (input[0] && (input[0] != '-' || input[1])) {
+			state.mode = CP_InvalidShape;
+		} else if (
+				state.input[0] && (state.input[0] != '-' || state.input[1])) {
 			actor->set_polymorph(i);
-			mode = CP_ShapeSet;
+			state.mode = CP_ShapeSet;
 		}
 
 		break;
@@ -2337,11 +2553,11 @@ void CheatScreen::FlagActivate(
 		// Advanced Numeric Flag Editor
 	case '^':
 		if (i < 0 || i > 63) {
-			mode = CP_InvalidValue;
-		} else if (!input[0]) {
-			mode = CP_Canceled;
+			state.mode = CP_InvalidValue;
+		} else if (!state.input[0]) {
+			state.mode = CP_Canceled;
 		} else {
-			mode = AdvancedFlagLoop(i, actor);
+			state.mode = AdvancedFlagLoop(i, actor);
 		}
 		break;
 
@@ -2349,16 +2565,14 @@ void CheatScreen::FlagActivate(
 		break;
 	}
 	for (i = 0; i < 17; i++) {
-		input[i] = 0;
+		state.input[i] = 0;
 	}
-	command = 0;
+	state.command = 0;
 }
 
-// Checks the input
-bool CheatScreen::FlagCheck(
-		char* input, int& command, Cheat_Prompt& mode, bool& activate,
-		Actor* actor) {
-	switch (command) {
+// Checks the state.input
+bool CheatScreen::FlagCheck(Actor* actor) {
+	switch (state.command) {
 		// Everyone
 
 		// Toggles
@@ -2379,19 +2593,24 @@ bool CheatScreen::FlagCheck(
 	case 'q':    // Summoned
 	case 'r':    // Bleedin
 	case 'w':    // Freeze
-	case '3':    // Tournament
-		activate = true;
-		input[0] = command;
+	case 'g':    // Tournament
+		state.activate = true;
+		state.input[0] = state.command;
 		break;
 
 		// Value
-	case '2':    // Polymorph
+	case 'h':    // Polymorph
 		if (actor->get_polymorph() == -1) {
-			mode     = CP_Shape;
-			input[0] = 0;
+			state.mode    = CP_Shape;
+			state.val_min = 0;
+			state.val_max = Shape_manager::get_instance()
+									->get_shapes()
+									.get_num_shapes()
+							- 1;
+			state.input[0] = 0;
 		} else {
-			activate = true;
-			input[0] = command;
+			state.activate = true;
+			state.input[0] = state.command;
 		}
 		break;
 
@@ -2400,11 +2619,13 @@ bool CheatScreen::FlagCheck(
 		// Value
 	case 'y':    // Temp
 		if (!actor->is_in_party()) {
-			command = 0;
+			state.command = 0;
 		} else {
-			mode = CP_TempNum;
+			state.mode    = CP_TempNum;
+			state.val_max = 0;
+			state.val_min = 63;
 		}
-		input[0] = 0;
+		state.input[0] = 0;
 		break;
 
 		// Avatar Only
@@ -2413,32 +2634,32 @@ bool CheatScreen::FlagCheck(
 	case 's':    // Sex
 	case '4':    // Read
 		if (actor->get_npc_num()) {
-			command = 0;
+			state.command = 0;
 		} else {
-			activate = true;
+			state.activate = true;
 		}
-		input[0] = command;
+		state.input[0] = state.command;
 		break;
 
 		// Toggles SI
 	case '5':    // Petra
 	case '7':    // Naked
 		if (actor->get_npc_num()) {
-			command = 0;
+			state.command = 0;
 		} else {
-			activate = true;
+			state.activate = true;
 		}
-		input[0] = command;
+		state.input[0] = state.command;
 		break;
 
 		// Value SI
 	case '1':    // Skin
 		if (actor->get_npc_num()) {
-			command = 0;
+			state.command = 0;
 		} else {
-			activate = true;
+			state.activate = true;
 		}
-		input[0] = command;
+		state.input[0] = state.command;
 		break;
 
 		// Everyone but avatar
@@ -2448,39 +2669,43 @@ bool CheatScreen::FlagCheck(
 	case 'u':    // No Cast
 	case 'z':    // Zombie
 		if (!actor->get_npc_num()) {
-			command = 0;
+			state.command = 0;
 		} else {
-			activate = true;
+			state.activate = true;
 		}
-		input[0] = command;
+		state.input[0] = state.command;
 		break;
 
 		// Value
 	case 'v':    // ID
 		if (!actor->get_npc_num()) {
-			command = 0;
+			state.command = 0;
 		} else {
-			mode = CP_EnterValue;
+			state.mode    = CP_EnterValue;
+			state.val_min = 0;
+			state.val_max = 63;
 		}
-		input[0] = 0;
+		state.input[0] = 0;
 		break;
 
 		// NPC Flag Editor
 
 	case SDLK_UP:
-		command  = '^';
-		input[0] = 0;
-		mode     = CP_NFlagNum;
+		state.command  = '^';
+		state.input[0] = 0;
+		state.mode     = CP_NFlagNum;
+		state.val_max  = 0;
+		state.val_min  = 63;
 		break;
 
 		// X and Escape leave
 	case SDLK_ESCAPE:
-		input[0] = command;
+		state.input[0] = state.command;
 		return false;
 
 		// Unknown
 	default:
-		command = 0;
+		state.command = 0;
 		break;
 	}
 
@@ -2494,26 +2719,16 @@ bool CheatScreen::FlagCheck(
 void CheatScreen::BusinessLoop(Actor* actor) {
 	bool looping = true;
 
-	// This is for the prompt message
-	Cheat_Prompt mode = CP_Command;
+	int time = 0;
+	int prev = 0;
 
-	// This is the command
-	char input[17];
-	int  i;
-	int  command;
-	bool activate = false;
-	int  time     = 0;
-	int  prev     = 0;
-
-	for (i = 0; i < 17; i++) {
-		input[i] = 0;
-	}
-
+	ClearState clear(state);
 	while (looping) {
+		hotspots.clear();
 		gwin->clear_screen();
 
 		// First the display
-		if (mode == CP_Activity) {
+		if (state.mode == CP_Activity) {
 			ActivityDisplay();
 		} else {
 			BusinessDisplay(actor);
@@ -2523,21 +2738,20 @@ void CheatScreen::BusinessLoop(Actor* actor) {
 		BusinessMenu(actor);
 
 		// Finally the Prompt...
-		SharedPrompt(input, mode);
+		SharedPrompt();
 
 		// Draw it!
-		gwin->get_win()->show();
+		EndFrame();
 
 		// Check to see if we need to change menus
-		if (activate) {
-			BusinessActivate(input, command, mode, actor, time, prev);
-			activate = false;
+		if (state.activate) {
+			BusinessActivate(actor, time, prev);
+			state.activate = false;
 			continue;
 		}
 
-		if (SharedInput(input, 17, command, mode, activate)) {
-			looping = BusinessCheck(
-					input, command, mode, activate, actor, time);
+		if (SharedInput()) {
+			looping = BusinessCheck(actor, time);
 		}
 	}
 }
@@ -2545,7 +2759,7 @@ void CheatScreen::BusinessLoop(Actor* actor) {
 void CheatScreen::BusinessDisplay(Actor* actor) {
 	char             buf[512];
 	const Tile_coord t = actor->get_tile();
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx  = 10;
 	const int offsety1 = 20;
 	const int offsetx2 = 171;
@@ -2569,7 +2783,7 @@ void CheatScreen::BusinessDisplay(Actor* actor) {
 	snprintf(buf, sizeof(buf), "Loc (%04i, %04i, %02i)", t.tx, t.ty, t.tz);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, 8, 8);
 
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const char activity_msg[] = "%2i %s";
 #else
 	const char activity_msg[] = "Current Activity:  %2i - %s";
@@ -2579,17 +2793,16 @@ void CheatScreen::BusinessDisplay(Actor* actor) {
 			schedules[actor->get_schedule_type()]);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx2, offsety3, 8);
 
-	// Avatar can't have schedules
-	if (actor->get_npc_num() > 0) {
+	Schedule_change* scheds;
+	int              num;
+	actor->get_schedules(scheds, num);
+
+	if (num) {
 		font->paint_text_fixedwidth(ibuf, "Schedules:", offsetx2, offsety2, 8);
 
-		Schedule_change* scheds;
-		int              num;
-		int              types[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
-		int              x[8];
-		int              y[8];
-
-		actor->get_schedules(scheds, num);
+		int types[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
+		int x[8]     = {0};
+		int y[8]     = {0};
 
 		for (int i = 0; i < num; i++) {
 			const int time        = scheds[i].get_time();
@@ -2621,63 +2834,70 @@ void CheatScreen::BusinessDisplay(Actor* actor) {
 }
 
 void CheatScreen::BusinessMenu(Actor* actor) {
+	char buf[64];
 	// Left Column
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx = 10;
+	const int offsety = 0;
 #else
 	const int offsetx = 0;
+	const int offsety = 4;
 #endif
+	int nextx;
 	// Might break on monster npcs?
-	if (actor->get_npc_num() > 0) {
-		font->paint_text_fixedwidth(
-				ibuf, "12 AM: [A] Set [I] Location [1] Clear", offsetx,
-				maxy - 96, 8);
-		font->paint_text_fixedwidth(
-				ibuf, " 3 AM: [B] Set [J] Location [2] Clear", offsetx,
-				maxy - 88, 8);
-		font->paint_text_fixedwidth(
-				ibuf, " 6 AM: [C] Set [K] Location [3] Clear", offsetx,
-				maxy - 80, 8);
-		font->paint_text_fixedwidth(
-				ibuf, " 9 AM: [D] Set [L] Location [4] Clear", offsetx,
-				maxy - 72, 8);
-		font->paint_text_fixedwidth(
-				ibuf, "12 PM: [E] Set [M] Location [5] Clear", offsetx,
-				maxy - 64, 8);
-		font->paint_text_fixedwidth(
-				ibuf, " 3 PM: [F] Set [N] Location [6] Clear", offsetx,
-				maxy - 56, 8);
-		font->paint_text_fixedwidth(
-				ibuf, " 6 PM: [G] Set [O] Location [7] Clear", offsetx,
-				maxy - 48, 8);
-		font->paint_text_fixedwidth(
-				ibuf, " 9 PM: [H] Set [P] Location [8] Clear", offsetx,
-				maxy - 40, 8);
+	if (actor->get_npc_num() > 0 && !actor->is_monster()) {
+		for (int h = 0; h < 24; h += 3) {
+			int row = h / 3;
+			int h12 = h % 12;
+			h12     = h12 ? h12 : 12;
+			int y   = 96 - row * 8;
+			snprintf(buf, sizeof(buf), "%2i %cM:", h12, h / 12 ? 'P' : 'A');
+			nextx = offsetx;
+			nextx += 8
+					 + font->paint_text_fixedwidth(
+							 ibuf, buf, nextx, maxy - offsety - y, 8);
+			nextx += 8
+					 + AddMenuItem(
+							 nextx, maxy - offsety - y,
+							 SDL_KeyCode(SDLK_a + row), " Set");
+			nextx += 8
+					 + AddMenuItem(
+							 nextx, maxy - offsety - y,
+							 SDL_KeyCode(SDLK_i + row), " Location");
+			AddMenuItem(
+					nextx, maxy - offsety - y, SDL_KeyCode(SDLK_1 + row),
+					" Clear");
+		}
+		nextx = offsetx;
+		nextx += 8
+				 + AddMenuItem(
+						 nextx, maxy - offsety - 32, SDLK_s,
+						 "et Current Activity");
 
-		font->paint_text_fixedwidth(
-				ibuf, "[S]et Current Activity [ESC] [R]evert", offsetx,
-				maxy - 30, 8);
+		AddMenuItem(nextx, maxy - offsety - 32, SDLK_r, "evert");
+
 	} else {
-		font->paint_text_fixedwidth(
-				ibuf, "[S]et Current Activity [ESC]", offsetx, maxy - 30, 8);
+		AddMenuItem(
+				offsetx, maxy - offsety - 96, SDLK_s, "et Current Activity");
 	}
+	SharedMenu();
 }
 
-void CheatScreen::BusinessActivate(
-		char* input, int& command, Cheat_Prompt& mode, Actor* actor, int& time,
-		int& prev) {
-	int i = std::atoi(input);
+void CheatScreen::BusinessActivate(Actor* actor, int& time, int& prev) {
+	int i = std::atoi(state.input);
 
-	mode          = CP_Command;
-	const int old = command;
-	command       = 0;
+	state.mode    = CP_Command;
+	const int old = state.command;
+	state.command = 0;
 	switch (old) {
 	case 'a':    // Set Activity
 		if (i < 0 || i > 31) {
-			mode = CP_InvalidValue;
-		} else if (!input[0]) {
-			mode    = CP_Activity;
-			command = 'a';
+			state.mode = CP_InvalidValue;
+		} else if (!state.input[0]) {
+			state.mode    = CP_Activity;
+			state.val_min = 0;
+			state.val_max = 31;
+			state.command = 'a';
 		} else {
 			actor->set_schedule_time_type(time, i);
 		}
@@ -2685,23 +2905,29 @@ void CheatScreen::BusinessActivate(
 
 	case 'i':    // X Coord
 		if (i < 0 || i > c_num_tiles) {
-			mode = CP_InvalidValue;
-		} else if (!input[0]) {
-			mode    = CP_XCoord;
-			command = 'i';
+			state.mode = CP_InvalidValue;
+		} else if (!state.input[0]) {
+			state.mode    = CP_XCoord;
+			state.val_min = 0;
+			state.val_max = c_num_tiles;
+			state.command = 'i';
 		} else {
-			prev    = i;
-			mode    = CP_YCoord;
-			command = 'j';
+			prev          = i;
+			state.mode    = CP_YCoord;
+			state.val_min = 0;
+			state.val_max = c_num_tiles;
+			state.command = 'j';
 		}
 		break;
 
 	case 'j':    // Y Coord
 		if (i < 0 || i > c_num_tiles) {
-			mode = CP_InvalidValue;
-		} else if (!input[0]) {
-			mode    = CP_YCoord;
-			command = 'j';
+			state.mode = CP_InvalidValue;
+		} else if (!state.input[0]) {
+			state.mode    = CP_YCoord;
+			state.val_min = 0;
+			state.val_max = c_num_tiles;
+			state.command = 'j';
 		} else {
 			actor->set_schedule_time_location(time, prev, i);
 		}
@@ -2713,10 +2939,12 @@ void CheatScreen::BusinessActivate(
 
 	case 's':    // Set Current
 		if (i < 0 || i > 31) {
-			mode = CP_InvalidValue;
-		} else if (!input[0]) {
-			mode    = CP_Activity;
-			command = 's';
+			state.mode = CP_InvalidValue;
+		} else if (!state.input[0]) {
+			state.mode    = CP_Activity;
+			state.val_min = 0;
+			state.val_max = 31;
+			state.command = 's';
 		} else {
 			actor->set_schedule_type(i);
 		}
@@ -2730,17 +2958,15 @@ void CheatScreen::BusinessActivate(
 		break;
 	}
 	for (i = 0; i < 17; i++) {
-		input[i] = 0;
+		state.input[i] = 0;
 	}
 }
 
-// Checks the input
-bool CheatScreen::BusinessCheck(
-		char* input, int& command, Cheat_Prompt& mode, bool& activate,
-		Actor* actor, int& time) {
+// Checks the state.input
+bool CheatScreen::BusinessCheck(Actor* actor, int& time) {
 	// Might break on monster npcs?
 	if (actor->get_npc_num() > 0) {
-		switch (command) {
+		switch (state.command) {
 		case 'a':
 		case 'b':
 		case 'c':
@@ -2749,9 +2975,11 @@ bool CheatScreen::BusinessCheck(
 		case 'f':
 		case 'g':
 		case 'h':
-			time    = command - 'a';
-			command = 'a';
-			mode    = CP_Activity;
+			time          = state.command - 'a';
+			state.command = 'a';
+			state.mode    = CP_Activity;
+			state.val_min = 0;
+			state.val_max = 31;
 			return true;
 
 		case 'i':
@@ -2762,9 +2990,11 @@ bool CheatScreen::BusinessCheck(
 		case 'n':
 		case 'o':
 		case 'p':
-			time    = command - 'i';
-			command = 'i';
-			mode    = CP_XCoord;
+			time          = state.command - 'i';
+			state.command = 'i';
+			state.mode    = CP_XCoord;
+			state.val_min = 0;
+			state.val_max = c_num_tiles;
 			return true;
 
 		case '1':
@@ -2775,14 +3005,14 @@ bool CheatScreen::BusinessCheck(
 		case '6':
 		case '7':
 		case '8':
-			time     = command - '1';
-			command  = '1';
-			activate = true;
+			time           = state.command - '1';
+			state.command  = '1';
+			state.activate = true;
 			return true;
 
 		case 'r':
-			command  = 'r';
-			activate = true;
+			state.command  = 'r';
+			state.activate = true;
 			return true;
 
 		default:
@@ -2790,23 +3020,25 @@ bool CheatScreen::BusinessCheck(
 		}
 	}
 
-	switch (command) {
+	switch (state.command) {
 		// Set Current
 	case 's':
-		command  = 's';
-		input[0] = 0;
-		mode     = CP_Activity;
+		state.command  = 's';
+		state.input[0] = 0;
+		state.mode     = CP_Activity;
+		state.val_min  = 0;
+		state.val_max  = 31;
 		break;
 
 		// X and Escape leave
 	case SDLK_ESCAPE:
-		input[0] = command;
+		state.input[0] = state.command;
 		return false;
 
 		// Unknown
 	default:
-		command = 0;
-		mode    = CP_InvalidCom;
+		state.command = 0;
+		state.mode    = CP_InvalidCom;
 		break;
 	}
 
@@ -2818,28 +3050,17 @@ bool CheatScreen::BusinessCheck(
 //
 
 void CheatScreen::StatLoop(Actor* actor) {
-#if !defined(__IPHONEOS__) && !defined(ANDROID)
+#if !defined(__IPHONEOS__) && !defined(ANDROID) && !defined(TEST_MOBILE)
 	int num = actor->get_npc_num();
 #endif
 	bool looping = true;
 
-	// This is for the prompt message
-	Cheat_Prompt mode = CP_Command;
-
-	// This is the command
-	char input[17];
-	int  i;
-	int  command;
-	bool activate = false;
-
-	for (i = 0; i < 17; i++) {
-		input[i] = 0;
-	}
-
+	ClearState clear(state);
 	while (looping) {
+		hotspots.clear();
 		gwin->clear_screen();
 
-#if !defined(__IPHONEOS__) && !defined(ANDROID)
+#if !defined(__IPHONEOS__) && !defined(ANDROID) && !defined(TEST_MOBILE)
 		// First the display
 		NPCDisplay(actor, num);
 #endif
@@ -2848,27 +3069,27 @@ void CheatScreen::StatLoop(Actor* actor) {
 		StatMenu(actor);
 
 		// Finally the Prompt...
-		SharedPrompt(input, mode);
+		SharedPrompt();
 
 		// Draw it!
-		gwin->get_win()->show();
+		EndFrame();
 
 		// Check to see if we need to change menus
-		if (activate) {
-			StatActivate(input, command, mode, actor);
-			activate = false;
+		if (state.activate) {
+			StatActivate(actor);
+			state.activate = false;
 			continue;
 		}
 
-		if (SharedInput(input, 17, command, mode, activate)) {
-			looping = StatCheck(input, command, mode, activate, actor);
+		if (SharedInput()) {
+			looping = StatCheck(actor);
 		}
 	}
 }
 
 void CheatScreen::StatMenu(Actor* actor) {
 	char buf[512];
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx  = 15;
 	const int offsety1 = 92;
 #else
@@ -2880,71 +3101,68 @@ void CheatScreen::StatMenu(Actor* actor) {
 
 	// Dexterity
 	snprintf(
-			buf, sizeof(buf), "[D]exterity....%3i",
+			buf, sizeof(buf), "exterity....%3i",
 			actor->get_property(Actor::dexterity));
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 108, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 108, SDLK_d, buf);
 
 	// Food Level
 	snprintf(
-			buf, sizeof(buf), "[F]ood Level...%3i",
+			buf, sizeof(buf), "ood Level...%3i",
 			actor->get_property(Actor::food_level));
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 99, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 99, SDLK_f, buf);
 
 	// Intelligence
 	snprintf(
-			buf, sizeof(buf), "[I]ntellicence.%3i",
+			buf, sizeof(buf), "ntellicence.%3i",
 			actor->get_property(Actor::intelligence));
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 90, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 90, SDLK_i, buf);
 
 	// Strength
 	snprintf(
-			buf, sizeof(buf), "[S]trength.....%3i",
+			buf, sizeof(buf), "trength.....%3i",
 			actor->get_property(Actor::strength));
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 81, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 81, SDLK_s, buf);
 
 	// Combat Skill
 	snprintf(
-			buf, sizeof(buf), "[C]ombat Skill.%3i",
+			buf, sizeof(buf), "ombat Skill.%3i",
 			actor->get_property(Actor::combat));
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 72, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 72, SDLK_c, buf);
 
 	// Hit Points
 	snprintf(
-			buf, sizeof(buf), "[H]it Points...%3i",
+			buf, sizeof(buf), "it Points...%3i",
 			actor->get_property(Actor::health));
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 63, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 63, SDLK_h, buf);
 
 	// Magic
 	// Magic Points
 	snprintf(
-			buf, sizeof(buf), "[M]agic Points.%3i",
+			buf, sizeof(buf), "agic Points.%3i",
 			actor->get_property(Actor::magic));
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 54, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 54, SDLK_m, buf);
 
 	// Mana
 	snprintf(
-			buf, sizeof(buf), "[V]ana Level...%3i",
+			buf, sizeof(buf), "ana Level...%3i",
 			actor->get_property(Actor::mana));
-	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 45, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 45, SDLK_v, buf);
 
-	// Exit
-	font->paint_text_fixedwidth(
-			ibuf, "[ESC] Exit", offsetx, maxy - offsety1 - 36, 8);
+	SharedMenu();
 }
 
-void CheatScreen::StatActivate(
-		char* input, int& command, Cheat_Prompt& mode, Actor* actor) {
-	int i = std::atoi(input);
-	mode  = CP_Command;
+void CheatScreen::StatActivate(Actor* actor) {
+	int i      = std::atoi(state.input);
+	state.mode = CP_Command;
 	// Enforce sane bounds.
 	if (i > 60) {
 		i = 60;
-	} else if (i < 0 && command != 'h') {
+	} else if (i < 0 && state.command != 'h') {
 		if (i == -1) {    // canceled
 			for (i = 0; i < 17; i++) {
-				input[i] = 0;
+				state.input[i] = 0;
 			}
-			command = 0;
+			state.command = 0;
 			return;
 		}
 		i = 0;
@@ -2952,7 +3170,7 @@ void CheatScreen::StatActivate(
 		i = -50;
 	}
 
-	switch (command) {
+	switch (state.command) {
 	case 'd':    // Dexterity
 		actor->set_property(Actor::dexterity, i);
 		break;
@@ -2989,21 +3207,23 @@ void CheatScreen::StatActivate(
 		break;
 	}
 	for (i = 0; i < 17; i++) {
-		input[i] = 0;
+		state.input[i] = 0;
 	}
-	command = 0;
+	state.command = 0;
 }
 
-// Checks the input
-bool CheatScreen::StatCheck(
-		char* input, int& command, Cheat_Prompt& mode, bool& activate,
-		Actor* actor) {
-	ignore_unused_variable_warning(activate, actor);
-	switch (command) {
+// Checks the state.input
+bool CheatScreen::StatCheck(Actor* actor) {
+	ignore_unused_variable_warning(state.activate, actor);
+
+	switch (state.command) {
 		// Everyone
 	case 'h':    // Hit Points
-		input[0] = 0;
-		mode     = CP_EnterValueNoCancel;
+		state.input[0] = 0;
+		state.mode     = CP_EnterValueNoCancel;
+		state.val_min  = 0;
+		state.val_max  = actor->get_property(Actor::strength);
+		;
 		break;
 	case 'd':    // Dexterity
 	case 'f':    // Food Level
@@ -3012,18 +3232,20 @@ bool CheatScreen::StatCheck(
 	case 'c':    // Combat Points
 	case 'm':    // Magic
 	case 'v':    // [V]ana
-		input[0] = 0;
-		mode     = CP_EnterValue;
+		state.input[0] = 0;
+		state.mode     = CP_EnterValue;
+		state.val_min  = 0;
+		state.val_max  = 255;
 		break;
 
 		// X and Escape leave
 	case SDLK_ESCAPE:
-		input[0] = command;
+		state.input[0] = state.command;
 		return false;
 
 		// Unknown
 	default:
-		command = 0;
+		state.command = 0;
 		break;
 	}
 
@@ -3035,64 +3257,53 @@ bool CheatScreen::StatCheck(
 //
 
 void CheatScreen::PalEffectLoop(Actor* actor) {
-#if !defined(__IPHONEOS__) && !defined(ANDROID)
+#if !defined(__IPHONEOS__) && !defined(ANDROID) && !defined(TEST_MOBILE)
 	int num = actor->get_npc_num();
 #endif
 	bool looping = true;
 
-	// This is for the prompt message
-	Cheat_Prompt mode = CP_Command;
-
-	// This is the command
-	char input[17];
-	int  i;
-	int  command  = 0;
-	bool activate = false;
-
-	for (i = 0; i < 17; i++) {
-		input[i] = 0;
-	}
-
+	ClearState clear(state);
 	while (looping) {
+		hotspots.clear();
 		gwin->clear_screen();
 
-#if !defined(__IPHONEOS__) && !defined(ANDROID)
+#if !defined(__IPHONEOS__) && !defined(ANDROID) && !defined(TEST_MOBILE)
 		// First the display
 		NPCDisplay(actor, num);
 #endif
 
 		// Now the Menu Column
-		PalEffectMenu(actor, command);
+		PalEffectMenu(actor);
 
 		// Finally the Prompt...
-		SharedPrompt(input, mode);
+		SharedPrompt();
 
 		// Draw it!
-		gwin->get_win()->show();
+		EndFrame();
 
 		// Check to see if we need to change menus
-		if (activate) {
-			PalEffectActivate(input, command, mode, actor);
-			activate = false;
+		if (state.activate) {
+			PalEffectActivate(actor);
+			state.activate = false;
 			continue;
 		}
 
-		if (SharedInput(input, 17, command, mode, activate)) {
-			looping = PalEffectCheck(input, command, mode, activate, actor);
+		if (SharedInput()) {
+			looping = PalEffectCheck(actor);
 		}
 	}
 }
 
-void CheatScreen::PalEffectMenu(Actor* actor, int command) {
+void CheatScreen::PalEffectMenu(Actor* actor) {
 	char buf[512];
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx  = 15;
 	const int offsety1 = 81;
-	const int offsety2 = 72;
+	// const int offsety2 = 72;
 #else
 	const int offsetx  = 0;
 	const int offsety1 = 0;
-	const int offsety2 = maxy - 36;
+	// const int offsety2 = maxy - 36;
 
 #endif
 	int pt = actor->get_palette_transform();
@@ -3115,11 +3326,11 @@ void CheatScreen::PalEffectMenu(Actor* actor, int command) {
 	}
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, maxy - offsety1 - 119, 8);
 
-	if (command == 't') {
-		if (saved_value == 255) {
+	if (state.command == 't') {
+		if (state.saved_value == 255) {
 			snprintf(buf, sizeof(buf), "From Ramp: All");
 		} else {
-			snprintf(buf, sizeof(buf), "From Ramp: %i", saved_value & 31);
+			snprintf(buf, sizeof(buf), "From Ramp: %i", state.saved_value & 31);
 		}
 
 		font->paint_text_fixedwidth(
@@ -3129,40 +3340,31 @@ void CheatScreen::PalEffectMenu(Actor* actor, int command) {
 	// Left Column
 
 	// ramp remap
-	font->paint_text_fixedwidth(
-			ibuf, "[R]amp Remap", offsetx, maxy - offsety1 - 99, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 99, SDLK_r, "amp Remap");
 
 	// xform
-	font->paint_text_fixedwidth(
-			ibuf, "[X]form.", offsetx, maxy - offsety1 - 90, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 90, SDLK_x, "form");
 
 	// Shift
-	font->paint_text_fixedwidth(
-			ibuf, "[S]hift", offsetx, maxy - offsety1 - 81, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 81, SDLK_s, "hift");
 
 	// clear
-	font->paint_text_fixedwidth(
-			ibuf, "[C]lear", offsetx, maxy - offsety1 - 72, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 72, SDLK_c, "lear");
 
-	// Exit
-	font->paint_text_fixedwidth(ibuf, "[ESC] Exit", offsetx, offsety2, 8);
+	SharedMenu();
 }
 
-void CheatScreen::PalEffectActivate(
-		char* input, int& command, Cheat_Prompt& mode, Actor* actor) {
-	int   i = std::atoi(input);
+void CheatScreen::PalEffectActivate(Actor* actor) {
+	int   i = std::atoi(state.input);
 	char* end;
-	auto  u = std::strtoul(input, &end, 10);
-	mode    = CP_Command;
-	for (int ii = 0; ii < 17; ii++) {
-		input[ii] = 0;    // Enforce sane bounds.
-	}
+	auto  u    = std::strtoul(state.input, &end, 10);
+	state.mode = CP_Command;
 
-	switch (command) {
+	switch (state.command) {
 	case 'x':    // XForm
 		actor->set_palette_transform(
 				ShapeID::PT_xForm
-				| i % Shape_manager::get_instance()->get_xforms_cnt());
+				| i % int(Shape_manager::get_instance()->get_xforms_cnt()));
 		break;
 
 	case 'f':    // from Ramp
@@ -3171,18 +3373,23 @@ void CheatScreen::PalEffectActivate(
 		static char  staticPrompttext[sizeof(prompttext) + 16];
 		unsigned int numramps = 0;
 		gwin->get_pal()->get_ramps(numramps);
+		if (numramps) {
+			numramps--;
+		}
 		if (u >= numramps && u != 255) {
-			mode = CP_InvalidValue;
+			state.mode = CP_InvalidValue;
 			break;
 		}
 		std::snprintf(
 				staticPrompttext, sizeof(staticPrompttext), prompttext,
 				numramps);
-		input[0]      = 0;
-		custom_prompt = staticPrompttext;
-		mode          = CP_CustomValue;
-		command       = 't';
-		saved_value   = i;
+		state.input[0]      = 0;
+		state.custom_prompt = staticPrompttext;
+		state.mode          = CP_CustomValue;
+		state.command       = 't';
+		state.saved_value   = i;
+		state.val_min       = 0;
+		state.val_max       = int(numramps);
 		return;
 	}
 
@@ -3191,16 +3398,16 @@ void CheatScreen::PalEffectActivate(
 		unsigned int numramps = 0;
 		gwin->get_pal()->get_ramps(numramps);
 		if (u >= numramps) {
-			mode = CP_InvalidValue;
+			state.mode = CP_InvalidValue;
 			break;
 		}
-		if (saved_value == 255) {
+		if (state.saved_value == 255) {
 			actor->set_palette_transform(
 					ShapeID::PT_RampRemapAllFrom | (i & 31));
 		} else {
 			actor->set_palette_transform(
 					ShapeID::PT_RampRemap | (i & 31)
-					| ((saved_value & 0xff) << 5));
+					| ((state.saved_value & 0xff) << 5));
 		}
 	} break;
 
@@ -3215,15 +3422,14 @@ void CheatScreen::PalEffectActivate(
 	default:
 		break;
 	}
-	command = 0;
+	ClearState clear(state, false, true);
+	state.command = 0;
 }
 
-// Checks the input
-bool CheatScreen::PalEffectCheck(
-		char* input, int& command, Cheat_Prompt& mode, bool& activate,
-		Actor* actor) {
-	ignore_unused_variable_warning(activate, actor);
-	switch (command) {
+// Checks the state.input
+bool CheatScreen::PalEffectCheck(Actor* actor) {
+	ignore_unused_variable_warning(state.activate, actor);
+	switch (state.command) {
 	case 'r':    // [R]amp Remap
 	{
 		const char   prompttext[] = "enter From Ramp (0-%i) or 255 for all";
@@ -3236,48 +3442,54 @@ bool CheatScreen::PalEffectCheck(
 		std::snprintf(
 				staticPrompttext, sizeof(staticPrompttext), prompttext,
 				numramps);
-		input[0]      = 0;
-		custom_prompt = staticPrompttext;
-		mode          = CP_CustomValue;
-		command       = 'f';
+		state.input[0]      = 0;
+		state.custom_prompt = staticPrompttext;
+		state.mode          = CP_CustomValue;
+		state.command       = 'f';
+		state.val_min       = 0;
+		state.val_max       = 255;
 	} break;
 
 	case 'x':    // [X]Form
 	{
 		const char  prompttext[] = "enter XFORM Index (0-%i)";
 		static char staticPrompttext[sizeof(prompttext) + 16];
-		int         numxforms = Shape_manager::get_instance()->get_xforms_cnt();
+		auto        numxforms = Shape_manager::get_instance()->get_xforms_cnt();
 		if (numxforms) {
 			numxforms--;
 		}
 		std::snprintf(
 				staticPrompttext, sizeof(staticPrompttext), prompttext,
 				numxforms);
-		input[0]      = 0;
-		custom_prompt = staticPrompttext;
-		mode          = CP_CustomValue;
+		state.input[0]      = 0;
+		state.custom_prompt = staticPrompttext;
+		state.mode          = CP_CustomValue;
+		state.val_min       = 0;
+		state.val_max       = int(numxforms);
 	} break;
 
 	case 's':    // [S]hift
-		input[0]      = 0;
-		custom_prompt = "enter shift amount (0-255)";
-		mode          = CP_EnterValue;
+		state.input[0]      = 0;
+		state.custom_prompt = "enter shift amount (0-255)";
+		state.mode          = CP_EnterValue;
+		state.val_min       = 0;
+		state.val_max       = 255;
 		break;
 
 		// Escape leaves
 		// X and Escape leave
 	case SDLK_ESCAPE:
-		input[0] = command;
+		state.input[0] = state.command;
 		return false;
 
 		// clear
 	case 'c':
-		activate = true;
+		state.activate = true;
 		break;
 
 		// Unknown
 	default:
-		command = 0;
+		state.command = 0;
 		break;
 	}
 
@@ -3289,35 +3501,25 @@ bool CheatScreen::PalEffectCheck(
 //
 
 CheatScreen::Cheat_Prompt CheatScreen::AdvancedFlagLoop(int num, Actor* actor) {
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx  = 15;
 	const int offsety1 = 83;
-	const int offsety2 = 72;
+	// const int offsety2 = 72;
 #else
 	int       npc_num  = actor->get_npc_num();
 	const int offsetx  = 0;
 	const int offsety1 = 0;
-	const int offsety2 = maxy - 36;
+	// const int offsety2 = maxy - 36;
 #endif
 	bool looping = true;
-	// This is for the prompt message
-	Cheat_Prompt mode = CP_Command;
+	char buf[64];
 
-	// This is the command
-	char input[17];
-	int  i;
-	int  command;
-	bool activate = false;
-	char buf[512];
-
-	for (i = 0; i < 17; i++) {
-		input[i] = 0;
-	}
-
+	ClearState clear(state);
 	while (looping) {
+		hotspots.clear();
 		gwin->clear_screen();
 
-#if !defined(__IPHONEOS__) && !defined(ANDROID)
+#if !defined(__IPHONEOS__) && !defined(ANDROID) && !defined(TEST_MOBILE)
 		NPCDisplay(actor, npc_num);
 #endif
 
@@ -3344,70 +3546,54 @@ CheatScreen::Cheat_Prompt CheatScreen::AdvancedFlagLoop(int num, Actor* actor) {
 
 		// Now the Menu Column
 		if (!actor->get_flag(num)) {
-			font->paint_text_fixedwidth(
-					ibuf, "[S]et Flag", offsetx + 160, maxy - offsety1 - 90, 8);
+			AddMenuItem(offsetx + 160, maxy - offsety1 - 90, SDLK_s, "et Flag");
 		} else {
-			font->paint_text_fixedwidth(
-					ibuf, "[U]nset Flag", offsetx + 160, maxy - offsety1 - 90,
-					8);
+			AddMenuItem(
+					offsetx + 160, maxy - offsety1 - 90, SDLK_u, "nset Flag");
 		}
 
 		// Change Flag
-		PaintArrow(offsetx + 8, maxy - offsety1 - 72, '^');
-		font->paint_text_fixedwidth(
-				ibuf, "[ ] Change Flag", offsetx, maxy - offsety1 - 72, 8);
-		if (num > 0 && num < 63) {
-			PaintArrow(offsetx + 8, maxy - offsety1 - 63, '<');
-			PaintArrow(offsetx + 17, maxy - offsety1 - 63, '>');
+		AddMenuItem(offsetx, maxy - offsety1 - 72, SDLK_UP, " Change Flag");
 
-			font->paint_text_fixedwidth(
-					ibuf, "[  ] Scroll Flags", offsetx, maxy - offsety1 - 63,
-					8);
-		} else if (num == 0) {
-			PaintArrow(offsetx + 8, maxy - offsety1 - 63, '>');
-			font->paint_text_fixedwidth(
-					ibuf, "[ ] Scroll Flags", offsetx, maxy - offsety1 - 63, 8);
-		} else {
-			PaintArrow(offsetx + 8, maxy - offsety1 - 63, '<');
-			font->paint_text_fixedwidth(
-					ibuf, "[ ] Scroll Flags", offsetx, maxy - offsety1 - 63, 8);
-		}
+		AddLeftRightMenuItem(
+				offsetx, maxy - offsety1 - 63, "Scroll Flags", num > 0,
+				num < 63, false, true);
 
-		font->paint_text_fixedwidth(ibuf, "[ESC] Exit", offsetx, offsety2, 8);
+		SharedMenu();
 
 		// Finally the Prompt...
-		SharedPrompt(input, mode);
+		SharedPrompt();
 
 		// Draw it!
-		gwin->get_win()->show();
+		EndFrame();
 
 		// Check to see if we need to change menus
-		if (activate) {
-			mode = CP_Command;
-			if (command == '<') {    // Decrement
+		if (state.activate) {
+			state.mode = CP_Command;
+			if (state.command == '<') {    // Decrement
 				num--;
 				if (num < 0) {
 					num = 0;
 				}
-			} else if (command == '>') {    // Increment
+			} else if (state.command == '>') {    // Increment
 				num++;
 				if (num > 63) {
 					num = 63;
 				}
-			} else if (command == '^') {    // Change Flag
-				i = std::atoi(input);
+			} else if (state.command == '^') {    // Change Flag
+				int i = std::atoi(state.input);
 				if (i < 0 || i > 63) {
-					mode = CP_InvalidValue;
-				} else if (input[0]) {
+					state.mode = CP_InvalidValue;
+				} else if (state.input[0]) {
 					num = i;
 				}
-			} else if (command == 's') {    // Set
+			} else if (state.command == 's') {    // Set
 				actor->set_flag(num);
 				if (num == Obj_flags::in_party) {
 					gwin->get_party_man()->add_to_party(actor);
 					actor->set_schedule_type(Schedule::follow_avatar);
 				}
-			} else if (command == 'u') {    // Unset
+			} else if (state.command == 'u') {    // Unset
 				if (num == Obj_flags::in_party) {
 					gwin->get_party_man()->remove_from_party(actor);
 					gwin->revert_schedules(actor);
@@ -3415,54 +3601,52 @@ CheatScreen::Cheat_Prompt CheatScreen::AdvancedFlagLoop(int num, Actor* actor) {
 				actor->clear_flag(num);
 			}
 
-			for (i = 0; i < 17; i++) {
-				input[i] = 0;
-			}
-			command  = 0;
-			activate = false;
+			ClearState clearer(state);
 			continue;
 		}
 
-		if (SharedInput(input, 17, command, mode, activate)) {
-			switch (command) {
+		if (SharedInput()) {
+			switch (state.command) {
 				// Simple commands
 			case 's':    // Set Flag
 			case 'u':    // Unset flag
-				input[0] = command;
-				activate = true;
+				state.input[0] = state.command;
+				state.activate = true;
 				break;
 
 				// Decrement
 			case SDLK_LEFT:
-				command  = '<';
-				input[0] = command;
-				activate = true;
+				state.command  = '<';
+				state.input[0] = state.command;
+				state.activate = true;
 				break;
 
 				// Increment
 			case SDLK_RIGHT:
-				command  = '>';
-				input[0] = command;
-				activate = true;
+				state.command  = '>';
+				state.input[0] = state.command;
+				state.activate = true;
 				break;
 
 				// * Change Flag
 			case SDLK_UP:
-				command  = '^';
-				input[0] = 0;
-				mode     = CP_NFlagNum;
+				state.command  = '^';
+				state.input[0] = 0;
+				state.mode     = CP_NFlagNum;
+				state.val_max  = 0;
+				state.val_min  = 63;
 				break;
 
 				// X and Escape leave
 			case SDLK_ESCAPE:
-				input[0] = command;
-				looping  = false;
+				state.input[0] = state.command;
+				looping        = false;
 				break;
 
 			default:
-				mode     = CP_InvalidCom;
-				input[0] = command;
-				command  = 0;
+				state.mode     = CP_InvalidCom;
+				state.input[0] = state.command;
+				state.command  = 0;
 				break;
 			}
 		}
@@ -3477,21 +3661,11 @@ CheatScreen::Cheat_Prompt CheatScreen::AdvancedFlagLoop(int num, Actor* actor) {
 void CheatScreen::TeleportLoop() {
 	bool looping = true;
 
-	// This is for the prompt message
-	Cheat_Prompt mode = CP_Command;
+	int prev = 0;
 
-	// This is the command
-	char input[5];
-	int  i;
-	int  command;
-	bool activate = false;
-	int  prev     = 0;
-
-	for (i = 0; i < 5; i++) {
-		input[i] = 0;
-	}
-
+	ClearState clear(state);
 	while (looping) {
+		hotspots.clear();
 		gwin->clear_screen();
 
 		// First the display
@@ -3501,20 +3675,20 @@ void CheatScreen::TeleportLoop() {
 		TeleportMenu();
 
 		// Finally the Prompt...
-		SharedPrompt(input, mode);
+		SharedPrompt();
 
 		// Draw it!
-		gwin->get_win()->show();
+		EndFrame();
 
 		// Check to see if we need to change menus
-		if (activate) {
-			TeleportActivate(input, command, mode, prev);
-			activate = false;
+		if (state.activate) {
+			TeleportActivate(prev);
+			state.activate = false;
 			continue;
 		}
 
-		if (SharedInput(input, 5, command, mode, activate)) {
-			looping = TeleportCheck(input, command, mode, activate);
+		if (SharedInput()) {
+			looping = TeleportCheck();
 		}
 	}
 }
@@ -3523,8 +3697,8 @@ void CheatScreen::TeleportDisplay() {
 	char             buf[512];
 	const Tile_coord t       = gwin->get_main_actor()->get_tile();
 	const int        curmap  = gwin->get_map()->get_num();
-	const int        highest = Find_highest_map();
-#if defined(__IPHONEOS__) || defined(ANDROID)
+	const int        highest = Get_highest_map();
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx  = 15;
 	const int offsety1 = 54;
 #else
@@ -3532,7 +3706,7 @@ void CheatScreen::TeleportDisplay() {
 	const int offsety1 = 0;
 #endif
 
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	font->paint_text_fixedwidth(
 			ibuf, "Teleport Menu - Dangerous!", offsetx, 0, 8);
 #else
@@ -3543,7 +3717,7 @@ void CheatScreen::TeleportDisplay() {
 
 	const int longi = ((t.tx - 0x3A5) / 10);
 	const int lati  = ((t.ty - 0x46E) / 10);
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	snprintf(
 			buf, sizeof(buf), "Coords %d %s %d %s, Map #%d of %d", abs(lati),
 			(lati < 0 ? "North" : "South"), abs(longi),
@@ -3567,126 +3741,135 @@ void CheatScreen::TeleportDisplay() {
 			t.tz);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, 81 - offsety1, 8);
 
-#if !defined(__IPHONEOS__) && !defined(ANDROID)
+#if !defined(__IPHONEOS__) && !defined(ANDROID) && !defined(TEST_MOBILE)
 	snprintf(buf, sizeof(buf), "On Map #%d of %d", curmap, highest);
 	font->paint_text_fixedwidth(ibuf, buf, offsetx, 90, 8);
 #endif
 }
 
 void CheatScreen::TeleportMenu() {
-#if defined(__IPHONEOS__) || defined(ANDROID)
+#if defined(__IPHONEOS__) || defined(ANDROID) || defined(TEST_MOBILE)
 	const int offsetx  = 15;
 	const int offsety1 = 64;
 	const int offsetx2 = 175;
 	const int offsety2 = 63;
-	const int offsety3 = 72;
+	// const int offsety3 = 72;
 #else
 	const int offsetx  = 0;
 	const int offsety1 = 0;
 	const int offsetx2 = offsetx;
 	const int offsety2 = maxy - 63;
-	const int offsety3 = maxy - 36;
+	// const int offsety3 = maxy - 36;
 #endif
 
 	// Left Column
 	// Geo
-	font->paint_text_fixedwidth(
-			ibuf, "[G]eographic Coordinates", offsetx, maxy - offsety1 - 99, 8);
-
+	AddMenuItem(offsetx, maxy - offsety1 - 99, SDLK_g, "eographic Coordinates");
 	// Hex
-	font->paint_text_fixedwidth(
-			ibuf, "[H]exadecimal Coordinates", offsetx, maxy - offsety1 - 90,
-			8);
+	AddMenuItem(
+			offsetx, maxy - offsety1 - 90, SDLK_h, "exadecimal Coordinates");
 
 	// Dec
-	font->paint_text_fixedwidth(
-			ibuf, "[D]ecimal Coordinates", offsetx, maxy - offsety1 - 81, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 81, SDLK_d, "ecimal Coordinates");
 
 	// NPC
-	font->paint_text_fixedwidth(
-			ibuf, "[N]PC Number", offsetx, maxy - offsety1 - 72, 8);
+	AddMenuItem(offsetx, maxy - offsety1 - 72, SDLK_n, "PC Number");
 
+	AddMenuItem(offsetx2, offsety2, SDLK_m, "ap Number");
 	// Map
-	font->paint_text_fixedwidth(ibuf, "[M]ap Number", offsetx2, offsety2, 8);
 
-	// eXit
-	font->paint_text_fixedwidth(ibuf, "[ESC] Exit", offsetx, offsety3, 8);
+	SharedMenu();
 }
 
-void CheatScreen::TeleportActivate(
-		char* input, int& command, Cheat_Prompt& mode, int& prev) {
-	int        i = std::atoi(input);
+void CheatScreen::TeleportActivate(int& prev) {
+	int        i = std::atoi(state.input);
 	static int lat;
 	Tile_coord t       = gwin->get_main_actor()->get_tile();
-	const int  highest = Find_highest_map();
+	const int  highest = Get_highest_map();
 
-	mode = CP_Command;
-	switch (command) {
+	state.mode = CP_Command;
+	switch (state.command) {
 	case 'g':    // North or South
-		if (!input[0]) {
-			mode    = CP_NorthSouth;
-			command = 'g';
-		} else if (input[0] == 'n' || input[0] == 's') {
-			prev = input[0];
+		if (!state.input[0]) {
+			state.mode    = CP_NorthSouth;
+			state.command = 'g';
+		} else if (state.input[0] == 'n' || state.input[0] == 's') {
+			prev = state.input[0];
 			if (prev == 'n') {
-				mode = CP_NLatitude;
+				state.mode    = CP_NLatitude;
+				state.val_max = 0;
+				state.val_min = 113;
 			} else {
-				mode = CP_SLatitude;
+				state.mode    = CP_SLatitude;
+				state.val_max = 0;
+				state.val_min = 193;
 			}
-			command = 'a';
+			state.command = 'a';
 		} else {
-			mode = CP_InvalidValue;
+			state.mode = CP_InvalidValue;
 		}
 		break;
 
 	case 'a':    // latitude
 		if (i < 0 || (prev == 'n' && i > 113) || (prev == 's' && i > 193)) {
-			mode = CP_InvalidValue;
-		} else if (!input[0]) {
+			state.mode = CP_InvalidValue;
+		} else if (!state.input[0]) {
 			if (prev == 'n') {
-				mode = CP_NLatitude;
+				state.mode    = CP_NLatitude;
+				state.val_max = 0;
+				state.val_min = 113;
 			} else {
-				mode = CP_SLatitude;
+				state.mode    = CP_SLatitude;
+				state.val_max = 0;
+				state.val_min = 193;
 			}
-			command = 'a';
+			state.command = 'a';
 		} else {
 			if (prev == 'n') {
 				lat = ((i * -10) + 0x46E);
 			} else {
 				lat = ((i * 10) + 0x46E);
 			}
-			mode    = CP_WestEast;
-			command = 'b';
+			state.mode    = CP_WestEast;
+			state.command = 'b';
 		}
 		break;
 
 	case 'b':    // West or East
-		if (!input[0]) {
-			mode    = CP_WestEast;
-			command = 'b';
-		} else if (input[0] == 'w' || input[0] == 'e') {
-			prev = input[0];
+		if (!state.input[0]) {
+			state.mode    = CP_WestEast;
+			state.command = 'b';
+		} else if (state.input[0] == 'w' || state.input[0] == 'e') {
+			prev = state.input[0];
 			if (prev == 'w') {
-				mode = CP_WLongitude;
+				state.mode    = CP_WLongitude;
+				state.val_max = 0;
+				state.val_min = 93;
 			} else {
-				mode = CP_ELongitude;
+				state.mode    = CP_ELongitude;
+				state.val_max = 0;
+				state.val_min = 213;
 			}
-			command = 'c';
+			state.command = 'c';
 		} else {
-			mode = CP_InvalidValue;
+			state.mode = CP_InvalidValue;
 		}
 		break;
 
 	case 'c':    // longitude
 		if (i < 0 || (prev == 'w' && i > 93) || (prev == 'e' && i > 213)) {
-			mode = CP_InvalidValue;
-		} else if (!input[0]) {
+			state.mode = CP_InvalidValue;
+		} else if (!state.input[0]) {
 			if (prev == 'w') {
-				mode = CP_WLongitude;
+				state.mode    = CP_WLongitude;
+				state.val_max = 0;
+				state.val_min = 93;
 			} else {
-				mode = CP_ELongitude;
+				state.mode    = CP_ELongitude;
+				state.val_max = 0;
+				state.val_min = 213;
 			}
-			command = 'c';
+			state.command = 'c';
 		} else {
 			if (prev == 'w') {
 				t.tx = ((i * -10) + 0x3A5);
@@ -3700,26 +3883,36 @@ void CheatScreen::TeleportActivate(
 		break;
 
 	case 'h':    // hex X coord
-		i = strtol(input, nullptr, 16);
+		i = strtol(state.input, nullptr, 16);
 		if (i < 0 || i > c_num_tiles) {
-			mode = CP_InvalidValue;
-		} else if (!input[0]) {
-			mode    = CP_HexXCoord;
-			command = 'h';
+			state.mode = CP_InvalidValue;
+		} else if (!state.input[0]) {
+			state.mode    = CP_HexXCoord;
+			state.val_min = 0;
+			state.val_max = c_num_tiles;
+			state.command = 'h';
 		} else {
-			prev    = i;
-			mode    = CP_HexYCoord;
-			command = 'i';
+			prev          = i;
+			state.mode    = CP_HexYCoord;
+			state.val_min = 0;
+			state.val_max = c_num_tiles;
+			state.val_min = 0;
+			state.val_max = c_num_tiles;
+			state.command = 'i';
 		}
+		state.val_max = 0;
+		state.val_min = c_num_tiles;
 		break;
 
 	case 'i':    // hex Y coord
-		i = strtol(input, nullptr, 16);
+		i = strtol(state.input, nullptr, 16);
 		if (i < 0 || i > c_num_tiles) {
-			mode = CP_InvalidValue;
-		} else if (!input[0]) {
-			mode    = CP_HexYCoord;
-			command = 'i';
+			state.mode = CP_InvalidValue;
+		} else if (!state.input[0]) {
+			state.mode    = CP_HexYCoord;
+			state.val_min = 0;
+			state.val_max = c_num_tiles;
+			state.command = 'i';
 		} else {
 			t.tx = prev;
 			t.ty = i;
@@ -3730,23 +3923,29 @@ void CheatScreen::TeleportActivate(
 
 	case 'd':    // dec X coord
 		if (i < 0 || i > c_num_tiles) {
-			mode = CP_InvalidValue;
-		} else if (!input[0]) {
-			mode    = CP_XCoord;
-			command = 'd';
+			state.mode = CP_InvalidValue;
+		} else if (!state.input[0]) {
+			state.mode    = CP_XCoord;
+			state.command = 'd';
+			state.val_min = 0;
+			state.val_max = c_num_tiles;
 		} else {
-			prev    = i;
-			mode    = CP_YCoord;
-			command = 'e';
+			prev          = i;
+			state.mode    = CP_YCoord;
+			state.command = 'e';
+			state.val_min = 0;
+			state.val_max = c_num_tiles;
 		}
 		break;
 
 	case 'e':    // dec Y coord
 		if (i < 0 || i > c_num_tiles) {
-			mode = CP_InvalidValue;
-		} else if (!input[0]) {
-			mode    = CP_YCoord;
-			command = 'e';
+			state.mode = CP_InvalidValue;
+		} else if (!state.input[0]) {
+			state.mode    = CP_YCoord;
+			state.val_min = 0;
+			state.val_max = c_num_tiles;
+			state.command = 'e';
 		} else {
 			t.tx = prev;
 			t.ty = i;
@@ -3757,7 +3956,7 @@ void CheatScreen::TeleportActivate(
 
 	case 'n':    // NPC
 		if (i < 0 || (i >= 356 && i <= 359)) {
-			mode = CP_InvalidNPC;
+			state.mode = CP_InvalidNPC;
 		} else {
 			Actor* actor = gwin->get_npc(i);
 			Game_window::get_instance()->teleport_party(
@@ -3767,7 +3966,7 @@ void CheatScreen::TeleportActivate(
 
 	case 'm':    // map
 		if ((i < 0 || i > 255) || i > highest) {
-			mode = CP_InvalidValue;
+			state.mode = CP_InvalidValue;
 		} else {
 			gwin->teleport_party(gwin->get_main_actor()->get_tile(), true, i);
 		}
@@ -3777,46 +3976,142 @@ void CheatScreen::TeleportActivate(
 		break;
 	}
 	for (i = 0; i < 5; i++) {
-		input[i] = 0;
+		state.input[i] = 0;
 	}
 }
 
-// Checks the input
-bool CheatScreen::TeleportCheck(
-		char* input, int& command, Cheat_Prompt& mode, bool& activate) {
-	ignore_unused_variable_warning(activate);
-	switch (command) {
+// Checks the state.input
+bool CheatScreen::TeleportCheck() {
+	ignore_unused_variable_warning(state.activate);
+	switch (state.command) {
 		// Simple commands
 	case 'g':    // geographic
-		mode = CP_NorthSouth;
+		state.mode = CP_NorthSouth;
 		return true;
 
 	case 'h':    // hex
-		mode = CP_HexXCoord;
+		state.mode    = CP_HexXCoord;
+		state.val_min = 0;
+		state.val_max = c_num_tiles;
 		return true;
 
 	case 'd':    // dec teleport
-		mode = CP_XCoord;
+		state.mode    = CP_XCoord;
+		state.val_min = 0;
+		state.val_max = c_num_tiles;
 		return true;
 
 	case 'n':    // NPC teleport
-		mode = CP_ChooseNPC;
+		state.mode = CP_ChooseNPC;
 		break;
 
 	case 'm':    // NPC teleport
-		mode = CP_EnterValue;
+		state.mode    = CP_EnterValue;
+		state.val_min = 0;
+		state.val_max = gwin->get_num_npcs() - 1;
 		break;
 
 		// X and Escape leave
 	case SDLK_ESCAPE:
-		input[0] = command;
+		state.input[0] = state.command;
 		return false;
 
 	default:
-		command = 0;
-		mode    = CP_InvalidCom;
+		state.command = 0;
+		state.mode    = CP_InvalidCom;
 		break;
 	}
 
 	return true;
+}
+
+int CheatScreen::AddMenuItem(
+		int offsetx, int offsety, SDL_KeyCode keycode, const char* label) {
+	int keywidth = 8;
+	switch (keycode) {
+	case SDLK_UP:
+		PaintArrow(offsetx + 8, offsety, '^');
+		break;
+	case SDLK_DOWN:
+		PaintArrow(offsetx + 8, offsety, 'V');
+		break;
+	case SDLK_LEFT:
+		PaintArrow(offsetx + 8, offsety, '<');
+		break;
+	case SDLK_RIGHT:
+		PaintArrow(offsetx + 8, offsety, '>');
+		break;
+	case SDLK_ESCAPE:
+		keywidth = 24;
+		font->paint_text_fixedwidth(ibuf, "ESC", offsetx + 8, offsety, 8);
+		break;
+	default:
+		if (std::isalnum(keycode)) {
+			char buf[] = {char(std::toupper(keycode)), 0};
+
+			font->paint_text_fixedwidth(ibuf, buf, offsetx + 8, offsety, 8);
+		}
+		break;
+	}
+	font->paint_text_fixedwidth(ibuf, "[", offsetx, offsety, 8);
+	font->paint_text_fixedwidth(ibuf, "]", offsetx + keywidth + 8, offsety, 8);
+	int labelstart = 16 + keywidth;
+	int labelwidth = font->paint_text_fixedwidth(
+			ibuf, label, offsetx + labelstart, offsety, 8);
+	hotspots.push_back(Hotspot(keycode, offsetx, offsety, 16 + keywidth, 8));
+	if (state.highlight == keycode) {
+		ibuf->fill_translucent8(
+				0, 8 * (int(std::strlen(label)) + 2) + keywidth, 8, offsetx,
+				offsety, highlighttable);
+	}
+	return labelstart + labelwidth;
+}
+
+int CheatScreen::AddLeftRightMenuItem(
+		int offsetx, int offsety, const char* label, bool left, bool right,
+		bool leaveempty, bool fixedlabel) {
+	// Change NPC
+
+	int right_offset = (left || leaveempty) ? 8 : 0;
+	int totalspace   = right_offset + ((right || leaveempty) ? 8 : 0);
+	int xwidth       = right ? 8 : leaveempty ? 24 : 16;
+
+	if (left) {
+		PaintArrow(offsetx + 8, offsety, '<');
+	}
+	if (right) {
+		PaintArrow(offsetx + 9 + right_offset, offsety, '>');
+		hotspots.push_back(Hotspot(
+				SDLK_RIGHT, offsetx + 9 + right_offset, offsety, 16, 8));
+	}
+	if (left) {
+		hotspots.push_back(
+				Hotspot(SDLK_LEFT, offsetx - 8, offsety, 16 + xwidth, 8));
+	}
+
+	font->paint_text_fixedwidth(ibuf, "[", offsetx, offsety, 8);
+	font->paint_text_fixedwidth(
+			ibuf, "]", offsetx + totalspace + 8, offsety, 8);
+	int labelstart = (fixedlabel ? 32 : (totalspace + 16));
+	int labelwidth = font->paint_text_fixedwidth(
+			ibuf, label, offsetx + labelstart, offsety, 8);
+
+	if (state.highlight == SDLK_LEFT && left) {
+		ibuf->fill_translucent8(
+				0, 8 + xwidth, 8, offsetx, offsety, highlighttable);
+	} else if (state.highlight == SDLK_RIGHT && right) {
+		int extend = !left ? 16 : 0;
+		ibuf->fill_translucent8(
+				0, 16 + extend, 8, offsetx + 8 + right_offset - extend, offsety,
+				highlighttable);
+	}
+
+	return labelstart + labelwidth;
+}
+
+void CheatScreen::EndFrame() {
+	PaintHotspots();
+	Mouse::mouse->show();
+	gwin->get_win()->show();
+	Mouse::mouse->hide();    // Must immediately hide to prevent flickering
 }

--- a/cheat_screen.cc
+++ b/cheat_screen.cc
@@ -695,19 +695,20 @@ bool CheatScreen::SharedInput() {
 							if (event.button.clicks >= 2) {
 								simulate_key = SDLK_RETURN;
 							}
-						}
-						CERR("window size( " << gwin->get_width() << " , "
-											 << gwin->get_height() << " )");
-						// Touch on the cheat screen will bring up the keyboard
-						// but not if the tap was within a 20 pixel border on
-						// the edge of the game screen)
-						if (SDL_IsTextInputActive()) {
-							SDL_StopTextInput();
-						} else if (
-								gx > 20 && gy > 20
-								&& gx < (gwin->get_width() - 20)
-								&& gy < (gwin->get_height() - 20)) {
-							SDL_StartTextInput();
+
+							CERR("window size( " << gwin->get_width() << " , "
+												 << gwin->get_height() << " )");
+							// Touch on the cheat screen will bring up the
+							// keyboard but not if the tap was within a 20 pixel
+							// border on the edge of the game screen)
+							if (SDL_IsTextInputActive()) {
+								SDL_StopTextInput();
+							} else if (
+									gx > 20 && gy > 20
+									&& gx < (gwin->get_width() - 20)
+									&& gy < (gwin->get_height() - 20)) {
+								SDL_StartTextInput();
+							}
 						}
 					}
 				} break;
@@ -1367,51 +1368,47 @@ void CheatScreen::ActivityDisplay() {
 }
 
 void CheatScreen::PaintArrow(int offsetx, int offsety, int type) {
+	// Need to draw arrows with overlapping characters
 	// up arrow
 	if (type == '^') {
-		// Need to draw up arrow with overlapping characters
 		// Use an i as the stem of the arrow
 		font->paint_text_fixedwidth(ibuf, "i", offsetx, offsety, 8);
 		// Draw a black line to narrow the stem
 		ibuf->draw_line8(0, offsetx + 4, offsety, offsetx + 4, offsety + 8);
 		// Draw point of arrow
 		font->paint_text_fixedwidth(ibuf, "^", offsetx, offsety, 8);
-
 	}    // down arrow
 	else if (type == 'V') {
-		// Need to draw up arrow with overlapping characters
 		// Use an l as the stem of the arrow
 		font->paint_text_fixedwidth(ibuf, "l", offsetx, offsety, 8);
-		// Draw a black lines to narrow the stem
+		// Draw black lines to narrow the stem
 		ibuf->draw_line8(0, offsetx + 2, offsety, offsetx + 2, offsety + 2);
 		ibuf->draw_line8(0, offsetx + 4, offsety, offsetx + 4, offsety + 6);
-		// Draw point of arrow
 
+		// Draw point of arrow
 		font->paint_text_fixedwidth(ibuf, "m", offsetx, offsety + 2, 8);
+
 		// Paint black lines to make it pointy
 		ibuf->draw_line8(0, offsetx + 0, offsety + 5, offsetx + 0, offsety + 8);
 		ibuf->draw_line8(0, offsetx + 6, offsety + 5, offsetx + 6, offsety + 8);
 		ibuf->draw_line8(0, offsetx + 1, offsety + 6, offsetx + 1, offsety + 8);
 		ibuf->draw_line8(0, offsetx + 5, offsety + 6, offsetx + 5, offsety + 8);
-	}
-
-	// left arrow
+	}    // left arrow
 	else if (type == '<') {
 		// Stem of arrow
 		font->paint_text_fixedwidth(ibuf, "-", offsetx + 1, offsety, 8);
-		// Paint black line to make it pointier
+		// Paint black line  to narrow the stem
 		ibuf->draw_line8(0, offsetx + 0, offsety + 4, offsetx + 7, offsety + 4);
 		// Point of  arrow
 		font->paint_text_fixedwidth(ibuf, "<", offsetx, offsety, 8);
 		// Paint black line to make it pointier
 		ibuf->draw_line8(0, offsetx + 1, offsety + 4, offsetx + 4, offsety + 7);
 		ibuf->put_pixel8(0, offsetx + 5, offsety + 7);
-
-		// Right Arrow
-	} else if (type == '>') {
+	}    // Right Arrow
+	else if (type == '>') {
 		// Stem of arrow
 		font->paint_text_fixedwidth(ibuf, "-", offsetx, offsety, 8);
-		// Paint black line to make it pointier
+		// Paint black line to narrow the stem
 		ibuf->draw_line8(0, offsetx + 0, offsety + 4, offsetx + 7, offsety + 4);
 		// Point of arrow
 		font->paint_text_fixedwidth(ibuf, ">", offsetx + 2, offsety, 8);

--- a/cheat_screen.cc
+++ b/cheat_screen.cc
@@ -1425,6 +1425,9 @@ CheatScreen::Cheat_Prompt CheatScreen::TimeSetLoop() {
 	int        day  = 0;
 	int        hour = 0;
 	ClearState clear(state);
+	state.mode = CP_Day;
+	state.val_min = 0;
+	state.val_max = INT_MAX;	// This seems unbounded
 	while (true) {
 		hotspots.clear();
 		gwin->clear_screen();

--- a/cheat_screen.h
+++ b/cheat_screen.h
@@ -27,6 +27,7 @@
 
 #include <climits>
 #include <memory>
+#include <unordered_set>
 #include <vector>
 
 class Game_window;
@@ -42,6 +43,8 @@ class CheatScreen {
 	static const char* alignments[4];
 
 public:
+	CheatScreen() : highlighttable(), hovertable(), buttons_down() {}
+
 	void show_screen();
 
 	void SetGrabbedActor(Actor* g) {
@@ -248,6 +251,11 @@ private:
 	int  highest_map = INT_MIN;
 	int  Get_highest_map();
 	void EndFrame();
+
+	//
+	static const int             button_down_finger = -1;
+	std::unordered_multiset<int> buttons_down;
+	void                         WaitButtonsUp();
 };
 
 #endif

--- a/cheat_screen.h
+++ b/cheat_screen.h
@@ -131,6 +131,7 @@ private:
 
 		private:
 		Cheat_Prompt mode = CP_Command;
+
 		public:
 		Cheat_Prompt GetMode() {
 			return mode;

--- a/cheat_screen.h
+++ b/cheat_screen.h
@@ -25,9 +25,9 @@
 
 #include <SDL.h>
 
+#include <climits>
 #include <memory>
 #include <vector>
-static const Uint32 EXSDL_TOUCH_MOUSEID = SDL_TOUCH_MOUSEID;
 
 class Game_window;
 class Image_buffer8;
@@ -111,21 +111,21 @@ private:
 	std::vector<Hotspot> hotspots;
 
 	struct {
-		int         highlight     = 0;
-		Uint32      highlighttime = 0;
-		char        input[17]     = {0};
-		int         command       = 0;
-		bool        activate      = false;
+		int          highlight     = 0;
+		Uint32       highlighttime = 0;
+		char         input[17]     = {0};
+		int          command       = 0;
+		bool         activate      = false;
 		Cheat_Prompt mode          = CP_Command;
-		const char* custom_prompt = nullptr;
-		int         saved_value   = 0;
-		long        val_min       = LONG_MIN;
-		long        val_max       = LONG_MAX;
-		long        value;
-		Uint32      last_swipe = 0;
+		const char*  custom_prompt = nullptr;
+		int          saved_value   = 0;
+		long         val_min       = LONG_MIN;
+		long         val_max       = LONG_MAX;
+		long         value;
+		Uint32       last_swipe = 0;
 		// Accumulated swipe deltas. We treat these as a vector
-		float        swipe_dx = 0;
-		float        swipe_dy = 0;
+		float swipe_dx = 0;
+		float swipe_dy = 0;
 
 	} state;
 
@@ -185,38 +185,29 @@ private:
 	Cheat_Prompt NPCLoop(int num);
 	void         NPCDisplay(Actor* actor, int& num);
 	void         NPCMenu(Actor* actor, int& num);
-	void NPCActivate(Actor* actor, int& num);
-	bool NPCCheck(
-			Actor* actor,
-			int& num);
+	void         NPCActivate(Actor* actor, int& num);
+	bool         NPCCheck(Actor* actor, int& num);
 
-	void FlagLoop(Actor* actor);
-	void FlagMenu(Actor* actor);
-	void FlagActivate(Actor* actor);
-	bool FlagCheck(
-			Actor* actor);
+	void         FlagLoop(Actor* actor);
+	void         FlagMenu(Actor* actor);
+	void         FlagActivate(Actor* actor);
+	bool         FlagCheck(Actor* actor);
 	Cheat_Prompt AdvancedFlagLoop(int flagnum, Actor* actor);
 
 	void BusinessLoop(Actor* actor);
 	void BusinessDisplay(Actor* actor);
 	void BusinessMenu(Actor* actor);
-	void BusinessActivate(
-			Actor* actor, int& time,
-			int& prev);
-	bool BusinessCheck(
-			Actor* actor,
-			int& time);
+	void BusinessActivate(Actor* actor, int& time, int& prev);
+	bool BusinessCheck(Actor* actor, int& time);
 
 	void StatLoop(Actor* actor);
 	void StatMenu(Actor* actor);
 	void StatActivate(Actor* actor);
-	bool StatCheck(
-			 Actor* actor);
+	bool StatCheck(Actor* actor);
 	void PalEffectLoop(Actor*);
 	void PalEffectMenu(Actor* actor);
 	void PalEffectActivate(Actor* actor);
-	bool PalEffectCheck(
-			Actor* actor);
+	bool PalEffectCheck(Actor* actor);
 	void TeleportLoop();
 	void TeleportDisplay();
 	void TeleportMenu();
@@ -231,15 +222,17 @@ private:
 	//! @return Width in pixels of the menu item
 	int AddMenuItem(
 			int offsetx, int offsety, SDL_KeyCode keycode, const char* label);
-	
+
 	//! @brief Add a menuitem for left and right cursor keys
 	//! @param offsetx X coord for the menu item
 	//! @param offsety  Y coord for the menu item
 	//! @param label Label of the Menu item
 	//! @param left Flag for if the left arrow should be shown
 	//! @param right Flag for if the right arrow should be shown
-	//! @param leaveempty Flag to indicate that blank space should be used inplace of missing arrows
-	//! @param fixedlabel Flag to indicate the label should be drawn at a fixed position if arrows are mising
+	//! @param leaveempty Flag to indicate that blank space should be used
+	//! inplace of missing arrows
+	//! @param fixedlabel Flag to indicate the label should be drawn at a fixed
+	//! position if arrows are mising
 	//! @return Width in pixels of the menu item
 	int AddLeftRightMenuItem(
 			int offsetx, int offsety, const char* label, bool left, bool right,

--- a/cheat_screen.h
+++ b/cheat_screen.h
@@ -119,7 +119,6 @@ private:
 		char         input[17]     = {0};
 		int          command       = 0;
 		bool         activate      = false;
-		Cheat_Prompt mode          = CP_Command;
 		const char*  custom_prompt = nullptr;
 		int          saved_value   = 0;
 		long         val_min       = LONG_MIN;
@@ -129,6 +128,20 @@ private:
 		// Accumulated swipe deltas. We treat these as a vector
 		float swipe_dx = 0;
 		float swipe_dy = 0;
+
+		private:
+		Cheat_Prompt mode = CP_Command;
+		public:
+		Cheat_Prompt GetMode() {
+			return mode;
+		}
+		void SetMode(Cheat_Prompt newmode, bool clearinput=true) {
+			// Clear the input if changing to or from a text/value input mode
+			if (clearinput) {
+				input[0] = 0;
+			}
+			mode = newmode;
+		}
 	} state;
 
 	template <class T>

--- a/cheat_screen.h
+++ b/cheat_screen.h
@@ -126,7 +126,6 @@ private:
 		// Accumulated swipe deltas. We treat these as a vector
 		float swipe_dx = 0;
 		float swipe_dy = 0;
-
 	} state;
 
 	template <class T>
@@ -161,6 +160,14 @@ private:
 	Palette               pal;
 	Xform_palette         highlighttable;
 	Xform_palette         hovertable;
+
+	// Turn off clang-format so it doesn't wrap the long comments
+	// clang-format off
+ 
+ 	// Constants used for touch input
+	const float  swipe_threshold     = 0.075f;	// Threshold for Swipes to be converted into key inputs.
+
+	// clang-format on
 
 	void        SharedPrompt();
 	bool        SharedInput();
@@ -232,7 +239,7 @@ private:
 	//! @param leaveempty Flag to indicate that blank space should be used
 	//! inplace of missing arrows
 	//! @param fixedlabel Flag to indicate the label should be drawn at a fixed
-	//! position if arrows are mising
+	//! position if arrows are mising and !leaveempty
 	//! @return Width in pixels of the menu item
 	int AddLeftRightMenuItem(
 			int offsetx, int offsety, const char* label, bool left, bool right,

--- a/gumps/Gump_manager.cc
+++ b/gumps/Gump_manager.cc
@@ -473,6 +473,9 @@ void Gump_manager::update_gumps() {
  *  Paint the gumps
  */
 void Gump_manager::paint(bool modal) {
+	if (modal && background) {
+		background->paint();
+	}
 	for (Gump_list* gmp = open_gumps; gmp; gmp = gmp->next) {
 		if (gmp->gump->is_modal() == modal) {
 			gmp->gump->paint();
@@ -485,14 +488,14 @@ void Gump_manager::paint(bool modal) {
  *
  *  Output: true to quit.
  */
-bool Gump_manager::okay_to_quit() {
+bool Gump_manager::okay_to_quit(Paintable* paint) {
 	// Prevent reentering this function
 	static bool inthis = false;
 	if (inthis) {
 		return false;
 	}
 	inthis = true;
-	if (Yesno_gump::ask("Do you really want to quit?")) {
+	if (Yesno_gump::ask("Do you really want to quit?", paint)) {
 		quitting_time = QUIT_TIME_YES;
 	}
 	inthis = false;
@@ -805,6 +808,10 @@ bool Gump_manager::do_modal_gump(
 		Mouse::mouse->set_shape(shape);
 	}
 	bool escaped = false;
+	background   = dynamic_cast<BackgroundPaintable*>(paint);
+	if (background) {
+		paint = nullptr;
+	}
 	add_gump(gump);
 	gump->run();
 	gwin->paint();    // Show everything now.
@@ -813,6 +820,7 @@ bool Gump_manager::do_modal_gump(
 	}
 	Mouse::mouse->show();
 	gwin->show();
+	//gwin->set_all_dirty();
 	if (touchui != nullptr) {
 		touchui->hideGameControls();
 	}
@@ -857,6 +865,7 @@ bool Gump_manager::do_modal_gump(
 			touchui->showGameControls();
 		}
 	}
+	background = nullptr;
 	return !escaped;
 }
 

--- a/gumps/Gump_manager.cc
+++ b/gumps/Gump_manager.cc
@@ -820,7 +820,6 @@ bool Gump_manager::do_modal_gump(
 	}
 	Mouse::mouse->show();
 	gwin->show();
-	//gwin->set_all_dirty();
 	if (touchui != nullptr) {
 		touchui->hideGameControls();
 	}

--- a/gumps/Gump_manager.h
+++ b/gumps/Gump_manager.h
@@ -105,7 +105,7 @@ public:
 
 	void set_gumps_dont_pause_game(bool p);
 
-	bool okay_to_quit();
+	bool okay_to_quit(Paintable* paint = nullptr);
 	int  prompt_for_number(
 			 int minval, int maxval, int step, int def,
 			 Paintable* paint = nullptr);
@@ -121,6 +121,8 @@ public:
 
 private:
 	bool handle_modal_gump_event(Modal_gump* gump, SDL_Event& event);
+
+	BackgroundPaintable* background = nullptr;
 };
 
 #endif    // GUMP_MANAGER_INCLUDED

--- a/gumps/VideoOptions_gump.cc
+++ b/gumps/VideoOptions_gump.cc
@@ -390,7 +390,7 @@ void VideoOptions_gump::save_settings() {
 	if (tw / (scaling + 1) < 320 || th / (scaling + 1) < 200) {
 		if (!Yesno_gump::ask(
 					"Scaled size less than 320x200.\nExult may be "
-					"unusable.\nApply anyway?",
+					"unusable.\nApply anyway?",nullptr,
 					"TINY_BLACK_FONT")) {
 			return;
 		}
@@ -398,7 +398,7 @@ void VideoOptions_gump::save_settings() {
 	if (highdpi != o_highdpi) {
 		if (!Yesno_gump::ask(
 					"After toggling HighDPI you will need to restart "
-					"Exult!\nApply anyway?",
+					"Exult!\nApply anyway?",nullptr,
 					"TINY_BLACK_FONT")) {
 			return;
 		}

--- a/gumps/Yesno_gump.cc
+++ b/gumps/Yesno_gump.cc
@@ -173,10 +173,10 @@ bool Yesno_gump::key_down(int chr) {
 
 bool Yesno_gump::ask(
 		const char* txt,    // What to ask.
-		const char* font) {
+		Paintable* paint, const char* font) {
 	Yesno_gump dlg(txt, font);
 	bool       answer;
-	if (!gumpman->do_modal_gump(&dlg, Mouse::hand)) {
+	if (!gumpman->do_modal_gump(&dlg, Mouse::hand,paint)) {
 		answer = false;
 	} else {
 		answer = dlg.get_answer();

--- a/gumps/Yesno_gump.h
+++ b/gumps/Yesno_gump.h
@@ -57,8 +57,9 @@ public:
 	bool        key_down(int chr) override;    // Character typed.
 	static bool ask(
 			const char* txt,
-			const char* font
-			= "SMALL_BLACK_FONT");    // Ask question, get answer.
+			Paintable* paint=nullptr,
+			const char* font = "SMALL_BLACK_FONT"
+			);    // Ask question, get answer.
 };
 
 class Countdown_gump : public Yesno_gump {

--- a/msvcstuff/vs2019/msvc_include.h
+++ b/msvcstuff/vs2019/msvc_include.h
@@ -47,6 +47,10 @@
 #pragma warning(3 : 4018)
 #pragma warning(3 : 4388)
 #pragma warning(3 : 4389)
+// unused variable warnings
+#pragma warning(3 : 4101)
+#pragma warning(3 : 4100)
+#pragma warning(3 : 4189)
 
 #include <windows.h>
 

--- a/palette.cc
+++ b/palette.cc
@@ -623,7 +623,7 @@ uint8 Palette::remap_colour_to_ramp(uint8 colindex, unsigned int newramp) {
 	return ramps[newramp].start + newoffset;
 }
 
-void Palette::Generate_remap_xformtable(uint8 table[256], int* remaps) {
+void Palette::Generate_remap_xformtable(uint8 table[256], const int* remaps) {
 	unsigned int num_ramps = 0;
 	auto         ramps     = get_ramps(num_ramps);
 

--- a/palette.h
+++ b/palette.h
@@ -179,7 +179,7 @@ public:
 	//! Generate an xform table to remap colours to a specific ramp
 	//! \param[out] table array to recieve generated table
 	//! \param[in] remaps array to indicate which ramps should get remapped to which other ramp. i = remaps[i], use -1 as terminator
-	void Generate_remap_xformtable(uint8 table[256], int* remaps);
+	void Generate_remap_xformtable(uint8 table[256], const int* remaps);
 };
 
 /*

--- a/shapeid.cc
+++ b/shapeid.cc
@@ -565,3 +565,16 @@ uint8* ShapeID::Get_palette_transform_table(uint8 table[256]) const {
 	}
 	return table;
 }
+
+ImageBufferPaintable::ImageBufferPaintable() : x(0),y(0) {
+	auto gwin = Game_window::get_instance();
+	auto iwin = gwin->get_win();
+	buffer = iwin->create_buffer(iwin->get_full_width(), iwin->get_full_height());
+	iwin->get(buffer.get(),x, y);
+}
+
+void ImageBufferPaintable::paint() {
+	auto gwin = Game_window::get_instance();
+	auto iwin = gwin->get_win();
+	iwin->put(buffer.get(), x, y);
+}

--- a/shapeid.h
+++ b/shapeid.h
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include <vector>
+#include <optional>
 
 class Shape_frame;
 class Shape_info;
@@ -325,7 +326,9 @@ public:
 		shapefile = shfile;
 	}
 
-	void paint_shape(int xoff, int yoff, bool force_trans = false) const {
+	void paint_shape(
+			int xoff, int yoff,
+			std::optional<bool> force_trans = std::nullopt) const {
 		auto           cache      = cache_shape();
 		unsigned char* transtable = nullptr;
 		unsigned char  table[256];
@@ -333,7 +336,8 @@ public:
 			transtable = Get_palette_transform_table(table);
 		}
 		sman->paint_shape(
-				xoff, yoff, cache.shape, cache.has_trans || force_trans,
+				xoff, yoff, cache.shape,
+				force_trans?*force_trans:cache.has_trans,
 				transtable);
 	}
 
@@ -365,7 +369,7 @@ public:
 };
 
 /*
- *  An interface used in Get_click():
+ *  An interface used in Get_click(): This will be painted on top of everything else
  */
 class Paintable {
 public:
@@ -375,7 +379,6 @@ public:
 
 // A paintable that should be painted as a background and not on top of everything.
 class BackgroundPaintable : public Paintable {
-
 };
 
 class ImageBufferPaintable : public BackgroundPaintable {

--- a/shapeid.h
+++ b/shapeid.h
@@ -31,6 +31,7 @@
 class Shape_frame;
 class Shape_info;
 class Font;
+class Image_buffer;
 class Image_buffer8;
 struct Cursor_info;
 
@@ -372,4 +373,27 @@ public:
 	virtual ~Paintable() = default;
 };
 
+// A paintable that should be painted as a background and not on top of everything.
+class BackgroundPaintable : public Paintable {
+
+};
+
+class ImageBufferPaintable : public BackgroundPaintable {
+	std::unique_ptr<Image_buffer> buffer;
+	int x,y;
+
+public:
+	// Construct from an existing Image_buffer
+	ImageBufferPaintable(std::unique_ptr<Image_buffer>&& buffer, int x, int y) :
+			buffer(std::move(buffer)),
+			x(x),y(y) {
+	}
+
+	// Construct from a screenshot of the current screen
+	ImageBufferPaintable();
+
+	virtual ~ImageBufferPaintable() = default;
+	// Inherited via Paintable
+	void paint() override;
+};
 #endif

--- a/version.cc
+++ b/version.cc
@@ -88,15 +88,15 @@ static const char git_url[] = GIT_REMOTE_URL;
 static const char git_url[] = "";
 #endif
 
-std::string VersionGetGitRevision(bool shortrev) {
+std::string_view VersionGetGitRevision(bool shortrev) {
 	if (git_rev[0]) {
 		if (shortrev) {
-			return std::string(git_rev, 7);
+			return std::string_view(git_rev, 7);
 		} else {
-			return git_rev;
+			return std::string_view(git_rev);
 		}
 	}
-	return std::string();
+	return std::string_view();
 }
 
 std::string VersionGetGitInfo(bool limitedwidth) {

--- a/version.h
+++ b/version.h
@@ -20,10 +20,10 @@
  */
 
 #include <iostream>
-#include <string>
+#include <string_view>
 
 void        getVersionInfo(std::ostream& out);
-std::string VersionGetGitRevision(bool shortrev);
+std::string_view VersionGetGitRevision(bool shortrev);
 std::string VersionGetGitInfo(bool limitedwidth = false);
 
 #endif

--- a/version.h
+++ b/version.h
@@ -22,8 +22,8 @@
 #include <iostream>
 #include <string_view>
 
-void        getVersionInfo(std::ostream& out);
+void             getVersionInfo(std::ostream& out);
 std::string_view VersionGetGitRevision(bool shortrev);
-std::string VersionGetGitInfo(bool limitedwidth = false);
+std::string      VersionGetGitInfo(bool limitedwidth = false);
 
 #endif


### PR DESCRIPTION
The PR adds mouse and touch support to the Cheat screen. Primarily it does this by Creating hot spots for each menu item that can be clicked. The hot spots are the Bracketed Key indicators on each menu item. For small touch devices the hot spots may be a bit small so the pre-existing method of using the On screen keyboard to select menu item can still be used. As part of adding hot spots I added highlights to the hotspots for when the mouse hovers over them. 

I also added an additional highlight that will highlight the entire menu item when it is selected. This only works for Menu items that do not switch to a new menu. Hover highlight is red, activation highlight is blue and both at the same time give purple

Double clicking/tapping will now act as pressing the return key provided the clicks and taps were not on a hotspot

An addition to a recent change I made to use arrow keys in the Cheat Screen, I added the ability to increment and decrement numeric value inputs using right (inc) and left (dec). There being no input is treated as zero when incrementing or decrementing. There are limits imposed when incrementing and decrementing based on the current mode, 

For the mouse I made it so the mouse wheel will simulate left and right key presses. This makes it possible to use the cheat screen entirely with the mouse except for text input like change name. It's not very efficient to select numbers with the mouse wheel but it is at least now possible to use it without using the keyboard for most functions (this is a minor accessibility feature for people like myself with disabilities preventing normal keyboard+mouse use).

Related to that, when using Touch, Swipes across the screen will also act as arrow key presses (up, down, left, right). Longer swipes will cause repeated simulated key presses. It is setup to give 1 keypress for every 7.5% of the screen a swipe goes across. You should get about 13 key presses if swiping across the entire screen, 

I made some menu layout changes so the [ESC] exit options are always in the same place for every menu. This allows for quick exiting for deep in the menus without moving the mouse. Just hover over [ESC] and left click till you are out of the cheat screen

Previously Tapping anywhere on the cheatscreen would toggle the OS onscreen touch keyboard. I have changed things slightly. Tapping on hotspots will not toggle the OSK. The keyboard will also not be shown if a tap occurs in a 20 pixel border around the edge of the screen so swipes from the edge of the screen will not trigger the keyboard. If the OSK is shown when doing a swipe, it will get hidden.

In The Version info shown by the cheat screen's initial menu, I added the compile date and time as an additional line of info. I mostly added this so I could know for sure that my phone was actually using the latest Android build I compiled. I had no end of troubles trying to debug Exult on Android and this was just a simple sanity check.

I also Changed VersionGetGitRevision to return string_view and made the necessary change to the Cheat screen so this would work.

I did some general clean up of some parts of the cheat screen code. There is more I could do, but I don't think re-engineering the entire thing is really worth it, 