### PR TITLE
Migrate the Shape loader / exporter from Gimp 2 to Gimp 3

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -120,6 +120,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.sys }}
+          update: true
           install: |
             base-devel git zip
             ${{ matrix.env }}-toolchain ${{ matrix.env }}-binutils ${{ matrix.env }}-ntldd ${{ matrix.env }}-SDL2

--- a/.github/workflows/snapshots-windows.yml
+++ b/.github/workflows/snapshots-windows.yml
@@ -33,6 +33,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: MSYS
+          update: true
           install: |
             base-devel git p7zip zip
             mingw-w64-x86_64-toolchain mingw-w64-x86_64-binutils mingw-w64-x86_64-ntldd mingw-w64-x86_64-SDL2
@@ -103,7 +104,7 @@ jobs:
           cp ${{ env.EXULT_SNAPSHOT_PATH }}/Exult.exe ./windows-snapshot
           cp ${{ env.EXULT_SNAPSHOT_PATH }}/ExultStudio.exe ./windows-snapshot
           cp ${{ env.EXULT_SNAPSHOT_PATH }}/ExultTools.exe ./windows-snapshot
-          cp ${{ env.EXULT_SNAPSHOT_PATH }}/Gimp20Plugin.exe ./windows-snapshot
+          cp ${{ env.EXULT_SNAPSHOT_PATH }}/Gimp30Plugin.exe ./windows-snapshot
           cp ${{ env.EXULT_SNAPSHOT_PATH }}/Keyring.zip ./windows-snapshot
           cp ${{ env.EXULT_SNAPSHOT_PATH }}/SFisland.zip ./windows-snapshot
           cp ${{ env.EXULT_SNAPSHOT_PATH }}/Sifixes.zip ./windows-snapshot

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -64,7 +64,7 @@ jobs:
             Exult.exe
             ExultStudio.exe
             ExultTools.exe
-            Gimp20Plugin.exe
+            Gimp30Plugin.exe
       - name: Generate VirusTotal Body
         if: ${{ (env.HAVE_WINDOWS_SNAPSHOT == 'true' && env.HAVE_ANDROID_SNAPSHOT == 'true')}}
         run: |
@@ -92,7 +92,7 @@ jobs:
             Exult.exe
             ExultStudio.exe
             ExultTools.exe
-            Gimp20Plugin.exe
+            Gimp30Plugin.exe
             Keyring.zip
             SFisland.zip
             Sifixes.zip

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -55,8 +55,8 @@ else ifeq ($(MSYSTEM),UCRT64)
 	CC:=gcc
 	CXX:=g++
 else ifeq ($(MSYSTEM),CLANGARM64)
-// march=native should not be used when building official releases
-// so if we start making official ARM build this needs to be changed
+# march=native should not be used when building official releases
+# so if we start making official ARM build this needs to be changed
 	ARCHTYPE:=-march=native
 	ARCHFLAGS:=-m64
 	CC:=clang
@@ -67,8 +67,6 @@ else
 	CC:=gcc
 	CXX:=g++
 endif
-
-
 
 ifdef USE_CONSOLE
 	SUBSYSTEM:=-mconsole
@@ -135,10 +133,19 @@ ES_INCLUDES:=$(GTK_INCLUDES) $(FREETYPE2_INCLUDES) $(ICU_INCLUDES)
 ES_LIBS:=$(GTK_LIBS) $(FREETYPE2_LIBS) $(ICU_LIBS) $(ZIP_LIBS) -lpng -luuid -lole32 -lwinmm -lws2_32 $(SUBSYSTEM)
 
 ### GIMP libs and includes, for the GIMP plugin.
-# If this doesn't work, insert output of 'gimptool --cflags' manually
-GIMP_INCLUDES:=$(shell pkg-config --cflags gimpui-2.0 gtk+-2.0)
-# If this doesn't work, insert output of 'gimptool --libs' manually
+GIMP3_INSTALLED:=$(shell pkg-config --silence-errors --cflags gimpui-3.0)
+GIMP2_INSTALLED:=$(shell pkg-config --silence-errors --cflags gimpui-2.0)
+ifneq ($(GIMP3_INSTALLED),$())
+PLUGIN_SRC:=u7shp
+GIMP_INCLUDES:=$(GIMP3_INSTALLED)
+GIMP_LIBS:=$(shell pkg-config --libs gimpui-3.0)
+else
+ifneq ($(GIMP2_INSTALLED),$())
+PLUGIN_SRC:=u7shp-old
+GIMP_INCLUDES:=$(GIMP2_INSTALLED)
 GIMP_LIBS:=$(shell pkg-config --libs gimpui-2.0)
