### PR TITLE
Test build ci-windows should build in MINGW64 and CLANG64

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -105,6 +105,13 @@ jobs:
           text: '**[The Windows build failed:](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**'
   ci-windows:
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sys: [mingw64, clang64]
+        include:
+          - { sys: mingw64, env: mingw-w64-x86_64 }
+          - { sys: clang64, env: mingw-w64-clang-x86_64 }
     defaults:
       run:
         shell: msys2 {0}
@@ -112,14 +119,14 @@ jobs:
       - name: Install dependencies
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: ${{ matrix.sys }}
           install: |
             base-devel git
-            mingw-w64-x86_64-toolchain mingw-w64-x86_64-binutils mingw-w64-x86_64-ntldd mingw-w64-x86_64-SDL2
-            mingw-w64-x86_64-fluidsynth mingw-w64-x86_64-libtimidity mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis
-            mingw-w64-x86_64-munt-mt32emu mingw-w64-x86_64-libpng mingw-w64-x86_64-zlib mingw-w64-x86_64-SDL2_image
-            mingw-w64-x86_64-gtk3 mingw-w64-x86_64-adwaita-icon-theme mingw-w64-x86_64-libxml2 mingw-w64-x86_64-freetype
-            mingw-w64-x86_64-gtk2 mingw-w64-x86_64-gimp mingw-w64-x86_64-icu
+            ${{ matrix.env }}-toolchain ${{ matrix.env }}-binutils ${{ matrix.env }}-ntldd ${{ matrix.env }}-SDL2
+            ${{ matrix.env }}-fluidsynth ${{ matrix.env }}-libtimidity ${{ matrix.env }}-libogg ${{ matrix.env }}-libvorbis
+            ${{ matrix.env }}-munt-mt32emu ${{ matrix.env }}-libpng ${{ matrix.env }}-zlib ${{ matrix.env }}-SDL2_image
+            ${{ matrix.env }}-gtk3 ${{ matrix.env }}-adwaita-icon-theme ${{ matrix.env }}-libxml2 ${{ matrix.env }}-freetype
+            ${{ matrix.env }}-gtk2 ${{ matrix.env }}-gimp ${{ matrix.env }}-icu
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Build

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -49,15 +49,23 @@ else ifeq ($(MSYSTEM),UCRT64)
 	ARCHFLAGS:=-m64
 	CC:=gcc
 	CXX:=g++
+else ifeq ($(MSYSTEM),CLANGARM64)
+	ARCHFLAGS:=-m64
+	CC:=clang
+	CXX:=clang++
 else
 	ARCHFLAGS:=-m64
 	CC:=gcc
 	CXX:=g++
 endif
 
-# Lets target CPUs around 16 years old or newer for snapshots.
+# Lets target X86 CPUs around 16 years old or newer for snapshots.
 ifdef SNAPSHOT
+ifeq ($(MSYSTEM),CLANGARM64)
+	ARCHTYPE:=-march=native
+else
 	ARCHTYPE:=-march=x86-64-v2
+endif
 else
 	ARCHTYPE:=-march=native
 endif
@@ -538,8 +546,8 @@ exultico.o: win32/exultico.rc win32/exult.ico win32/exult.exe.manifest
 exconfig_rc.o: win32/exconfig.rc
 	windres --include-dir win32 win32/exconfig.rc exconfig_rc.o
 
-exconfig.dll: win32/exconfig.def $(FILE_OBJS) $(CONF_OBJS) exconfig_rc.o win32/exconfig.o
-	$(CXX) $(LDFLAGS) -shared -o $@ $(filter-out $<,$^) --def $< -static -lstdc++ -Wl,--add-stdcall-alias -Wl,--dynamicbase
+exconfig.dll: $(FILE_OBJS) $(CONF_OBJS) exconfig_rc.o win32/exconfig.o
+	$(CXX) $(LDFLAGS) -shared -o $@ $^ -static -lstdc++ -Wl,--dynamicbase
 
 exult_studio$(EXEEXT): $(BG_PAPERDOLL) $(FLEXES) $(ES_OBJS)
 	$(CXX) $(LDFLAGS) -o $@ $(ES_OBJS) $(ES_LIBS)

