### PR TITLE
Add AppStream metadata and release info

### DIFF
--- a/desktop/info.exult.exult.metainfo.xml
+++ b/desktop/info.exult.exult.metainfo.xml
@@ -9,7 +9,7 @@
   <summary>A cross-platform engine for the Ultima 7 games</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <launchable type="desktop-id">info.exult.exult</launchable>
-  <project_license> GPL-2.0-only</project_license>
+  <project_license>GPL-2.0-only</project_license>
   <url type="homepage">https://exult.info/</url>
   <description>
     <p>Exult is a project to recreate Ultima 7 for modern operating systems, using the game's original plot, data, and graphics files.</p>

--- a/desktop/info.exult.exult.metainfo.xml
+++ b/desktop/info.exult.exult.metainfo.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component>
+  <id>info.exult.exult</id>
+  <name>Exult Ultima 7 Engine</name>
+  <developer id="info.exult.exult">
+    <name>Exult Contributors</name>
+    <url>https://github.com/exult/exult/graphs/contributors</url>
+  </developer>
+  <summary>A cross-platform engine for the Ultima 7 games</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <launchable type="desktop-id">info.exult.exult</launchable>
+  <project_license> GPL-2.0-only</project_license>
+  <url type="homepage">https://exult.info/</url>
+  <description>
+    <p>Exult is a project to recreate Ultima 7 for modern operating systems, using the game's original plot, data, and graphics files.</p>
+    <p>Ultima 7, an RPG from the early 1990's, still has a huge following. But, being a DOS game with a very nonstandard memory manager, it is difficult to run it on the latest computers. Exult is a project to create an Ultima 7 game engine that runs on modern operating systems, capable of using the data and graphics files that come with the game.</p>
+    <p>Exult is written in C++ and runs on, at least, Linux, Mac OS X and Windows using the SDL library to make porting to other platforms relatively easy. The current version supports all of "Ultima 7: The Black Gate" and "Ultima 7 part 2: The Serpent Isle", allowing you to finish both games. This is only possible due to the work done by other fans who have decoded the various Ultima 7 data files, especially Gary Thompson, Maxim Shatskih, Jakob Schonberg, and Wouter Dijkslag.</p>
+    <p>Exult aims to let those people who own Ultima 7 (copyright 1993) play the game on modern hardware, in as close to (or perhaps even surpassing) its original splendor as is possible. You need to own "Ultima 7: The Black Gate" and/or "Ultima 7: Serpent Isle" and optionally the add-ons (not required to run) in order to use Exult, and we encourage you to buy a legal copy.</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://exult.info/images/screenshots/mainmenu.png</image>
+      <caption>Select the game to play</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://exult.info/images/screenshots/si.png</image>
+      <caption>Supports all of the Ultima 7 games, including The Serpent Isle</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://exult.info/images/screenshots/gamemenu.png</image>
+      <caption>Includes various high-quality scaling algorithms for the original low-resolution artwork</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://exult.info/images/screenshots/gameplaymenu.png</image>
+      <caption>A wide range of customization options</caption>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Game</category>
+  </categories>
+  <releases type="external" url="https://raw.githubusercontent.com/exult/exult/master/desktop/info.exult.exult.releases.xml" />
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-fantasy">intense</content_attribute>
+    <content_attribute id="violence-bloodshed">intense</content_attribute>
+    <content_attribute id="violence-desecration">moderate</content_attribute>
+    <content_attribute id="violence-slavery">mild</content_attribute>
+    <content_attribute id="drugs-alcohol">moderate</content_attribute>
+    <content_attribute id="drugs-narcotics">moderate</content_attribute>
+    <content_attribute id="sex-nudity">mild</content_attribute>
+    <content_attribute id="sex-themes">moderate</content_attribute>
+    <content_attribute id="language-profanity">mild</content_attribute>
+    <content_attribute id="language-humor">intense</content_attribute>
+    <content_attribute id="language-discrimination">intense</content_attribute>
+    <content_attribute id="money-gambling">moderate</content_attribute>
+  </content_rating>
+  <update_contact>https://github.com/exult/exult/issues</update_contact>
+</component>

--- a/desktop/info.exult.exult.metainfo.xml
+++ b/desktop/info.exult.exult.metainfo.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component>
   <id>info.exult.exult</id>
-  <name>Exult Ultima 7 Engine</name>
+  <name>Exult Ultima VII Engine</name>
   <developer id="info.exult.exult">
     <name>Exult Contributors</name>
     <url>https://github.com/exult/exult/graphs/contributors</url>
   </developer>
-  <summary>A cross-platform engine for the Ultima 7 games</summary>
+  <summary>A cross-platform engine for the Ultima VII games</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <launchable type="desktop-id">info.exult.exult</launchable>
   <project_license>GPL-2.0-only</project_license>
   <url type="homepage">https://exult.info/</url>
   <description>
