### PR TITLE
Permit alternate installation folders for the Shape Thumbnailer configuration files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,8 @@ cxx_compilers="g++ clang++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC"
 
 # determine windowing system from 'host'
 AC_MSG_CHECKING([windowing system])
-HOME_DATADIR="${XDG_CONFIG_HOME:-${HOME}/.config}"
+HOME_CFGDIR="${XDG_CONFIG_HOME:-${HOME}/.config}"
+HOME_SHRDIR="${XDG_DATA_HOME:-${HOME}/.local/share}"
 case "$host_os" in
 	linux-android*)
 		# Android cross compiled from Linux, supported.
@@ -117,7 +118,7 @@ case "$host_os" in
 		SYSLIBS="-framework CoreFoundation -framework AudioUnit -framework AudioToolbox -framework CoreMIDI"
 		CXXFLAGS="$CXXFLAGS -stdlib=libc++ -pthread"
 		EXULT_DATADIR="/Library/Application\ Support/Exult/data"
-		HOME_DATADIR="${HOME}/Library/Application\ Support"
+		HOME_CFGDIR="${HOME}/Library/Application\ Support"
 		ARCH=macosx
 		dnl swap around clang for OSX
 		cxx_compilers="clang++ g++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC"
@@ -882,9 +883,10 @@ else
 fi
 
 # gnome-shp-thumbnailer
-AC_ARG_ENABLE(gnome-shp-thumbnailer, AS_HELP_STRING([--enable-gnome-shp-thumbnailer], [Build Gnome SHP Thumbnailer @<:@default no@:>@]),,enable_gnome_shp_thumbnailer=no)
+AC_ARG_ENABLE(gnome-shp-thumbnailer, AS_HELP_STRING([--enable-gnome-shp-thumbnailer@<:@=yes|system|local|user|ingame|no@:>@],
+		[Build Gnome SHP Thumbnailer, yes or system and local for system (local) install (requires root), user for user install, ingame for Exult ingame install (requires XDG_DATA_DIRS) @<:@default no@:>@]),,enable_gnome_shp_thumbnailer=no)
 AC_MSG_CHECKING([whether to build the Gnome SHP Thumbnailer])
-if test x$enable_gnome_shp_thumbnailer = xyes; then
+if test x$enable_gnome_shp_thumbnailer != xno; then
 	AC_MSG_RESULT(yes)
 	# needs Gdk-Pixbuf
 	PKG_CHECK_MODULES(GDK_PIXBUF, gdk-pixbuf-2.0, have_gdk_pixbuf=yes, have_gdk_pixbuf=no)
@@ -899,6 +901,16 @@ if test x$enable_gnome_shp_thumbnailer = xyes; then
 		exit 1
 	fi
 	AM_CONDITIONAL(BUILD_GTHUMB, true)
+	if   test x$enable_gnome_shp_thumbnailer == xlocal; then
+		GTHUMB_PREFIX="/usr/local/share"
+	elif test x$enable_gnome_shp_thumbnailer == xuser; then
+		GTHUMB_PREFIX="${HOME_SHRDIR}"
+	elif test x$enable_gnome_shp_thumbnailer == xingame; then
+		GTHUMB_PREFIX="${datadir}"
+	else
+		GTHUMB_PREFIX="/usr/share"
+	fi
+	AC_SUBST(GTHUMB_PREFIX)
 else
 	AM_CONDITIONAL(BUILD_GTHUMB, false)
 	AC_MSG_RESULT(no)
@@ -924,7 +936,7 @@ if test x$enable_gimp_plugin != xno; then
 			AM_CONDITIONAL(GIMP3_PLUGIN, true)
 			AS_IF([test x$enable_gimp_plugin != xuser],
 				[GIMP_PLUGIN_PREFIX=`$GIMPTOOL --gimpplugindir`],
-				[GIMP_PLUGIN_PREFIX="${HOME_DATADIR}/GIMP/3.0"])
+				[GIMP_PLUGIN_PREFIX="${HOME_CFGDIR}/GIMP/3.0"])
 			GIMP_PLUGIN_PREFIX="$GIMP_PLUGIN_PREFIX/plug-ins"
 			AC_SUBST(GIMP_PLUGIN_PREFIX)
 			AC_DEFINE(HAVE_GIMP, 1, [Have GIMP])
