### PR TITLE
Fix List Field fights

### DIFF
--- a/actors.cc
+++ b/actors.cc
@@ -3034,6 +3034,10 @@ int Actor::reduce_health(
 		// No more pushover banes!
 		if (npc) {    // Just to be sure.
 			set_oppressor(npc->get_npc_num());
+			// Unset target, so that we are not endlessly pursuing
+			// fleeing targets that no longer take damage in
+			// tournament mode.
+			npc->set_target(nullptr);
 		}
 		ucmachine->call_usecode(get_usecode(), this, Usecode_machine::died);
 		return 0;    // If needed, NPC usecode does the killing (possibly


### PR DESCRIPTION
During List Field fighting, the party member fights against all knights. Once the current opponent has been defeated, it does not die but flees as the tournament flag is set. However, the party member has been pursuing this fleeing opponent endlessly, trying to hit it. But even if they hit, they will not make any more damage due to the active tournament flag. Any other knights are ignored and they will eventually win against the party member.

To fix this, clear the target before we call the "died" usecode, so that the party member can select a new foe.

Fixes: #571