### PR TITLE
Build the Windows Snapshot with CLang64

### DIFF
--- a/.github/workflows/snapshots-windows.yml
+++ b/.github/workflows/snapshots-windows.yml
@@ -36,11 +36,11 @@ jobs:
           update: true
           install: |
             base-devel git p7zip zip
-            mingw-w64-x86_64-toolchain mingw-w64-x86_64-binutils mingw-w64-x86_64-ntldd mingw-w64-x86_64-SDL2
-            mingw-w64-x86_64-fluidsynth mingw-w64-x86_64-libtimidity mingw-w64-x86_64-libogg mingw-w64-x86_64-libvorbis
-            mingw-w64-x86_64-munt-mt32emu mingw-w64-x86_64-libpng mingw-w64-x86_64-zlib mingw-w64-x86_64-SDL2_image
-            mingw-w64-x86_64-gtk3 mingw-w64-x86_64-adwaita-icon-theme mingw-w64-x86_64-libxml2 mingw-w64-x86_64-freetype
-            mingw-w64-x86_64-gimp mingw-w64-x86_64-icu
+            mingw-w64-clang-x86_64-toolchain mingw-w64-clang-x86_64-binutils mingw-w64-clang-x86_64-ntldd mingw-w64-clang-x86_64-SDL2
+            mingw-w64-clang-x86_64-fluidsynth mingw-w64-clang-x86_64-libtimidity mingw-w64-clang-x86_64-libogg mingw-w64-clang-x86_64-libvorbis
+            mingw-w64-clang-x86_64-munt-mt32emu mingw-w64-clang-x86_64-libpng mingw-w64-clang-x86_64-zlib mingw-w64-clang-x86_64-SDL2_image
+            mingw-w64-clang-x86_64-gtk3 mingw-w64-clang-x86_64-adwaita-icon-theme mingw-w64-clang-x86_64-libxml2 mingw-w64-clang-x86_64-freetype
+            mingw-w64-clang-x86_64-gimp mingw-w64-clang-x86_64-icu
             mingw-w64-i686-toolchain mingw-w64-i686-binutils mingw-w64-i686-ntldd mingw-w64-i686-SDL2
             mingw-w64-i686-fluidsynth mingw-w64-i686-libtimidity mingw-w64-i686-libogg mingw-w64-i686-libvorbis
             mingw-w64-i686-libpng mingw-w64-i686-zlib mingw-w64-i686-SDL2_image
@@ -93,7 +93,7 @@ jobs:
       - name: Build x86_64
         if: ${{ env.EXULT_REPO_ALIVE == 'true' }}
         env:
-          MSYSTEM: MINGW64
+          MSYSTEM: CLANG64
           ARCH: x86_64
         run: |
           SNAPSHOT_PATH=$(cygpath -m ~/Exult-dist)

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -755,8 +755,8 @@ plugininstall: plugin
 	# Note: Gimp has almost everything a plugin needs already, so we don't
 	# need to do this step.
 	#$(call copy_dlls_for_exe, u7shp$(EXEEXT), $(GIMPPATH))
-	# But we do need the GCC runtime & C++ libraries for CLang built Gimp 3, for a GCC built plugin.
-	for ff in $$($(MSYSTEM_PREFIX)/bin/ntldd u7shp$(EXEEXT) | grep -oE 'libgcc_s_seh-1\.dll|libgcc_s_dw2-1\.dll|libstdc\+\+-6\.dll' | sort -u); do cp -v $(MSYSTEM_PREFIX)/bin/$$ff $(GIMPPATH)/$$ff; done
+	# We do need the GCC runtime (for a GCC built plugin) and the C++ libraries, in case Gimp 3 is built with another compiler than the plugin.
+	for ff in $$($(MSYSTEM_PREFIX)/bin/ntldd u7shp$(EXEEXT) | grep -oE 'libgcc_s_seh-1\.dll|libgcc_s_dw2-1\.dll|libstdc\+\+-6\.dll|libc\+\+\.dll' | sort -u); do cp -v $(MSYSTEM_PREFIX)/bin/$$ff $(GIMPPATH)/$$ff; done
 
 plugindist: GIMPPATH:=$(DISTPATH)/GimpPlugin-$(MSYSTEM_CARCH)
 plugindist: plugin plugininstall

--- a/win32/exult_shpplugin_installer.iss
+++ b/win32/exult_shpplugin_installer.iss
@@ -50,13 +50,12 @@ PrivilegesRequired=none
 
 [Files]
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
-; The official Gimp 3 is built with CLang, but the Shape plugin is built with GCC, this we need the DLLs libgcc_s_seh and libstdc++
+; The official Gimp 3 32 bits is built with MingW32 and so is Exult, the official Gimp 3 64 bits is built with CLang64 and so is Exult
+; => The dependent DLLs of the Gimp plugin are provided by Gimp
 ; 32-bit files
 Source: "GimpPlugin-i686\u7shp.exe"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: not Is64BitGIMP
 ; 64-bit files
 Source: "GimpPlugin-x86_64\u7shp.exe"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: Is64BitGIMP
-Source: "GimpPlugin-x86_64\libgcc_s_seh-1.dll"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: Is64BitGIMP
-Source: "GimpPlugin-x86_64\libstdc++-6.dll"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: Is64BitGIMP
 
 [Code]
 const


### PR DESCRIPTION
This removes the need of the dependent DLLs `libgcc_s_seh-1.dll` and `libstdc++-6.dll`.
- `.github/workflows/snapshots-windows.yml` : Bring pacman packages from `mingw-w64-clang-x86_64`, Use MSys2 variant `CLANG64`,
- `Makefile.mingw` : For safety during the build, deploy the CLang `libc++.dll` with the plugin into the `C:\GimpPlugin` folder along with `u7shp.exe` in case Gimp is built using GCC,
- `win32/exult_shpplugin_installer.iss` : The build of the plugin build in the Windows **snapshot** uses CLang64 like the build of Gimp : Remove the dependent DLLs from the installation script.