### PR TITLE
Fix double automatic door opening

### DIFF
--- a/actions.cc
+++ b/actions.cc
@@ -353,6 +353,13 @@ int Path_walking_actor_action::handle_event(Actor* actor) {
  */
 
 bool Path_walking_actor_action::open_door(Actor* actor, Game_object* door) {
+	// Check if already handling a door interaction
+	if (handling_door || door_sequence_complete) {
+		return false;
+	}
+	// Set the handling flag to indicate a door is being processed
+	handling_door = true;
+
 	const Tile_coord cur = actor->get_tile();
 	// Get door's footprint in tiles.
 	const TileRect foot = door->get_footprint();
@@ -400,10 +407,12 @@ bool Path_walking_actor_action::open_door(Actor* actor, Game_object* door) {
 				actor, past,
 				new Sequence_actor_action(
 						new Frames_actor_action(frames.data(), frames.size()),
-						new Activate_actor_action(door),
+						new Door_activate_action(door, this),
 						new Frames_actor_action(&standframe, 1))));
+		door_sequence_complete = true;
 		return true;
 	}
+	handling_door = false;
 	return false;
 }
 

--- a/actions.h
+++ b/actions.h
@@ -133,6 +133,9 @@ private:
 		subseq = sub;
 	}
 
+	bool handling_door = false;    // Temporary flag to track door handling
+	bool door_sequence_complete;
+
 public:
 	Path_walking_actor_action(
 			PathFinder* p = nullptr, int maxblk = 3, int pers = 0);
@@ -160,6 +163,18 @@ public:
 	Actor_action* kill() override {
 		deleted = true;
 		return this;
+	}
+
+	void set_handling_door(bool val) {
+		handling_door = val;
+	}
+
+	bool is_door_sequence_complete() const {
+		return door_sequence_complete;
+	}
+
+	void set_door_sequence_complete() {
+		door_sequence_complete = true;
 	}
 };
 
@@ -392,6 +407,23 @@ class Change_actor_action : public Actor_action {
 public:
 	Change_actor_action(Game_object* o, int sh, int fr, int ql);
 	int handle_event(Actor* actor) override;
+};
+
+/*
+ *  Action to open a door.
+ */
+class Door_activate_action : public Activate_actor_action {
+	Path_walking_actor_action* path_action;
+
+public:
+	Door_activate_action(Game_object* o, Path_walking_actor_action* p)
+			: Activate_actor_action(o), path_action(p) {}
+
+	int handle_event(Actor* actor) override {
+		int ret = Activate_actor_action::handle_event(actor);
+		path_action->set_handling_door(false);
+		return ret;
+	}
 };
 
 #endif /* INCL_ACTIONS */


### PR DESCRIPTION
Fixes #373
When the Avatar "runs" (via mouse movement) against a closed door, he will open it, go through, turn to the door, close it, turn away. This was bugged as in the Avatar opened and closed it twice, moving through the locked door at times.