### PR TITLE
Fixes #663

### DIFF
--- a/actors.cc
+++ b/actors.cc
@@ -5539,6 +5539,10 @@ void Npc_actor::switched_chunks(
  */
 
 void Npc_actor::move(int newtx, int newty, int newlift, int newmap) {
+	// prevent teleporting if dead
+	if (is_dead()) {
+		return;
+	}
 	// Store old chunk list.
 	Map_chunk* olist = get_chunk();
 	// Move it.


### PR DESCRIPTION
Already slain NPCs will not teleport (especially after the banes are released, this would leave duplicate bodies of already dead NPCs)