### PR TITLE
Build Smooth and Mockup tools during GitHub actions

### DIFF
--- a/.github/workflows/ci-freebsd.yml
+++ b/.github/workflows/ci-freebsd.yml
@@ -122,7 +122,7 @@ jobs:
           pkg install -y at-spi2-core
           pkg install -y alsa-lib fluidsynth libogg libvorbis
           pkg install -y autoconf autoconf-archive automake bison flex gettext-runtime \
-                         git glib gmake icu json-glib libtool pkgconf sdl2
+                         git glib gmake icu json-glib libtool pkgconf sdl2 sdl2_image
           pkg install -y cairo gdk-pixbuf2 gegl gimp-app png
           pkg install -y freetype2 harfbuzz
           pkg install -y fontconfig

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -131,7 +131,7 @@ jobs:
             sudo apt-fast update
           fi
           sudo apt-fast install -y \
-            zlib1g-dev libogg-dev libvorbis-dev libasound2-dev libfluidsynth-dev libsdl2-dev libpng-dev libfreetype6-dev libgtk2.0-dev libgtk-3-dev \
+            zlib1g-dev libogg-dev libvorbis-dev libasound2-dev libfluidsynth-dev libsdl2-dev libsdl2-image-dev libpng-dev libfreetype6-dev libgtk2.0-dev libgtk-3-dev \
             libgdk-pixbuf2.0-dev libxml2-dev bison flex timidity libgimp2.0-dev libicu-dev autoconf-archive
       - name: Checkout code
         uses: actions/checkout@v4
@@ -145,7 +145,7 @@ jobs:
         run: |
           ./configure --with-debug=extreme --enable-exult-studio --enable-exult-studio-support --enable-compiler --enable-gimp-plugin \
             --enable-zip-support --enable-shared --enable-midi-sfx --enable-shp-thumbnailer --enable-data --enable-mods \
-            --with-usecode-debugger=yes --enable-usecode-container --enable-nonreadied-objects --disable-oggtest --disable-vorbistest \
+            --with-usecode-debugger=yes --enable-usecode-container --enable-nonreadied-objects \
             --enable-aseprite-plugin \
             CXX=${OVERRIDE_CXX} CC=${OVERRIDE_CC}
       - name: Build

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -111,7 +111,7 @@ jobs:
           brew update
           brew upgrade || true
           brew install automake libtool pkg-config libpng zlib libogg libvorbis fluid-synth freetype gtk+3 libxml2 bison flex
-          brew install sdl2 icu4c mt32emu autoconf-archive
+          brew install sdl2 sdl2_image icu4c mt32emu autoconf-archive
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run autoreconf
@@ -125,7 +125,7 @@ jobs:
           export PKG_CONFIG_PATH="$(brew --prefix zlib)/lib/pkgconfig:$(brew --prefix libxml2)/lib/pkgconfig:$(brew --prefix icu4c)/lib/pkgconfig"
           ./configure --with-debug=extreme --enable-exult-studio --enable-exult-studio-support --enable-compiler \
             --enable-zip-support --enable-shared --enable-shp-thumbnailer --enable-data --enable-mods --enable-aseprite-plugin \
-            --disable-alsa --disable-timidity-midi --disable-oggtest --disable-vorbistest
+            --disable-alsa --disable-timidity-midi
       - name: Build
         run: |
           export LDFLAGS="-L$(brew --prefix bison)/lib -L$(brew --prefix flex)/lib -L$(brew --prefix zlib)/lib"

--- a/.github/workflows/ci-omnios.yml
+++ b/.github/workflows/ci-omnios.yml
@@ -130,7 +130,7 @@ jobs:
           pkgin -y install at-spi2-core xorgproto
           pkgin -y install alsa-lib fluidsynth libogg libvorbis
           pkgin -y install autoconf autoconf-archive automake bison flex gettext \
