### PR TITLE
Allow keyring.dat to be saved when playing SI Beta

### DIFF
--- a/usecode/ucinternal.cc
+++ b/usecode/ucinternal.cc
@@ -3220,7 +3220,7 @@ bool Usecode_internal::in_usecode_for(Game_object* item, Usecode_events event) {
 
 void Usecode_internal::write() {
 	// Assume new games will have keyring.
-	if (Game::get_game_type() != BLACK_GATE && !Game::is_si_beta()) {
+	if (Game::get_game_type() != BLACK_GATE) {
 		keyring->write();    // write keyring data
 	}
 


### PR DESCRIPTION
Removes the check preventing Keyring.dat from being saved while playing SI Beta. Not saving keyring.dat causes exult to terminate due to < gamedat >/keyring.dat not existing  when trying to create single combined savegame files from gamedat as the code in gamedat.cc assumes that all SI games will have a keyring.dat
It seems quite safe to allow this as the keyring should always be empty so Keyring.dat will be empty. I consider allowing this preferable to special casing SIBeta in gamedat.cc. 
This change has Exult treat SI beta the same as the release version of SI without SS in regards to saving the keyring. However SI without SS will reload keyring.dat but SIBeta is still prevented from reading it. This shouldn't matter unless someone tries to mod the keyring into SI beta
fixes #593