+endif
+endif
 
 ### Ogg vorbis inclides
 OGG_INCLUDES:=$(shell pkg-config --cflags ogg vorbis vorbisfile)
@@ -555,10 +562,18 @@ exult_studio$(EXEEXT): $(BG_PAPERDOLL) $(FLEXES) $(ES_OBJS)
 exultstudioico.o: $(SRC)/win32/exultstudioico.rc $(SRC)/win32/exultstudio.ico win32/exult_studio.exe.manifest
 	windres --include-dir $(SRC)/win32 $(SRC)/win32/exultstudioico.rc $@
 
-mapedit/u7shp.o: CPPFLAGS:=$(PLUGIN_CPPFLAGS)
-
+ifneq ($(PLUGIN_SRC),$())
+mapedit/u7shp.o: mapedit/$(PLUGIN_SRC).cc
+	$(CXX) $(CXXFLAGS) $(PLUGIN_CPPFLAGS) -c -o $(@) mapedit/$(PLUGIN_SRC).cc
+else
+mapedit/u7shp.o:
+	$(error Neither Gimp 3 nor Gimp 2 is installed, cannot build the Gimp plugin)
+endif
+# The libgexiv2 is a GLib wrapper for the Exiv2 metadata library, that the Plugin does not need.
+# It exports some std::string symbols from the libstdc++, so the Plugin gets linking or loading errors.
+# => Remove the libgexiv2 from the library list ( Feb 2025 ).
 u7shp$(EXEEXT) : mapedit/u7shp.o $(FILE_OBJS) shapes/vgafile.o imagewin/ibuf8.o imagewin/imagebuf.o
-	$(CXX) $(LDFLAGS) -o $(@) $+ $(GIMP_LIBS) -mwindows
+	$(CXX) $(LDFLAGS) -o $(@) $+ $(subst -lgexiv2,,$(GIMP_LIBS)) -mwindows
 
 install: $(EXEC)
 	mkdir -p $(U7PATH)
@@ -737,9 +752,11 @@ plugin: u7shp$(EXEEXT)
 plugininstall: plugin
 	mkdir -p $(GIMPPATH)
 	strip u7shp$(EXEEXT) -o $(GIMPPATH)/u7shp$(EXEEXT)
-	# Note: Gimp has everything a plugin needs already, so we don't
-	# need to ship anything else really.
+	# Note: Gimp has almost everything a plugin needs already, so we don't
+	# need to do this step.
 	#$(call copy_dlls_for_exe, u7shp$(EXEEXT), $(GIMPPATH))
+	# But we do need the GCC runtime & C++ libraries for CLang built Gimp 3, for a GCC built plugin.
+	for ff in $$($(MSYSTEM_PREFIX)/bin/ntldd u7shp$(EXEEXT) | grep -oE 'libgcc_s_seh-1\.dll|libstdc\+\+-6\.dll' | sort -u); do cp $(MSYSTEM_PREFIX)/bin/$$ff $(GIMPPATH)/$$ff; done
 
 plugindist: GIMPPATH:=$(DISTPATH)/GimpPlugin-$(MSYSTEM_CARCH)
 plugindist: plugin plugininstall