-                           git glib2 gmake icu json-glib libtool pkgconf SDL2
+                           git glib2 gmake icu json-glib libtool pkgconf SDL2 SDL2_image
           pkgin -y install cairo gdk-pixbuf2 gegl gimp png
           pkgin -y install freetype2 harfbuzz
           pkgin -y install fontconfig

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -107,7 +107,7 @@ jobs:
             sudo apt-fast update
           fi
           sudo apt-fast install -y \
-            zlib1g-dev libogg-dev libvorbis-dev libasound2-dev libfluidsynth-dev libsdl2-dev libpng-dev libfreetype6-dev libgtk2.0-dev libgtk-3-dev \
+            zlib1g-dev libogg-dev libvorbis-dev libasound2-dev libfluidsynth-dev libsdl2-dev libsdl2-image-dev libpng-dev libfreetype6-dev libgtk2.0-dev libgtk-3-dev \
             libgdk-pixbuf2.0-dev libxml2-dev bison flex timidity libgimp2.0-dev autoconf-archive
       - name: Run autoreconf
         run: |
@@ -116,7 +116,7 @@ jobs:
         run: |
           ./configure --with-debug=extreme --enable-exult-studio --enable-exult-studio-support --enable-compiler --enable-gimp-plugin \
             --enable-zip-support --enable-shared --enable-midi-sfx --enable-shp-thumbnailer --enable-data --enable-mods \
-            --with-usecode-debugger=yes --enable-usecode-container --enable-nonreadied-objects --disable-oggtest --disable-vorbistest \
+            --with-usecode-debugger=yes --enable-usecode-container --enable-nonreadied-objects \
             --enable-aseprite-plugin
       - name: Build
         run: make -j 2

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -47,7 +47,7 @@ jobs:
             sudo apt-fast update
           fi
           sudo apt-fast install -y \
-            zlib1g-dev libogg-dev libvorbis-dev libasound2-dev libfluidsynth-dev libsdl2-dev libpng-dev libfreetype6-dev libgtk2.0-dev libgtk-3-dev \
+            zlib1g-dev libogg-dev libvorbis-dev libasound2-dev libfluidsynth-dev libsdl2-dev libsdl2-image-dev libpng-dev libfreetype6-dev libgtk2.0-dev libgtk-3-dev \
             libgdk-pixbuf2.0-dev libxml2-dev bison flex timidity libgimp2.0-dev libicu-dev autoconf-archive
       - name: Download Coverity Build Tool
         if: ${{ env.EXULT_REPO_ALIVE == 'true' }}
@@ -67,7 +67,7 @@ jobs:
         run: |
           ./configure --with-debug=extreme --enable-exult-studio --enable-exult-studio-support --enable-compiler --enable-gimp-plugin \
             --enable-zip-support --enable-shared --enable-midi-sfx --enable-shp-thumbnailer --enable-data --enable-mods \
-            --with-usecode-debugger=yes --enable-usecode-container --enable-nonreadied-objects --disable-oggtest --disable-vorbistest \
+            --with-usecode-debugger=yes --enable-usecode-container --enable-nonreadied-objects \
             --enable-aseprite-plugin
       - name: Build with cov-build
         if: ${{ env.EXULT_REPO_ALIVE == 'true' }}

--- a/android/app/src/main/cpp/dependencies/exult/CMakeLists.txt.in
+++ b/android/app/src/main/cpp/dependencies/exult/CMakeLists.txt.in
@@ -8,6 +8,6 @@ ExternalProject_Add(
   SOURCE_DIR        @EXULT_SOURCE_DIR@
   INSTALL_DIR       @DEPENDENCIES_INSTALL_DIR@
   CONFIGURE_COMMAND autoreconf -v -i <SOURCE_DIR>
-            COMMAND . @ENVFILE@ && <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --host=@ANDROID_LLVM_TRIPLE@ --enable-libexult --enable-shared --disable-data --disable-tools --enable-zip-support --enable-midi-sfx --enable-mt32emu --enable-fluidsynth=lite --disable-alsa --disable-timidity-midi --disable-oggtest --disable-vorbistest --with-optimization=@EXULT_ANDROID_OPT@ --with-debug=@EXULT_ANDROID_DEBUG@
+            COMMAND . @ENVFILE@ && <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --host=@ANDROID_LLVM_TRIPLE@ --enable-libexult --enable-shared --disable-data --disable-tools --enable-zip-support --enable-midi-sfx --enable-mt32emu --enable-fluidsynth=lite --disable-alsa --disable-timidity-midi --with-optimization=@EXULT_ANDROID_OPT@ --with-debug=@EXULT_ANDROID_DEBUG@
   BUILD_COMMAND     make -j@NCPU@ -s LIBTOOLFLAGS="--silent"
 )