--- a/win32/exconfig.cc
+++ b/win32/exconfig.cc
@@ -81,9 +81,9 @@ constexpr static const std::array BG_Files{ENDGAME};
 constexpr static const std::array SI_Files{PAPERDOL};
 
 extern "C" {
-__declspec(dllexport) int __stdcall VerifySIDirectory(char* path);
+__declspec(dllexport) int __cdecl VerifySIDirectory(char* path);
 
-__declspec(dllexport) int __stdcall VerifyBGDirectory(char* path);
+__declspec(dllexport) int __cdecl VerifyBGDirectory(char* path);
 }
 
 void strcat_safe(char* dest, const char* src, size_t size_dest) {
@@ -274,7 +274,7 @@ extern "C" {
 //
 // Get the Game paths from the config file
 //
-__declspec(dllexport) void __stdcall GetExultGamePaths(
+__declspec(dllexport) void __cdecl GetExultGamePaths(
 		char* ExultDir, char* BGPath, char* SIPath, int MaxPath) {
 	MessageBoxDebug(nullptr, ExultDir, "ExultDir", MB_OK);
 	MessageBoxDebug(nullptr, BGPath, "BGPath", MB_OK);
@@ -353,7 +353,7 @@ bool IsNullEmptyOrWhitespace(const char* s) {
 // Set Game paths in the config file
 //
 
-__declspec(dllexport) void __stdcall SetExultGamePaths(
+__declspec(dllexport) void __cdecl SetExultGamePaths(
 		char* ExultDir, char* BGPath, char* SIPath) {
 	MessageBoxDebug(nullptr, ExultDir, "ExultDir", MB_OK);
 	MessageBoxDebug(nullptr, BGPath, "BGPath", MB_OK);
@@ -443,7 +443,7 @@ __declspec(dllexport) void __stdcall SetExultGamePaths(
 //
 // Verify the BG Directory contains the right stuff
 //
-__declspec(dllexport) int __stdcall VerifyBGDirectory(char* path) {
+__declspec(dllexport) int __cdecl VerifyBGDirectory(char* path) {
 	if (IsNullEmptyOrWhitespace(path)) {
 		return false;
 	}
@@ -483,7 +483,7 @@ __declspec(dllexport) int __stdcall VerifyBGDirectory(char* path) {
 //
 // Verify the SI Directorys contains the right stuff
 //
-__declspec(dllexport) int __stdcall VerifySIDirectory(char* path) {
+__declspec(dllexport) int __cdecl VerifySIDirectory(char* path) {
 	if (IsNullEmptyOrWhitespace(path)) {
 		return false;
 	}

--- a/win32/exult_installer.iss
+++ b/win32/exult_installer.iss
@@ -18,6 +18,7 @@ InternalCompressLevel=max
 OutputDir=.
 DisableWelcomePage=no
 WizardStyle=modern
+ArchitecturesInstallIn64BitMode=x64compatible
 
 [Dirs]
 Name: "{app}\data"
@@ -108,19 +109,19 @@ var
 
 // Get Paths from Exult.cfg
 procedure GetExultGamePaths(sExultDir, sBGPath, sSIPath: AnsiString; iMaxPath: Integer);
-external 'GetExultGamePaths@files:exconfig-i686.dll stdcall';
+external 'GetExultGamePaths@files:exconfig-i686.dll cdecl';
 
 // Write Paths into Exult.cfg
 procedure SetExultGamePaths(sExultDir, sBGPath, sSIPath: AnsiString);
-external 'SetExultGamePaths@files:exconfig-i686.dll stdcall';
+external 'SetExultGamePaths@files:exconfig-i686.dll cdecl';
 
 // Verify BG Dir
 function VerifyBGDirectory(sPath: AnsiString) : Integer;
-external 'VerifyBGDirectory@files:exconfig-i686.dll stdcall';
+external 'VerifyBGDirectory@files:exconfig-i686.dll cdecl';
 
 // Verify SI Dir
 function VerifySIDirectory(sPath: AnsiString) : Integer;
-external 'VerifySIDirectory@files:exconfig-i686.dll stdcall';
+external 'VerifySIDirectory@files:exconfig-i686.dll cdecl';
 
 // Get the Previous Exult Installation Dir
 // This is done in a manner that is compatible with the old InstallShield setup

--- a/win32/exult_studio_installer.iss
+++ b/win32/exult_studio_installer.iss
@@ -20,6 +20,7 @@ AllowNoIcons=true
 OutputDir=.
 DisableWelcomePage=no
 WizardStyle=modern
+ArchitecturesInstallIn64BitMode=x64compatible
 
 [Files]
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files

--- a/win32/exult_tools_installer.iss
+++ b/win32/exult_tools_installer.iss
@@ -20,6 +20,7 @@ AllowNoIcons=true
 OutputDir=.
 DirExistsWarning=no
 WizardStyle=modern
+ArchitecturesInstallIn64BitMode=x64compatible
 
 [Files]
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files


### PR DESCRIPTION
- The workflow `ci-windows` is matriced to test build `MINGW64` and `CLANG64`.
The package install step receives a package name prefix to become MinGW environment independent.
- The build of `exconfig.dll` avoids the use of the Export definition file `exconfig.def` and the link option `--add-stdcall-alias` that CLang does not support.
The public entry points of `exconfig.dll` to the Inno Setup script `Get + SetExultGamePaths`, `VerifySI + BGDirectory` are switched from `stdcall` to `cdecl` to remove the need of the file `exconfig.def` and the option `--add-stdcall-alias`.