@@ -748,7 +765,7 @@ plugindist: plugin plugininstall
 	u2d $(GIMPPATH)/*.txt
 	cp win32/exult_shpplugin_installer.iss $(DISTPATH)
 
-allclean: clean toolsclean studioclean modsclean
+allclean: clean toolsclean studioclean modsclean pluginclean
 	rm -f exconfig.dll exconfig_rc.o win32/exconfig.o
 	rm -f Exult\ Source\ Code.url
 

--- a/README.win32
+++ b/README.win32
@@ -94,9 +94,14 @@ To build Exult Studio, you must install the following:
             mingw-w64-${MSYSTEM_CARCH}-zlib \
             mingw-w64-${MSYSTEM_CARCH}-icu
 
-To build the Gimp Plug-In, you must install the following:
+To build the Gimp 2 Plug-In, you must install the following:
     pacman -S --noconfirm --needed \
             mingw-w64-${MSYSTEM_CARCH}-gtk2 \
+            mingw-w64-${MSYSTEM_CARCH}-gimp2
+
+To build the Gimp 3 Plug-In, you must install the following:
+    pacman -S --noconfirm --needed \
+            mingw-w64-${MSYSTEM_CARCH}-gtk3 \
             mingw-w64-${MSYSTEM_CARCH}-gimp
 
 You now have everything needed to build any of the components you want.
@@ -116,6 +121,8 @@ to be installed to. This depends on the version of Gimp you use:
         C:/Users/<username>/.gimp-2.8/plug-ins
     Gimp 2.10 and newer:
         C:/Users/<username>/AppData/Roaming/GIMP/<version>/plug-ins
+    Gimp 3.0 and newer:
+        C:/Users/<username>/AppData/Roaming/GIMP/<version>/plug-ins/u7shp
 
 If you are compiling Exult Studio, it will be installed to the same directory
 that Exult when you compile it. You can change that directory in the same way.

--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,7 @@ cxx_compilers="g++ clang++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC"
 
 # determine windowing system from 'host'
 AC_MSG_CHECKING([windowing system])
+HOME_DATADIR="${XDG_CONFIG_HOME:-${HOME}/.config}"
 case "$host_os" in
 	linux-android*)
 		# Android cross compiled from Linux, supported.
@@ -116,6 +117,7 @@ case "$host_os" in
 		SYSLIBS="-framework CoreFoundation -framework AudioUnit -framework AudioToolbox -framework CoreMIDI"
 		CXXFLAGS="$CXXFLAGS -stdlib=libc++ -pthread"
 		EXULT_DATADIR="/Library/Application\ Support/Exult/data"
+		HOME_DATADIR="${HOME}/Library/Application\ Support"
 		ARCH=macosx
 		dnl swap around clang for OSX
 		cxx_compilers="clang++ g++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC"
@@ -903,35 +905,66 @@ else
 fi
 
 # GIMP plugin
-AM_CONDITIONAL(GIMP_PLUGIN, false)
-AC_ARG_ENABLE(gimp-plugin, AS_HELP_STRING([--enable-gimp-plugin], [Build the GIMP plugin @<:@default no@:>@]),,enable_gimp_plugin=no)
+AM_CONDITIONAL(GIMP3_PLUGIN, false)
+AM_CONDITIONAL(GIMP2_PLUGIN, false)
+AC_ARG_ENABLE(gimp-plugin,
+	AS_HELP_STRING([--enable-gimp-plugin@<:@=yes|system|user|no@:>@],
+		[Build the GIMP plugin, yes or system for system install (requires root), user for user install, @<:@default no@:>@]),,enable_gimp_plugin=no)
 AC_MSG_CHECKING([whether to build the GIMP plugin])
-if test x$enable_gimp_plugin = xyes; then
+if test x$enable_gimp_plugin != xno; then
 	AC_MSG_RESULT(yes)
-	AC_MSG_CHECKING([for gimptool])
-	AC_CHECK_PROGS(GIMPTOOL, gimptool-2.0)
-	if test -z "$GIMPTOOL"; then
-		AC_MSG_RESULT([no, not building GIMP plugin])
-	else
+	AC_CHECK_PROGS(GIMPTOOL, gimptool-3.0)
+	if test -n "$GIMPTOOL"; then
 		AC_MSG_CHECKING([for GIMP version])
 		gimp_version=`$GIMPTOOL --version`
-		AX_COMPARE_VERSION([$gimp_version], [ge], [2.8.0], [dnl
-			dnl $gimp_version >= 2.8.0
-			AC_MSG_RESULT([found $gimp_version >= 2.8.0])
+		AX_COMPARE_VERSION([$gimp_version], [ge], [3.0.0], [dnl
+			dnl $gimp_version >= 3.0.0
+			AC_MSG_RESULT([found $gimp_version >= 3.0.0])
 			AC_SUBST(GIMPTOOL)
-			AM_CONDITIONAL(GIMP_PLUGIN, true)
-			GIMP_PLUGIN_PREFIX=`$GIMPTOOL --gimpplugindir`
+			AM_CONDITIONAL(GIMP3_PLUGIN, true)
+			AS_IF([test x$enable_gimp_plugin != xuser],
+				[GIMP_PLUGIN_PREFIX=`$GIMPTOOL --gimpplugindir`],
+				[GIMP_PLUGIN_PREFIX="${HOME_DATADIR}/GIMP/3.0"])
 			GIMP_PLUGIN_PREFIX="$GIMP_PLUGIN_PREFIX/plug-ins"
 			AC_SUBST(GIMP_PLUGIN_PREFIX)
 			AC_DEFINE(HAVE_GIMP, 1, [Have GIMP])
-			GIMP_INCLUDES=`$PKG_CONFIG --cflags gimpui-2.0`
-			GIMP_LIBS=`$PKG_CONFIG --libs gimpui-2.0`
+			GIMP_INCLUDES=`$PKG_CONFIG --cflags gimpui-3.0`
+			GIMP_LIBS=`$PKG_CONFIG --libs gimpui-3.0`
 			AC_SUBST(GIMP_INCLUDES)
 			AC_SUBST(GIMP_LIBS)
 		], [
-			dnl $gimp_version < 2.8.0
-			AC_MSG_RESULT([found $gimp_version < 2.8.0 - disabling plugin])
+			dnl $gimp_version < 3.0.0
+			AC_MSG_RESULT([found $gimp_version < 3.0.0 - disabling plugin])
 		])
+	else
+		AC_CHECK_PROGS(GIMPTOOL, gimptool-2.0)
+		if test -n "$GIMPTOOL"; then
+			AC_MSG_CHECKING([for GIMP 2 version])
+			gimp_version=`$GIMPTOOL --version`
+			AX_COMPARE_VERSION([$gimp_version], [ge], [2.8.0], [dnl
+				dnl $gimp_version >= 2.8.0
+				AC_MSG_RESULT([found $gimp_version >= 2.8.0])
+				AC_SUBST(GIMPTOOL)
+				AM_CONDITIONAL(GIMP2_PLUGIN, true)
+				AS_IF([test x$enable_gimp_plugin != xuser],
+					[GIMP_PLUGIN_PREFIX=`$GIMPTOOL --gimpplugindir`],
+					[GIMP_PLUGIN_PREFIX="${HOME_DATADIR}/GIMP/2.0"])
+				GIMP_PLUGIN_PREFIX="$GIMP_PLUGIN_PREFIX/plug-ins"
+				AC_SUBST(GIMP_PLUGIN_PREFIX)
+				AC_DEFINE(HAVE_GIMP, 1, [Have GIMP])
+				GIMP_INCLUDES=`$PKG_CONFIG --cflags gimpui-2.0`
+				GIMP_LIBS=`$PKG_CONFIG --libs gimpui-2.0`
+				AC_SUBST(GIMP_INCLUDES)
+				AC_SUBST(GIMP_LIBS)
+			], [
+				dnl $gimp_version < 2.8.0
+				AC_MSG_RESULT([found $gimp_version < 2.8.0 - disabling plugin])
+			])
+		else
+			echo "The Gimp plugin requires the Gimp either in version 3 or in version 2, but neither is installed."
+			echo "Please try again, either with the Gimp installed, or with '--disable-gimp-plugin'."
+			exit 1
+		fi
 	fi
 else
 	AC_MSG_RESULT(no)
@@ -1397,6 +1430,9 @@ else
 	fi
 	if test x$enable_gnome_shp_thumbnailer = xyes; then
 		echo GDK-Pixbuf................. : `$PKG_CONFIG --modversion gdk-pixbuf-2.0`
+	fi
+	if test -n "$GIMPTOOL"; then
+		echo GIMP....................... : `$GIMPTOOL --version`
 	fi
 	echo
 fi

--- a/mapedit/Makefile.am
+++ b/mapedit/Makefile.am
@@ -5,19 +5,25 @@ AM_CPPFLAGS = -I$(top_srcdir)/headers -I$(top_srcdir) -I$(top_srcdir)/shapes \
 	$(GTK_CFLAGS) $(PNG_CFLAGS) $(ICU_CFLAGS) $(INCDIRS) $(WINDOWING_SYSTEM) \
 	$(DEBUG_LEVEL) $(OPT_LEVEL) $(WARNINGS) $(CPPFLAGS) -DEXULT_DATADIR=\"$(EXULT_DATADIR)\"
 
-if GIMP_PLUGIN
-GIMP_PLUGINS=u7shp
+if GIMP3_PLUGIN
+GIMP_PLUGIN_SRC = u7shp
+GIMP_PLUGINS = u7shp
 else
-GIMP_PLUGINS=
+if GIMP2_PLUGIN
+GIMP_PLUGIN_SRC = u7shp-old
+GIMP_PLUGINS = u7shp
+else
+GIMP_PLUGINS =
+endif
 endif
 
 if BUILD_STUDIO
-bin_PROGRAMS = exult_studio
+bin_PROGRAMS = exult_studio $(GIMP_PLUGINS)
 else
-bin_PROGRAMS =
+bin_PROGRAMS = $(GIMP_PLUGINS)
 endif
 
-u7shp_SOURCES = u7shp.cc
+u7shp_SOURCES = $(GIMP_PLUGIN_SRC).cc
 
 u7shp_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/files -I$(top_srcdir)/headers \
 	-I$(top_srcdir)/shapes -I$(top_srcdir)/imagewin -I$(top_srcdir)/files \
@@ -101,12 +107,18 @@ EXTRA_DIST=	\
 	uniquepal.c \
 	logo.xpm
 
-if GIMP_PLUGIN
+if GIMP3_PLUGIN
+install-exec-local:
+	install -d $(DESTDIR)$(GIMP_PLUGIN_PREFIX)/u7shp
+	install -c $(GIMP_PLUGINS) $(DESTDIR)$(GIMP_PLUGIN_PREFIX)/u7shp
+else
+if GIMP2_PLUGIN
 install-exec-local:
 	install -d $(DESTDIR)$(GIMP_PLUGIN_PREFIX)
 	install -c $(GIMP_PLUGINS) $(DESTDIR)$(GIMP_PLUGIN_PREFIX)
 else
 install-exec-local:
+endif
 endif
 
 CLEANFILES = *~ u7shp$(EXEEXT)

--- a/mapedit/gimpwin32.txt
+++ b/mapedit/gimpwin32.txt
@@ -1,16 +1,22 @@
 The GIMP shapes plug-in
 =======================
 
-This Plug-In is for the Windows Port of The Gimp. It is tested with the latest version (2.8.14).
+This Plug-In is for the Windows Port of The Gimp. It is tested with the latest version of Gimp 2 (2.8.14) and Gimp 3 (3.0)
 With it you can edit *.shp files used by Exult and the original Ultima VII. This shapes are compressed into *.flx or *.vga files. Use expack from our tools download to extract the files.
 
 Get the installer for The Gimp at http://www.gimp.org/downloads/
 
-Install
-=======
+Install for Gimp 2
+==================
 
 - Install the Gimp (example: C:\Program Files\GIMP 2)
 - execute Gimp20Plugin.exe and choose C:\Program Files\GIMP 2\lib\gimp\2.0\plug-ins (if you installed the Gimp somewhere else, change accordingly) for extract path. If you extracted the file to some other directory copy u7shp.exe into that directory
+
+Install for Gimp 3
+==================
+
+- Install the Gimp (example: C:\Program Files\GIMP 3)
+- execute Gimp20Plugin.exe and choose C:\Program Files\GIMP 3\lib\gimp\3.0\plug-ins\u7shp (if you installed the Gimp somewhere else, change accordingly) for extract path. If you extracted the file to some other directory copy u7shp.exe into that directory
 
 
 Usage

--- a/win32/exult_shpplugin_installer.iss
+++ b/win32/exult_shpplugin_installer.iss
@@ -30,11 +30,11 @@ AppSupportURL=https://exult.info/
 AppUpdatesURL=https://exult.info/
 ; Setup exe version number:
 VersionInfoVersion=1.11.0
-DisableDirPage=no
-DefaultDirName={code:GetGimpDir|{pf}\GIMP 2}
+DisableDirPage=yes
+DefaultDirName="{userappdata}\gimp\3.0\plug-ins\u7shp"
 DisableProgramGroupPage=yes
 DefaultGroupName=Exult GIMP Plugin
-OutputBaseFilename=Gimp20Plugin
+OutputBaseFilename=Gimp30Plugin
 Compression=lzma
 SolidCompression=yes
 InternalCompressLevel=max
@@ -46,34 +46,24 @@ WizardStyle=modern
 CreateUninstallRegKey=no
 UpdateUninstallLogAppName=no
 AppID=GIMP-U7SHP-Plugin
-UninstallFilesDir={code:GetUninstallDir}
+PrivilegesRequired=none
 
 [Files]
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
+; The official Gimp 3 is built with CLang, but the Shape plugin is built with GCC, this we need the DLLs libgcc_s_seh and libstdc++
 ; 32-bit files
-Source: "GimpPlugin-i686\u7shp.exe"; DestDir: "{app}\lib\gimp\2.0\plug-ins"; Flags: ignoreversion; Check: not Is64BitGIMP
+Source: "GimpPlugin-i686\u7shp.exe"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: not Is64BitGIMP
+Source: "GimpPlugin-i686\libgcc_s_seh-1.dll"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: not Is64BitGIMP
+Source: "GimpPlugin-i686\libstdc++-6.dll"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: not Is64BitGIMP
 ; 64-bit files
-Source: "GimpPlugin-x86_64\u7shp.exe"; DestDir: "{app}\lib\gimp\2.0\plug-ins"; Flags: ignoreversion; Check: Is64BitGIMP
+Source: "GimpPlugin-x86_64\u7shp.exe"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: Is64BitGIMP
+Source: "GimpPlugin-x86_64\libgcc_s_seh-1.dll"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: Is64BitGIMP
+Source: "GimpPlugin-x86_64\libstdc++-6.dll"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: Is64BitGIMP
 
 [Code]
-function SHAutoComplete(hWnd: Integer; dwFlags: DWORD): Integer; external 'SHAutoComplete@shlwapi.dll stdcall delayload';
-
-function WideCharToMultiByte(CodePage: Cardinal; dwFlags: DWORD; lpWideCharStr: String; cchWideCharStr: Integer;
-							 lpMultiByteStr: PAnsiChar; cbMultiByte: Integer; lpDefaultChar: Integer;
-							 lpUsedDefaultChar: Integer): Integer; external 'WideCharToMultiByte@Kernel32 stdcall';
-
-function MultiByteToWideChar(CodePage: Cardinal; dwFlags: DWORD; lpMultiByteStr: PAnsiChar; cbMultiByte: Integer;
-							 lpWideCharStr: String; cchWideChar: Integer): Integer;
-							 external 'MultiByteToWideChar@Kernel32 stdcall';
-
-function GetLastError(): DWORD; external 'GetLastError@Kernel32 stdcall';
-
 const
-	SHACF_FILESYSTEM = $1;
-	CP_UTF8 = 65001;
-
-	RegPath = 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\WinGimp-2.0_is1';
-	RegPathNew = 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GIMP-2_is1';
+	RegPath = 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\WinGimp-3.0_is1';
+	RegPathNew = 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GIMP-3_is1';
 	RegKey = 'Inno Setup: App Path';
 	VerKey = 'DisplayName';
 
@@ -83,183 +73,12 @@ var
 
 	InstallType: (itOld, itNew, itNew64);
 
-function Count(What, Where: String): Integer;
-begin
-	Result := 0;
-	if Length(What) = 0 then //nothing to count - should this throw an error?
-		exit;
-
-	while Pos(What,Where)>0 do
-	begin
-		Where := Copy(Where,Pos(What,Where)+Length(What),Length(Where));
-		Result := Result + 1;
-	end;
-end;
-
-
-//split text to array
-procedure Explode(var ADest: TArrayOfString; aText, aSeparator: String);
-var tmp: Integer;
-begin
-	if aSeparator='' then
-		exit;
-
-	SetArrayLength(ADest,Count(aSeparator,aText)+1)
-
-	tmp := 0;
-	repeat
-		if Pos(aSeparator,aText)>0 then
-		begin
-
-			ADest[tmp] := Copy(aText,1,Pos(aSeparator,aText)-1);
-			aText := Copy(aText,Pos(aSeparator,aText)+Length(aSeparator),Length(aText));
-			tmp := tmp + 1;
-
-		end else
-		begin
-
-			 ADest[tmp] := aText;
-			 aText := '';
-
-		end;
-	until Length(aText)=0;
-end;
-
-//compares two version numbers, returns -1 if vA is newer, 0 if both are identical, 1 if vB is newer
-function CompareVersion(vA,vB: String): Integer;
-var tmp: TArrayOfString;
-	verA,verB: Array of Integer;
-	i,len: Integer;
-begin
-
-	StringChange(vA,'-','.');
-	StringChange(vB,'-','.');
-
-	Explode(tmp,vA,'.');
-	SetArrayLength(verA,GetArrayLength(tmp));
-	for i := 0 to GetArrayLength(tmp) - 1 do
-		verA[i] := StrToIntDef(tmp[i],0);
-
-	Explode(tmp,vB,'.');
-	SetArrayLength(verB,GetArrayLength(tmp));
-	for i := 0 to GetArrayLength(tmp) - 1 do
-		verB[i] := StrToIntDef(tmp[i],0);
-
-	len := GetArrayLength(verA);
-	if GetArrayLength(verB) < len then
-		len := GetArrayLength(verB);
-
-	for i := 0 to len - 1 do
-		if verA[i] < verB[i] then
-		begin
-			Result := 1;
-			exit;
-		end else
-		if verA[i] > verB[i] then
-		begin
-			Result := -1;
-			exit
-		end;
-
-	if GetArrayLength(verA) < GetArrayLength(verB) then
-	begin
-		Result := 1;
-		exit;
-	end else
-	if GetArrayLength(verA) > GetArrayLength(verB) then
-	begin
-		Result := -1;
-		exit;
-	end;
-
-	Result := 0;
-end;
-
-function Utf82String(const pInput: AnsiString): String;
-#ifndef UNICODE
-	#error "Unicode Inno Setup required"
-#endif
-var Output: String;
-	ret, outLen, nulPos: Integer;
-begin
-	outLen := MultiByteToWideChar(CP_UTF8, 0, pInput, -1, Output, 0);
-	Output := StringOfChar(#0,outLen);
-	ret := MultiByteToWideChar(CP_UTF8, 0, pInput, -1, Output, outLen);
-
-	if ret = 0 then
-		RaiseException('MultiByteToWideChar failed: ' + IntToStr(GetLastError));
-
-	nulPos := Pos(#0,Output) - 1;
-	if nulPos = -1 then
-		nulPos := Length(Output);
-
-	Result := Copy(Output,1,nulPos);
-end;
-
-function LoadStringFromUTF8File(const pFileName: String; var oS: String): Boolean;
-var Utf8String: AnsiString;
-begin
-	Result := LoadStringFromFile(pFileName, Utf8String);
-	oS := Utf82String(Utf8String);
-end;
-
-function String2Utf8(const pInput: String): AnsiString;
-var Output: AnsiString;
-	ret, outLen, nulPos: Integer;
-begin
-	outLen := WideCharToMultiByte(CP_UTF8, 0, pInput, -1, Output, 0, 0, 0);
-	Output := StringOfChar(#0,outLen);
-	ret := WideCharToMultiByte(CP_UTF8, 0, pInput, -1, Output, outLen, 0, 0);
-
-	if ret = 0 then
-		RaiseException('WideCharToMultiByte failed: ' + IntToStr(GetLastError));
-
-	nulPos := Pos(#0,Output) - 1;
-	if nulPos = -1 then
-		nulPos := Length(Output);
-
-	Result := Copy(Output,1,nulPos);
-end;
-
-function SaveStringToUTF8File(const pFileName, pS: String; const pAppend: Boolean): Boolean;
-begin
-	Result := SaveStringToFile(pFileName, String2Utf8(pS), pAppend);
-end;
-
-procedure SaveToUninstInf(const pText: AnsiString);
-var sUnInf: String;
-	sOldContent: String;
-begin
-	sUnInf := ExpandConstant('{app}\uninst\uninst.inf');
-
-	if not FileExists(sUnInf) then //save small header
-		SaveStringToUTF8File(sUnInf,#$feff+'#Additional uninstall tasks'#13#10+ //#$feff BOM is required for LoadStringsFromFile
-									'#This file uses UTF-8 encoding'#13#10+
-									'#'#13#10+
-									'#Empty lines and lines beginning with # are ignored'#13#10+
-									'#'#13#10+
-									'#Add uninstallers for GIMP add-ons that should be removed together with GIMP like this:'#13#10+
-									'#Run:<description>/<full path to uninstaller>/<parameters for automatic uninstall>'#13#10+
-									'#'#13#10+
-									'#The file is parsed in reverse order' + #13#10 +
-									'' + #13#10 //needs '' in front, otherwise preprocessor complains
-									,False)
-	else
-	begin
-		if LoadStringFromUTF8File(sUnInf,sOldContent) then
-			if Pos(#13#10+pText+#13#10,sOldContent) > 0 then //don't write duplicate lines
-				exit;
-	end;
-
-	SaveStringToUTF8File(sUnInf,pText+#13#10,True);
-end;
-
 procedure GetGimpInfo(const pRootKey: Integer; const pRegPath: String);
 var p: Integer;
 begin
 	If not RegQueryStringValue(pRootKey, pRegPath, RegKey, GimpPath) then //find Gimp install dir
 	begin
-		GimpPath := ExpandConstant('{pf}\GIMP 2');
+		GimpPath := ExpandConstant('{pf}\GIMP 3');
 	end;
 
 	If not RegQueryStringValue(pRootKey, pRegPath, VerKey, GimpVer) then //find Gimp version
@@ -277,11 +96,6 @@ begin
 	end;
 end;
 
-procedure WriteUninstallInfo();
-begin
-	if InstallType <> itOld then //new installer expects components to be listed in the uninst.inf file
-		SaveToUninstInf('Run:GIMP Help/'+ExpandConstant('{uninstallexe}')+'//SILENT /NORESTART');
-end;
 
 function InitializeSetup(): Boolean;
 begin
@@ -303,7 +117,7 @@ begin
 		InstallType := itOld;
 	end else
 	begin
-		GimpPath := ExpandConstant('{pf}\GIMP 2'); //provide some defaults
+		GimpPath := ExpandConstant('{pf}\GIMP 3'); //provide some defaults
 		GimpVer := '0';
 	end;
 end;
@@ -311,38 +125,4 @@ end;
 function Is64BitGIMP(): boolean;
 begin
 	Result := InstallType = itNew64;
-end;
-
-procedure CurStepChanged(pCurStep: TSetupStep);
-begin
-	case pCurStep of
-		ssPostInstall:
-		begin
-			WriteUninstallInfo();
-		end;
-	end;
-end;
-
-procedure InitializeWizard();
-var r: Integer;
-begin
-	r := SHAutoComplete(WizardForm.DirEdit.Handle,SHACF_FILESYSTEM);
-end;
-
-function GetGimpDir(S: String): String;
-begin
-	Result := GimpPath;
-end;
-
-function GetUninstallDir(default: String): String;
-begin
-	if CompareVersion(GimpVer,'2.10.0') >= 0 then
-		Result := ExpandConstant('{app}')
-	else
-	begin
-		if InstallType = itOld then
-			Result := ExpandConstant('{app}\setup')
-		else
-			Result := ExpandConstant('{app}\uninst');
-	end;
 end;


### PR DESCRIPTION
  Commit 1 of 1:
    configure.ac
      Switch the Gimp requirement from 2 to 3
      Build the Gimp 2 or Gimp 3 plugin depending on the installed Gimp
      Die gracefully when asked to buid the plugin but Gimp is not installed
      Install the plugin into the user location with --enable-gimp-plugin=user
        Linux and al : ~/.config/GIMP/x.0/plug-ins/[u7shp/]
        MacOS : ~/Library/Application Support/GIMP/x.0/plug-ins/[u7shp/]
    Makefile.mingw
      Switch the Gimp requirement from 2 to 3
      Build the Gimp 2 or Gimp 3 plugin depending on the installed Gimp
      Die gracefully when asked to buid the plugin but Gimp is not installed
      Ensure the libgcc and the libstdc++ are statically linked
      Add pluginclean to allclean
      Fix comment in the CLANGARM64 branch
    mapedit/Makefile.am
      Ensure that u7shp get stored into the bin folder of the Exult install
      Install the Gimp 3 plugin into its subfolder
    mapedit/u7shp.cc
      Rework the Gimp side of the plugin
      Fix the API changes in the Shape side of the plugin
      Fix the load_image when the GFile does not exist
      Replace NULL by nullptr
      Retrieved some cleanup changes by Marzo
      Apply clang-format
    mapedit/u7shp-old.cc
      Restore Gimp 2 u7shp.cc as u7shp-old.cc
    .github/workflows/snapshot.yml + snapshots-windows.yml
      Produce and Use Gimp30Plugin
    .github/workflows/ci-windows.yml + snapshots-windows.yml
      Refresh the MingW cache to bring Gimp 3
    README.win32, mapedit/gimpwin32
      Document the target folder of the plugin in Gimp 3
    win32/exult_shpplugin_installer.iss
      Move the install target from Gimp 2 to Gimp 3, from Dominus
      Simplify the install into the local folder %APPDATA%\GIMP\3.0\plug-ins\u7shp