@@ -948,7 +960,7 @@ if test x$enable_gimp_plugin != xno; then
 				AM_CONDITIONAL(GIMP2_PLUGIN, true)
 				AS_IF([test x$enable_gimp_plugin != xuser],
 					[GIMP_PLUGIN_PREFIX=`$GIMPTOOL --gimpplugindir`],
-					[GIMP_PLUGIN_PREFIX="${HOME_DATADIR}/GIMP/2.0"])
+					[GIMP_PLUGIN_PREFIX="${HOME_CFGDIR}/GIMP/2.0"])
 				GIMP_PLUGIN_PREFIX="$GIMP_PLUGIN_PREFIX/plug-ins"
 				AC_SUBST(GIMP_PLUGIN_PREFIX)
 				AC_DEFINE(HAVE_GIMP, 1, [Have GIMP])

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -65,14 +65,24 @@ gnome_shp_thumbnailer_LDADD = \
 	$(PNG_LIBS) $(ZLIB_LIBS) $(SYSLIBS) $(GDK_PIXBUF_LIBS)
 
 if BUILD_GTHUMB
-## Does not work:
-#thumbnailerdir=$(datadir)/thumbnailers
-## Needs to be in /usr/share/thumbnailers
-thumbnailerdir=/usr/share/thumbnailers
+# The actual executable "gnome_shp_thumbnailer" is in <Exult>/bin
+#  It needs two files visible from XDG_DATA_HOME or one of XDG_DATA_DIRS :
+#   <XDG_DATA_HOME or one of XDG_DATA_DIRS>/mime/packages/x-shapefile.xml
+#     Defines the MIME type "image/x-shapefile"
+#   <XDG_DATA_HOME or one of XDG_DATA_DIRS>/thumbnailers/gnome_u7shapes.thumbnailer
+#     Thumbnails the U7 Shapes with "gnome_shp_thumbnailers"
+# The installation XDG_DATA_HOME or XDG_DATA_DIRS are chosen using
+#  --enable-gnome-shp-thumbnailer=Target
+#   with Target "yes" or "system" ( default ) => /usr/share ( requires root )
+#   with Target "local"                       => /usr/local/share ( requires root )
+#   with Target "user"                        => ~/.local/share
+#   with Target "ingame"                      => <Exult>/share ( requires setting this folder in XDG_DATA_DIRS )
+#
+thumbnailerdir=$(DESTDIR)$(GTHUMB_PREFIX)/thumbnailers
 thumbnailer_in_files=$(top_srcdir)/tools/gnome_u7shapes.thumbnailer.in
 thumbnailer_DATA=$(thumbnailer_in_files:.thumbnailer.in=.thumbnailer)
 gnome_shp_thumbnailer_DATA=x-shapefile.xml
-gnome_shp_thumbnailerdir=$(DESTDIR)$(datadir)/mime/packages
+gnome_shp_thumbnailerdir=$(DESTDIR)$(GTHUMB_PREFIX)/mime/packages
 
 # Rule to make the service file with bindir expanded
 $(thumbnailer_DATA): $(thumbnailer_in_files)
@@ -117,10 +127,10 @@ cmanip_LDADD = \
 
 if BUILD_GTHUMB
 install-data-hook:
-	update-mime-database $(DESTDIR)$(datadir)/mime || :
+	update-mime-database $(DESTDIR)$(GTHUMB_PREFIX)/mime || :
 
 uninstall-hook:
-	update-mime-database $(DESTDIR)$(datadir)/mime || :
+	update-mime-database $(DESTDIR)$(GTHUMP_PREFIX)/mime || :
 else
 install-data-hook:
 uninstall-hook:

--- a/tools/x-shapefile.xml
+++ b/tools/x-shapefile.xml
@@ -2,6 +2,6 @@
 	<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
 		<mime-type type="image/x-shapefile">
 			<comment>Exult Shape File</comment>
-			<glob pattern="*.shp"/>
+			<glob pattern="*.shp" weight="60"/>
 		</mime-type>
 	</mime-info>


### PR DESCRIPTION
The aim is to remove the need to be root when installing the Shape Thumbnailer as it installs two configuration files into `/usr/share` :
- `configure.ac`
```
      Add an optional target to the --enable-gnome-shp-thumbnailer option into GTHUMB_PREFIX
        system or (default) yes : /usr/share       ( requires root at install )
        local                   : /usr/local/share ( requires root at install )
        user                    : ~/.local/share
        ingame                  : <Exult>/share ( requires adding that folder to XDG_DATA_DIRS )
```
- `tools/x-shapefile.xml`
Increase the priority to 60 to pass over another .SHP file type
- `tools/Makefile.am`
Rework the installation of the configuration files and the `update-mime-database` step using `GTHUMB_PREFIX`

### Note to Reviewers

- The option inventory of `--enable-gnome-shp-thumbnailer` should go into some documentation for Exult, but I have not found a suitable place.
- The increase of the priority over the default ( 50 ) is not nice, I hoped that the Exult thumbnailer would be tested _after_
an installed SHP thumbnailer as this one would fail its magic check on the SHP file, but I could not make that work.