### PR TITLE
Windows Snapshot Fixes

### DIFF
--- a/.github/workflows/snapshots-windows.yml
+++ b/.github/workflows/snapshots-windows.yml
@@ -43,7 +43,7 @@ jobs:
             mingw-w64-clang-x86_64-gimp mingw-w64-clang-x86_64-icu
             mingw-w64-i686-toolchain mingw-w64-i686-binutils mingw-w64-i686-ntldd mingw-w64-i686-SDL2
             mingw-w64-i686-fluidsynth mingw-w64-i686-libtimidity mingw-w64-i686-libogg mingw-w64-i686-libvorbis
-            mingw-w64-i686-libpng mingw-w64-i686-zlib mingw-w64-i686-SDL2_image
+            mingw-w64-i686-libpng mingw-w64-i686-zlib 
             mingw-w64-i686-gtk3 mingw-w64-i686-adwaita-icon-theme mingw-w64-i686-libxml2 mingw-w64-i686-freetype
             mingw-w64-i686-gimp mingw-w64-i686-icu mingw-w64-i686-cmake
       - name: Checkout munt
@@ -63,6 +63,15 @@ jobs:
           cd munt
           cmake ./../libmt32emu -Dmunt_WITH_MT32EMU_SMF2WAV=FALSE -Dmunt_WITH_MT32EMU_QT=FALSE -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX
           ninja install
+      - name: Download and manually install SDL2_image-devel-2.8.8-mingw.tar.gz
+        if: ${{ env.EXULT_REPO_ALIVE == 'true' }}
+        env:
+          MSYSTEM: MINGW32
+          ARCH: i686
+        run: |
+         curl -L https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.8/SDL2_image-devel-2.8.8-mingw.tar.gz |gunzip |tar x
+         cp -r -v SDL2_image-2.8.8/i686-w64-mingw32/* $MINGW_PREFIX
+         rm -r -f SDL2_image-2.8.8
       - name: Checkout code for i686 build
         if: ${{ env.EXULT_REPO_ALIVE == 'true' }}
         uses: actions/checkout@v4

--- a/.github/workflows/snapshots-windows.yml
+++ b/.github/workflows/snapshots-windows.yml
@@ -61,11 +61,10 @@ jobs:
           cd $GITHUB_WORKSPACE
           mkdir -p munt
           cd munt
-          which cmake
           cmake --version
           cmake ./../libmt32emu -Dmunt_WITH_MT32EMU_SMF2WAV=FALSE -Dmunt_WITH_MT32EMU_QT=FALSE -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           ninja install
-      - name: Download and manually install SDL2_image-devel-2.8.8-mingw.tar.gz
+      - name: Download and manually install SDL2_image-devel-2.8.8-mingw.tar.gz for i686
         if: ${{ env.EXULT_REPO_ALIVE == 'true' }}
         env:
           MSYSTEM: MINGW32

--- a/.github/workflows/snapshots-windows.yml
+++ b/.github/workflows/snapshots-windows.yml
@@ -61,7 +61,9 @@ jobs:
           cd $GITHUB_WORKSPACE
           mkdir -p munt
           cd munt
-          cmake ./../libmt32emu -Dmunt_WITH_MT32EMU_SMF2WAV=FALSE -Dmunt_WITH_MT32EMU_QT=FALSE -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX
+          which cmake
+          cmake --version
+          cmake ./../libmt32emu -Dmunt_WITH_MT32EMU_SMF2WAV=FALSE -Dmunt_WITH_MT32EMU_QT=FALSE -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           ninja install
       - name: Download and manually install SDL2_image-devel-2.8.8-mingw.tar.gz
         if: ${{ env.EXULT_REPO_ALIVE == 'true' }}


### PR DESCRIPTION
Some fixes for the Windows Snapshot Workflow

First no longer install mingw-w64-i686-SDL2_image and instead download and install https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.8/SDL2_image-devel-2.8.8-mingw.tar.gz  for i686

Also added work around for CMake 4 error with libmt32emu by adding -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to the command to tell Cmake to treat  CMakeLists as if it is version 3.5 and not the no longer supported 2.8.12 as specified in the file