### PR TITLE
Sifixes: Fix possible hang in Fawn Trial cut scene.

### DIFF
--- a/content/sifixes/src/cutscenes/fawn_trial.uc
+++ b/content/sifixes/src/cutscenes/fawn_trial.uc
@@ -29,6 +29,9 @@ void FawnTrialBarks 0x939 (var quality) {
 		partySetTrialFacing();
 		delayedBark(trialnpc, "@" + getPoliteTitle() + "...@", 10);
 		delayedBark(AVATAR, "@" + getTrialNPC(false) + "!@", 5);
+		if (YELINDA->get_item_flag(ASLEEP)) {
+			YELINDA->clear_item_flag(ASLEEP);
+		}
 		abort;
 	} else if (quality == 0x00FD) {
 		script item {


### PR DESCRIPTION
Sometimes (not easily reproducible), the second part of the Fawn Trial cut scene hangs after Lady Yelinda remarks that Kylista is not around. This is because in those cases, she has the ASLEEP flag set and the usecode she is supposed to run (saying "Zulith...") checks if somebody can talk beforehand, which is not the case for sleeping NPCs. In order to fix this, clear the ASLEEP flag for her in case it is set at the beginning of the cutscene.

Fixes: #569