-    <p>Exult is a project to recreate Ultima 7 for modern operating systems, using the game's original plot, data, and graphics files.</p>
-    <p>Ultima 7, an RPG from the early 1990's, still has a huge following. But, being a DOS game with a very nonstandard memory manager, it is difficult to run it on the latest computers. Exult is a project to create an Ultima 7 game engine that runs on modern operating systems, capable of using the data and graphics files that come with the game.</p>
-    <p>Exult is written in C++ and runs on, at least, Linux, Mac OS X and Windows using the SDL library to make porting to other platforms relatively easy. The current version supports all of "Ultima 7: The Black Gate" and "Ultima 7 part 2: The Serpent Isle", allowing you to finish both games. This is only possible due to the work done by other fans who have decoded the various Ultima 7 data files, especially Gary Thompson, Maxim Shatskih, Jakob Schonberg, and Wouter Dijkslag.</p>
-    <p>Exult aims to let those people who own Ultima 7 (copyright 1993) play the game on modern hardware, in as close to (or perhaps even surpassing) its original splendor as is possible. You need to own "Ultima 7: The Black Gate" and/or "Ultima 7: Serpent Isle" and optionally the add-ons (not required to run) in order to use Exult, and we encourage you to buy a legal copy.</p>
+    <p>Exult is a project to recreate Ultima VII for modern operating systems, using the game's original plot, data, and graphics files.</p>
+    <p>Ultima VII, an RPG from the early 1990's, still has a huge following. But, being a DOS game with a very nonstandard memory manager, it is difficult to run it on the latest computers. Exult is a project to create an Ultima VII game engine that runs on modern operating systems, capable of using the data and graphics files that come with the game.</p>
+    <p>Exult is written in C++ and runs on, at least, Linux, Mac OS X and Windows using the SDL library to make porting to other platforms relatively easy. The current version supports all of "Ultima VII: The Black Gate" and "Ultima VII part 2: The Serpent Isle", allowing you to finish both games. This is only possible due to the work done by other fans who have decoded the various Ultima VII data files, especially Gary Thompson, Maxim Shatskih, Jakob Schonberg, and Wouter Dijkslag.</p>
+    <p>Exult aims to let those people who own Ultima VII (copyright 1993) play the game on modern hardware, in as close to (or perhaps even surpassing) its original splendor as is possible. You need to own "Ultima VII: The Black Gate" and/or "Ultima VII: Serpent Isle" and optionally the add-ons (not required to run) in order to use Exult, and we encourage you to buy a legal copy.</p>
   </description>
   <screenshots>
     <screenshot type="default">
@@ -24,7 +24,7 @@
     </screenshot>
     <screenshot>
       <image type="source">https://exult.info/images/screenshots/si.png</image>
-      <caption>Supports all of the Ultima 7 games, including The Serpent Isle</caption>
+      <caption>Supports all of the Ultima VII games, including The Serpent Isle</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://exult.info/images/screenshots/gamemenu.png</image>

--- a/desktop/info.exult.exult.releases.xml
+++ b/desktop/info.exult.exult.releases.xml
@@ -1,0 +1,43 @@
+<releases>
+  <release version="1.10" date="2024-09-09">
+    <description>
+    <ul>
+      <li>The Android port is now fully working</li>
+      <li>The Windows installer now offers to install several mods</li>
+      <li>New Volume Mixer to set individual volumes for music, sfx and speech</li>
+      <li>Cheat Screen overhauled so the options can now be activated by clicking or touching</li>
+      <li>Much improved combat:
+        <ul>
+          <li>Default attack mode “nearest” and attack mode “random” will try to select an enemy that is not already targeted by a party member</li>
+          <li>Implemented a version of berserk with a bit of chaos (but not as much as random)</li>
+          <li>Faking defend by selecting weakest enemy when low health, nearest otherwise</li>
+          <li>more blood</li>
+        </ul>
+      </li>
+      <li>Better detecting of clicks on gumps over the shortcutbar to prevent accidental triggering of a shortcut</li>
+      <li>mt32emu driver resampling fix</li>
+      <li>Endgames now wait for ingame speech to finish</li>
+      <li>Background sound effect music tracks are less annoying and disabled for FMOpl music driver</li>
+      <li>Music looping improved</li>
+      <li>Exult Studio allows zooming of the shapes view</li>
+      <li>Fixed a crash when swapping weapons in combat</li>
+      <li>Fixed random crash on sleeping past midnight in Britain</li>
+      <li>Attacking locked doors did not work</li>
+      <li>Immobile NPCs were able to move (e.g. Reapers)</li>
+      <li>Enemies poison now</li>
+    </ul>
+    <url>https://github.com/exult/exult/releases/tag/v1.10</url>
+  </release>
+  <release version="1.8" date="2022-04-16">
+    <url>https://github.com/exult/exult/releases/tag/v1.8</url>
+  </release>
+  <release version="1.6" date="2020-04-17">
+    <url>https://github.com/exult/exult/releases/tag/v1.6</url>
+  </release>
+  <release version="1.2" date="2016-03-12">
+    <url>https://github.com/exult/exult/releases/tag/v1.2</url>
+  </release>
+  <release version="1.00" date="2022-04-12">
+    <url>https://github.com/exult/exult/releases/tag/v1.00</url>
+  </release>
+</releases>


### PR DESCRIPTION
These files are what the FreeDesktop project describes as "catalog metadata", for display in graphical package managers. Primarily this would be used for the Flatpak distribution to render the project's page on the FlatHub listing (e.g. https://flathub.org/apps/io.itch.amcsquad.amcsquad), but if a Linux distribution vendor opted to create a system package for Exult they could also include these files so that package managers can display the same metadata.

The release info here is currently manually maintained and again would be used to display release information on Flathub; I'm currently working on a GitHub Action to automatically update the release info on AppStream catalog metadata files like these when a release is created. I'll add another PR to implement this when I'm done with that particular bit of yak shaving... :)