--- a/tools/smooth/config.c
+++ b/tools/smooth/config.c
@@ -22,7 +22,7 @@ int close_config(FILE* f) {
 	return fclose(f);
 }
 
-FILE* open_config(char* configfile) {
+FILE* open_config(const char* configfile) {
 	if (g_statics.debug) {
 		printf("\nConfig file: %s\n********************\n", configfile);
 	}

--- a/tools/smooth/config.h
+++ b/tools/smooth/config.h
@@ -1,5 +1,5 @@
 #include <SDL.h>
 
 int   close_config(FILE* f);
-FILE* open_config(char* configfile);
+FILE* open_config(const char* configfile);
 int   read_config(FILE* f);

--- a/tools/smooth/globals.h
+++ b/tools/smooth/globals.h
@@ -44,9 +44,9 @@ EXTERN glob_variables g_variables;
 typedef struct g_stat_struct {
 	int          debug;          // stat
 	SDL_Surface* image_in;       // stat
-	char*        filein;         // stat
-	char*        fileout;        // stat
-	char*        config_file;    // stat
+	const char*  filein;         // stat
+	const char*  fileout;        // stat
+	const char*  config_file;    // stat
 } glob_statics;
 
 EXTERN glob_statics g_statics;

--- a/tools/smooth/image.c
+++ b/tools/smooth/image.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-int img_read(char* filein) {
+int img_read(const char* filein) {
 	if (g_statics.debug) {
 		printf("Reading from %s\n", filein);
 		fflush(stdout);
@@ -112,7 +112,7 @@ int img_read(char* filein) {
 	return 0;
 }
 
-int img_write(char* img_out) {
+int img_write(const char* img_out) {
 	if (g_statics.debug) {
 		printf("Writing to %s\n", img_out);
 		fflush(stdout);

--- a/tools/smooth/image.h
+++ b/tools/smooth/image.h
@@ -1,5 +1,5 @@
-int   img_read(char* filein);
-int   img_write(char* img_out);
+int   img_read(const char* filein);
+int   img_write(const char* img_out);
 Uint8 getpixel(SDL_Surface* surface, int x, int y);
 void  putpixel(SDL_Surface* surface, int x, int y, Uint8 pixel);
 char* transform(int index);

--- a/tools/smooth/plugin.c
+++ b/tools/smooth/plugin.c
@@ -65,7 +65,7 @@ int plug_unload(libhandle_t a_hdl) {
 #endif
 }
 
-void* plug_load_func(libhandle_t a_hdl, char* func_name) {
+void* plug_load_func(libhandle_t a_hdl, const char* func_name) {
 	// Colourless: Unix specific part. Add your #def here
 #ifdef _WIN32
 	// Need to add _ to the start of the function names in windows

--- a/tools/smooth/plugin.h
+++ b/tools/smooth/plugin.h
@@ -6,7 +6,7 @@
  */
 
 char*       plug_error(void);
-void*       plug_load_func(libhandle_t a_hdl, char* func_name);
+void*       plug_load_func(libhandle_t a_hdl, const char* func_name);
 libhandle_t plug_load(char* plug_name);
 int         plug_unload(libhandle_t a_hdl);
 int         add_plugin_apply(int col_index, libhandle_t a_hdl);

--- a/tools/smooth/plugins/plugin_randomize.c
+++ b/tools/smooth/plugins/plugin_randomize.c
@@ -55,9 +55,9 @@ int plugin_parse(char* line) {
 	int          let      = 0;
 	unsigned int idx      = 0;
 	char         color[7] = {0};
-	unsigned     r        = 0;
-	unsigned     g        = 0;
-	unsigned     b        = 0;
+	colour_hex   r        = 0;
+	colour_hex   g        = 0;
+	colour_hex   b        = 0;
 
 	if (my_g_stat.debug > 3) {
 		printf("Parsing %s\n", line);
@@ -80,9 +80,7 @@ int plugin_parse(char* line) {
 			if (newrec == 0) {
 				color[let] = '\0';
 				sscanf(color, "%02x%02x%02x", &r, &g, &b);
-				col[glob_idx][idx]
-						= ((((colour_hex)r) << 16) | (((colour_hex)g) << 8)
-						   | ((colour_hex)b));
+				col[glob_idx][idx] = ((r << 16) | (g << 8) | (b));
 				col[glob_idx][0] = idx - 1;
 			}
 			newrec = 1;

--- a/tools/smooth/plugins/plugin_smooth.c
+++ b/tools/smooth/plugins/plugin_smooth.c
@@ -71,9 +71,9 @@ int plugin_parse(char* line) {
 	int          let      = 0;
 	unsigned int idx      = 0;
 	char         color[7] = {0};
-	unsigned     r        = 0;
-	unsigned     g        = 0;
-	unsigned     b        = 0;
+	colour_hex   r        = 0;
+	colour_hex   g        = 0;
+	colour_hex   b        = 0;
 
 	// in this case we know we should receive 18 parameters
 	// 1 for slave, 1 for master and 13 for the resulting colour
@@ -102,9 +102,7 @@ int plugin_parse(char* line) {
 					col[glob_idx][idx] = 0;
 				} else {
 					sscanf(color, "%02x%02x%02x", &r, &g, &b);
-					col[glob_idx][idx]
-							= ((((colour_hex)r) << 16) | (((colour_hex)g) << 8)
-							   | ((colour_hex)b));
+					col[glob_idx][idx] = ((r << 16) | (g << 8) | (b));
 				}
 			}
 			newrec = 1;

--- a/tools/smooth/plugins/plugin_stream.c
+++ b/tools/smooth/plugins/plugin_stream.c
@@ -67,9 +67,9 @@ int plugin_parse(char* line) {
 	int          let      = 0;
 	unsigned int idx      = 0;
 	char         color[7] = {0};
-	unsigned     r        = 0;
-	unsigned     g        = 0;
-	unsigned     b        = 0;
+	colour_hex   r        = 0;
+	colour_hex   g        = 0;
+	colour_hex   b        = 0;
 
 	// in this case we know we should receive 18 parameters
 	// 1 for slave, 1 for master and 16 for the resulting colour
@@ -98,9 +98,7 @@ int plugin_parse(char* line) {
 					col[glob_idx][idx] = 0;
 				} else {
 					sscanf(color, "%02x%02x%02x", &r, &g, &b);
-					col[glob_idx][idx]
-							= ((((colour_hex)r) << 16) | (((colour_hex)g) << 8)
-							   | ((colour_hex)b));
+					col[glob_idx][idx] = ((r << 16) | (g << 8) | (b));
 				}
 			}
 			newrec = 1;


### PR DESCRIPTION
- `.github/workflows/ci- freebsd + linux + macos + omnios .yml + coverity-scan.yml`
Install SDL2_image to enable the build of Smooth and Mockup,
Remove the `--disable-oggtest` and `--disable-vorbistest`, were valid with XIPH `ogg.m4`  + `vorbis.m4`.
- `android/app/src/main/cpp/dependencies/exult/CMakeLists.txt.in`
Remove the `--disable-oggtest` and `--disable-vorbistest`, were valid with XIPH `ogg.m4` + `vorbis.m4`.
- `tools/smooth/` various `.c + .h`
Add missing `const` to pass the builds, since the warning options of the mainline Exult are stricter than the specific options for Smooth and Mockup.