### PR TITLE
Scaler changes and fixes

### DIFF
--- a/flic/playfli.cc
+++ b/flic/playfli.cc
@@ -359,6 +359,7 @@ int playfli::play(
 
 		ticks += fli_speed * 10;
 
+		win->FillGuardband();
 		if (!dont_show && !skip_frame) {
 			win->show();
 		}

--- a/game.cc
+++ b/game.cc
@@ -704,7 +704,7 @@ int wait_delay(int ms, int startcol, int ncol, int rotspd) {
 			while (ticks2 > last_rotate + rot_speed) {
 				last_rotate += rot_speed;
 			}
-			gwin->get_win()->show();
+			gwin->get_win()->ShowFillGuardBand();
 		}
 	}
 

--- a/gamemgr/bggame.cc
+++ b/gamemgr/bggame.cc
@@ -471,7 +471,7 @@ void BG_Game::scene_lord_british() {
 		// Lord British presents...  (sh. 0x11)
 		pal->load(INTROPAL_DAT, PATCH_INTROPAL, 3);
 		sman->paint_shape(topx, topy, shapes.get_shape(lord_british_shp, 0));
-
+		gwin->get_win()->FillGuardband();
 		pal->fade_in(c_fade_in_time);
 		if (1 == wait_delay(2000)) {
 			throw UserBreakException();
@@ -524,7 +524,7 @@ void BG_Game::scene_butterfly() {
 				topy + y - butterfly->get_yabove());
 		sman->paint_shape(
 				topx + x, topy + y, shapes.get_shape(butterfly_shp, frame));
-		win->show();
+		win->ShowFillGuardBand();
 		WAITDELAY(delay);
 		win->put(
 				backup, topx + x - butterfly->get_xleft(),
@@ -559,7 +559,7 @@ void BG_Game::scene_butterfly() {
 		sman->paint_shape(topx, topy, shapes.get_shape(trees_shp, 0));
 		sman->paint_shape(
 				topx + 160, topy + 50, shapes.get_shape(ultima_text_shp, 0));
-
+		win->FillGuardband();
 		// Keep it dark for some more time, playing the music
 		WAITDELAY(4500);    //  - was WAITDELAY(3500);
 
@@ -568,7 +568,7 @@ void BG_Game::scene_butterfly() {
 
 		WAITDELAY(4000);
 
-		win->show();
+		win->ShowFillGuardBand();
 
 		WAITDELAY(7100);
 
@@ -642,7 +642,7 @@ void BG_Game::scene_butterfly() {
 #define FLASH_SHAPE1(x, y, shape, frame, delay)                              \
 	do {                                                                     \
 		sman->paint_shape((x), (y), shapes.get_shape((shape), (frame)));     \
-		win->show();                                                         \
+		win->ShowFillGuardBand();                                                         \
 		WAITDELAYCYCLE1((delay));                                            \
 		win->put(backup.get(), (x) - s->get_xleft(), (y) - s->get_yabove()); \
 	} while (0)
@@ -650,7 +650,7 @@ void BG_Game::scene_butterfly() {
 #define FLASH_SHAPE2(x, y, shape, frame, delay)                              \
 	do {                                                                     \
 		sman->paint_shape((x), (y), shapes.get_shape((shape), (frame)));     \
-		win->show();                                                         \
+		win->ShowFillGuardBand();                                                         \
 		WAITDELAYCYCLE4((delay));                                            \
 		win->put(backup.get(), (x) - s->get_xleft(), (y) - s->get_yabove()); \
 	} while (0)
@@ -811,7 +811,7 @@ void BG_Game::scene_guardian() {
 			ticks = SDL_GetTicks();
 			while (true) {
 				win->get_ibuf()->fill_static(0, 7, 15);
-				win->show();
+				win->ShowFillGuardBand();
 				WAITDELAYCYCLE1(2);
 				if (SDL_GetTicks() > ticks + 400) {    // 400)
 					break;
@@ -822,13 +822,13 @@ void BG_Game::scene_guardian() {
 					sfxfile, INTROSFX_MT32_FLX_INTRO_MT_STATIC2_WAV);
 
 			win->put(plasma.get(), win->get_start_x(), win->get_start_y());
-			win->show();
+			win->ShowFillGuardBand();
 			WAITDELAYCYCLE1(200);
 
 			ticks = SDL_GetTicks();
 			while (true) {
 				win->get_ibuf()->fill_static(0, 7, 15);
-				win->show();
+				win->ShowFillGuardBand();
 				WAITDELAYCYCLE1(2);
 				if (SDL_GetTicks() > ticks + 200) {
 					break;
@@ -839,13 +839,13 @@ void BG_Game::scene_guardian() {
 					sfxfile, INTROSFX_MT32_FLX_INTRO_MT_STATIC3_WAV);
 
 			win->put(plasma.get(), win->get_start_x(), win->get_start_y());
-			win->show();
+			win->ShowFillGuardBand();
 			WAITDELAYCYCLE1(200);
 
 			ticks = SDL_GetTicks();
 			while (true) {
 				win->get_ibuf()->fill_static(0, 7, 15);
-				win->show();
+				win->ShowFillGuardBand();
 				WAITDELAYCYCLE1(2);
 				if (SDL_GetTicks() > ticks + 100) {
 					break;
@@ -853,7 +853,7 @@ void BG_Game::scene_guardian() {
 			}
 
 			win->put(plasma.get(), win->get_start_x(), win->get_start_y());
-			win->show();
+			win->ShowFillGuardBand();
 		}
 
 		//
@@ -929,7 +929,7 @@ void BG_Game::scene_guardian() {
 			}
 
 			sman->paint_shape(centerx, centery, shapes.get_shape(0x23, 15));
-			win->show();
+			win->ShowFillGuardBand();
 
 			WAITDELAYCYCLE1(500);    // - show his face for half a second
 			// before he opens his eyes.
@@ -1075,9 +1075,9 @@ void BG_Game::scene_guardian() {
 						DrawSpeech();
 					}
 
-					win->show();
+					win->ShowFillGuardBand();
 					WAITDELAYCYCLE5(15);
-					win->show();
+					win->ShowFillGuardBand();
 					time = (SDL_GetTicks() - start);
 				}
 
@@ -1117,15 +1117,15 @@ void BG_Game::scene_guardian() {
 					if (need_redraw) {
 						DrawSpeech();
 					}
-					win->show();
+					win->ShowFillGuardBand();
 					WAITDELAYCYCLE6(15);
-					win->show();
+					win->ShowFillGuardBand();
 					time = (SDL_GetTicks() - start);
 				}
 
-				win->show();
+				win->ShowFillGuardBand();
 				WAITDELAYCYCLE6(1000);
-				win->show();
+				win->ShowFillGuardBand();
 
 				win->put(backup3.get(), 0, txt_ypos);
 				win->put(
@@ -1165,7 +1165,7 @@ void BG_Game::scene_guardian() {
 						centery - s->get_yabove());
 			}
 
-			win->show();
+			win->ShowFillGuardBand();
 		}
 		WAITDELAYCYCLE1(1200);
 
@@ -1180,7 +1180,7 @@ void BG_Game::scene_guardian() {
 		ticks = SDL_GetTicks();
 		while (true) {
 			win->get_ibuf()->fill_static(0, 7, 15);
-			win->show();
+			win->ShowFillGuardBand();
 			WAITDELAYCYCLE1(2);
 			if (SDL_GetTicks() > ticks + 400) {
 				break;
@@ -1352,13 +1352,13 @@ namespace {    // anonymous
 					staticScreen.get(),
 					centerx + 12 - screenShape->get_width() / 2,
 					centery - 22 - screenShape->get_height() / 2);
-			win->show();
+			win->ShowFillGuardBand();
 			drawHand = false;
 			break;
 		case eFLASH_FAKE_TITLE:
 		case eSHOW_FAKE_TITLE:
 			sman->paint_shape(centerx + 12, centery - 22, screenShape);
-			win->show();
+			win->ShowFillGuardBand();
 			drawHand = false;
 			if (currOp == eSHOW_FAKE_TITLE) {
 				currBackground = currOp;
@@ -1372,7 +1372,7 @@ namespace {    // anonymous
 					centery - 22 - screenShape->get_height() / 2);
 			if (currOp == eBLACK_SCREEN) {
 				currBackground = currOp;
-				win->show();
+				win->ShowFillGuardBand();
 				drawHand = false;
 			}
 			break;
@@ -1381,7 +1381,7 @@ namespace {    // anonymous
 		}
 
 		if (drawHand) {
-			win->show();
+			win->ShowFillGuardBand();
 		}
 
 		scriptPosition++;
@@ -1461,7 +1461,7 @@ void BG_Game::scene_desk() {
 					win->put(
 							zoomed.get(), 0 + (win->get_game_width() - 320) / 2,
 							0 + (win->get_game_height() - 200) / 2);
-					win->show();
+					win->ShowFillGuardBand();
 					int delta = next_ticks - SDL_GetTicks();
 					if (delta < 0) {
 						delta = 0;
@@ -1474,7 +1474,7 @@ void BG_Game::scene_desk() {
 			win->put(
 					unzoomed.get(), 0 + (win->get_game_width() - 320) / 2,
 					0 + (win->get_game_height() - 200) / 2);
-			win->show();
+			win->ShowFillGuardBand();
 		}
 
 		{
@@ -1489,7 +1489,7 @@ void BG_Game::scene_desk() {
 
 		// "Something is obviously amiss"
 		sman->paint_shape(centerx, centery + 50, shapes.get_shape(0x15, 0));
-		win->show();
+		win->ShowFillGuardBand();
 		WAITDELAY(3000);
 
 		// TODO: misaligned?
@@ -1509,7 +1509,7 @@ void BG_Game::scene_desk() {
 				sman->paint_shape(
 						centerx, centery + 50, shapes.get_shape(0x16, 0));
 			}
-			win->show();
+			win->ShowFillGuardBand();
 			WAITDELAY(110);    // was 30
 		}
 
@@ -1533,7 +1533,7 @@ void BG_Game::scene_desk() {
 					topx + 319, topy + 199 - i, shapes.get_shape(0x0B, 0));
 			// "The mystical Orb beckons you"
 			sman->paint_shape(centerx, topy, shapes.get_shape(0x17, 0));
-			win->show();
+			win->ShowFillGuardBand();
 			WAITDELAYCYCLE2(110);
 		}
 
@@ -1552,7 +1552,7 @@ void BG_Game::scene_desk() {
 		sman->paint_shape(topx + 319, topy + 149, shapes.get_shape(0x0B, 0));
 		// "It has opened gateways to Britannia in the past"
 		sman->paint_shape(centerx, topy, shapes.get_shape(0x18, 0));
-		win->show();
+		win->ShowFillGuardBand();
 
 		WAITDELAYCYCLE2(3200);
 		pal->fade_out(100);
@@ -1602,7 +1602,7 @@ void BG_Game::scene_moongate() {
 			sman->paint_shape(centerx, centery + 50, shapes.get_shape(0x1C, 0));
 		}
 
-		win->show();
+		win->ShowFillGuardBand();
 		WAITDELAYCYCLE3(80);
 	}
 
@@ -1654,7 +1654,7 @@ void BG_Game::scene_moongate() {
 			win->put(
 					zoomed.get(), 0 + (win->get_game_width() - 320) / 2,
 					0 + (win->get_game_height() - 200) / 2);
-			win->show();
+			win->ShowFillGuardBand();
 			int delta = next_ticks - SDL_GetTicks();
 			if (delta < 0) {
 				delta = 0;
@@ -1830,7 +1830,7 @@ void BG_Game::end_game(bool success, bool within_game) {
 				if (subtitles) {
 					endfont2->draw_text(ibuf, width, height, message);
 				}
-				win->show();
+				win->ShowFillGuardBand();
 				if (wait_delay(0, 0, 1)) {
 					throw UserSkipException();
 				}
@@ -1858,7 +1858,7 @@ void BG_Game::end_game(bool success, bool within_game) {
 				if (subtitles) {
 					endfont2->draw_text(ibuf, width, height, message);
 				}
-				win->show();
+				win->ShowFillGuardBand();
 				if (wait_delay(0, 0, 1)) {
 					throw UserSkipException();
 				}
@@ -1983,7 +1983,7 @@ void BG_Game::end_game(bool success, bool within_game) {
 								get_text_msg(txt_screen0 + m));
 					}
 				}
-				win->show();
+				win->ShowFillGuardBand();
 				if (wait_delay(10, 0, 1)) {
 					throw UserSkipException();
 				}
@@ -2139,7 +2139,7 @@ void BG_Game::end_game(bool success, bool within_game) {
 	} catch (const UserSkipException& /*x*/) {
 		pal->set_brightness(80);    // Set readable brightness
 		win->fill8(0);
-		win->show();
+		win->ShowFillGuardBand();
 	}
 
 	if (midi) {
@@ -2272,7 +2272,7 @@ bool BG_Game::new_game(Vga_file& shapes) {
 			}
 			font->draw_text(
 					ibuf, topx + 60, menuy + 10, disp_name, transto.data());
-			gwin->get_win()->show();
+			gwin->get_win()->ShowFillGuardBand();
 			redraw = false;
 		}
 

--- a/gamemgr/sigame.cc
+++ b/gamemgr/sigame.cc
@@ -298,12 +298,12 @@ void SI_Game::play_intro() {
 		int count = *selected_intro_counts++;
 		for (int j = 0; j < count; j++) {
 			next = fli0.play(win, 0, 0, next, j * 5);
-			win->show();
+			win->ShowFillGuardBand();
 			wait_delay(0, 0, 1);
 		}
 
 		next = fli0.play(win, 0, 0, next, 100);
-		win->show();
+		win->ShowFillGuardBand();
 
 		if (wait_delay(3000, 0, 1)) {
 			throw UserBreakException();
@@ -312,7 +312,7 @@ void SI_Game::play_intro() {
 		count = *selected_intro_counts++;
 		for (int j = count; j; j--) {
 			next = fli0.play(win, 0, 0, next, j * 5);
-			win->show();
+			win->ShowFillGuardBand();
 			wait_delay(0, 0, 1);
 		}
 
@@ -375,7 +375,7 @@ void SI_Game::play_intro() {
 
 			prev = num;
 			next += 75;
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(1, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -404,7 +404,7 @@ void SI_Game::play_intro() {
 
 			prev = num;
 			next += 75;
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(1, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -427,7 +427,7 @@ void SI_Game::play_intro() {
 
 			prev = num;
 			next += 75;
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(1, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -454,7 +454,7 @@ void SI_Game::play_intro() {
 
 			prev = num;
 			next += 75;
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(1, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -463,7 +463,7 @@ void SI_Game::play_intro() {
 		count = *selected_intro_counts++;
 		for (int j = count; j; j--) {
 			next = fli1.play(win, 0, 0, next, j * 5);
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -483,7 +483,7 @@ void SI_Game::play_intro() {
 		count = *selected_intro_counts++;
 		for (int j = 0; j < count; j++) {
 			next = fli2.play(win, 0, 0, next, j * 5);
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -494,7 +494,7 @@ void SI_Game::play_intro() {
 		count = *selected_intro_counts++;
 		for (j = 0; j < count; j++) {
 			next = fli2.play(win, j, j, next);
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -521,14 +521,14 @@ void SI_Game::play_intro() {
 						get_text_msg(my_leige));
 			}
 
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
 		}
 
 		next = fli2.play(win, j, j, next);
-		win->show();
+		win->ShowFillGuardBand();
 		wait_delay(0, 0, 1);
 
 		const char* const all_we[2]
@@ -553,7 +553,7 @@ void SI_Game::play_intro() {
 						centery + 87, all_we[1]);
 			}
 
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -579,7 +579,7 @@ void SI_Game::play_intro() {
 					centery + 87, and_a[1]);
 		}
 
-		win->show();
+		win->ShowFillGuardBand();
 		j++;
 
 		count = *selected_intro_counts++;
@@ -623,7 +623,7 @@ void SI_Game::play_intro() {
 						get_text_msg(indeed + 1));
 			}
 
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -649,7 +649,7 @@ void SI_Game::play_intro() {
 		count = *selected_intro_counts++;
 		for (j = 0; j < count; j++) {
 			next = fli3.play(win, j, j, next) + 20;
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -675,7 +675,7 @@ void SI_Game::play_intro() {
 						get_text_msg(stand_back));
 			}
 
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -756,7 +756,7 @@ void SI_Game::play_intro() {
 						ibuf, centerx, centery + 87, get_text_msg(there_i + 1));
 			}
 
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -770,7 +770,7 @@ void SI_Game::play_intro() {
 				sman->paint_shape(centerx - 36, centery, sf);
 			}
 
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -786,7 +786,7 @@ void SI_Game::play_intro() {
 		count = *selected_intro_counts++;
 		for (j = 0; j < count; j++) {
 			next = fli5.play(win, 0, 0, next, j * 5);
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -812,7 +812,7 @@ void SI_Game::play_intro() {
 						ibuf, centerx, centery + 87, get_text_msg(tis_my + 2));
 			}
 
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -828,7 +828,7 @@ void SI_Game::play_intro() {
 		count = *selected_intro_counts++;
 		for (j = 0; j < count; j++) {
 			next = fli6.play(win, j, j, next) + 30;
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -851,7 +851,7 @@ void SI_Game::play_intro() {
 				sifont->center_text(ibuf, centerx, centery + 74, zot);
 			}
 
-			win->show();
+			win->ShowFillGuardBand();
 			if (wait_delay(0, 0, 1)) {
 				throw UserBreakException();
 			}
@@ -867,12 +867,12 @@ void SI_Game::play_intro() {
 		count = *selected_intro_counts++;
 		for (j = 0; j < count; j++) {
 			next = fli8.play(win, 0, 0, next, j * 5);
-			win->show();
+			win->ShowFillGuardBand();
 			wait_delay(0, 0, 1);
 		}
 
 		next = fli8.play(win, 0, 0, next, 100);
-		win->show();
+		win->ShowFillGuardBand();
 		wait_delay(0, 0, 1);
 
 		count = *selected_intro_counts++;
@@ -885,7 +885,7 @@ void SI_Game::play_intro() {
 		count = *selected_intro_counts++;
 		for (j = count; j; j--) {
 			next = fli8.play(win, 0, 0, next, j * 5);
-			win->show();
+			win->ShowFillGuardBand();
 			wait_delay(0, 0, 1);
 		}
 	} catch (const UserBreakException& /*x*/) {
@@ -1375,7 +1375,7 @@ void SI_Game::end_game(bool success, bool within_game) {
 		}
 
 		if (updated) {
-			win->show();
+			win->ShowFillGuardBand();
 		}
 
 		if (wait_delay(0, 0, 1)) {
@@ -1391,7 +1391,7 @@ void SI_Game::end_game(bool success, bool within_game) {
 		// Fade out for 1 sec (50 cycles)
 		pal->set_brightness(80);    // Set readable brightness
 		win->fill8(0);
-		win->show();
+		win->ShowFillGuardBand();
 
 		// Congratulations screen
 		// show only when finishing a game and not when viewed from menu
@@ -1479,7 +1479,7 @@ bool SI_Game::new_game(Vga_file& shapes) {
 				snprintf(disp_name, max_len + 2, "%s", npc_name);
 			}
 			font->draw_text(ibuf, topx + 60, menuy + 10, disp_name);
-			gwin->get_win()->show();
+			gwin->get_win()->ShowFillGuardBand();
 			redraw = false;
 		}
 		SDL_Event event;

--- a/gamerend.cc
+++ b/gamerend.cc
@@ -354,6 +354,8 @@ void Game_window::paint(
 	if (!win->ready()) {
 		return;
 	}
+	// This will adjust and clip the rectangle as appropriate, it may end up bigger or smaller
+	win->BeginPaintIntoGuardBand(&x, &y, &w, &h);
 	int gx = x;
 	int gy = y;
 	int gw = w;
@@ -432,6 +434,8 @@ void Game_window::paint(
 		// Set palette for lights.
 		clock->set_light_source(carried_light + light_sources, in_dungeon);
 	}
+
+	win->EndPaintIntoGuardBand();
 	win->clear_clip();
 }
 

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -493,10 +493,12 @@ Game_window::Game_window(
  *  Blank out screen.
  */
 void Game_window::clear_screen(bool update) {
+	win->BeginPaintIntoGuardBand(nullptr, nullptr, nullptr, nullptr);
 	win->fill8(
 			0, win->get_full_width(), win->get_full_height(),
 			win->get_start_x(), win->get_start_y());
 
+	win->EndPaintIntoGuardBand();
 	// update screen
 	if (update) {
 		show(true);
@@ -2944,6 +2946,7 @@ void Game_window::setup_game(bool map_editing) {
 }
 
 void Game_window::plasma(int w, int h, int x, int y, int startc, int endc) {
+	win->BeginPaintIntoGuardBand(&x, &y, &w, &h);
 	Image_buffer8* ibuf = get_win()->get_ib8();
 
 	ibuf->fill8(startc, w, h, x, y);
@@ -2960,6 +2963,7 @@ void Game_window::plasma(int w, int h, int x, int y, int startc, int endc) {
 			ibuf->fill8(pc, 1, 3, px2, py2 - 1);
 		}
 	}
+	win->EndPaintIntoGuardBand();
 	painted = true;
 }
 

--- a/imagewin/BilinearScaler.h
+++ b/imagewin/BilinearScaler.h
@@ -22,14 +22,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "ArbScaler.h"
 
-namespace Pentagram {
-
-	class BilinearScaler : public ArbScaler {
+namespace Pentagram { namespace BilinearScaler {
+	class Scaler : public ArbScaler {
 	public:
-		BilinearScaler();
-
-		virtual uint32 ScaleBits()
-				const;    //< bits for supported integer scaling
+		Scaler();
 		virtual bool ScaleArbitrary()
 				const;    //< supports arbitrary scaling of any degree
 
@@ -40,6 +36,6 @@ namespace Pentagram {
 				const override;    //< Scaler Copyright info
 	};
 
-}    // namespace Pentagram
+}}    // namespace Pentagram::BilinearScaler
 
 #endif

--- a/imagewin/BilinearScalerInternal_2x.cpp
+++ b/imagewin/BilinearScalerInternal_2x.cpp
@@ -138,8 +138,6 @@ namespace Pentagram { namespace BilinearScaler {
 			texel++;
 
 			// Src Loop X, loops while there are 2 or more columns available
-			// auto xdiff = xloop_end - (texel + numxloops * blockwidth);
-			// xloop_end  = texel + (numxloops * blockwidth);
 			assert(xloop_end == (texel + numxloops * blockwidth));
 			while (texel != xloop_end) {
 				// Read next column of 5 lines into fghij
@@ -186,7 +184,6 @@ namespace Pentagram { namespace BilinearScaler {
 				pixel -= pitch * destblockheight;
 				pixel += sizeof(uintX) * destblockwidth;
 			}
-			//	assert(cols == numxloops);
 
 			// Final X (clipping) if  have a source column available
 			if (clip_x) {
@@ -278,10 +275,6 @@ namespace Pentagram { namespace BilinearScaler {
 				pixel -= pitch * destblockheight;
 				pixel += sizeof(uintX) * 2;
 
-				// Read5_Clipped(a, b, c, d, e, 4);
-				a[0] = 0;
-				a[1] = 0xff;
-				a[2] = 0;
 				ReadTexelsV<Manip>(
 						lines_remaining, texel, tpitch, a, b, c, d, e);
 				texel++;

--- a/imagewin/BilinearScalerInternal_2x.cpp
+++ b/imagewin/BilinearScalerInternal_2x.cpp
@@ -65,7 +65,7 @@ namespace Pentagram { namespace BilinearScaler {
 
 		// Number of loops that can run.
 		// this is the number of blocks we can safely scale without
-		// checking for buffer overruns
+		// per pixel checking for buffer overruns
 		
 		int numyloops = (sh - 1) / linesperxloop;
 		int numxloops = (sw - 1) / blockwidth;

--- a/imagewin/BilinearScalerInternal_2x.cpp
+++ b/imagewin/BilinearScalerInternal_2x.cpp
@@ -23,160 +23,318 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "ignore_unused_variable_warning.h"
 #include "manip.h"
 
-namespace Pentagram {
+namespace Pentagram { namespace BilinearScaler {
 
+	template <
+			class uintX, class Manip, class uintS,
+			typename limit_t = std::nullptr_t>
+	// Generate 2x2 pixels from source 2x2 block scaling up by 2x
+	BSI_FORCE_INLINE void Interpolate2x2BlockBy2x(
+			const uint8* const tl, const uint8* const bl, const uint8* const tr,
+			const uint8* const br, uint8*& pixel, const uint_fast32_t pitch,
+			const limit_t limit = nullptr) {
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				tl, bl, tr, br, 256, 128, 256, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				tl, bl, tr, br, 256, 128, 128, pixel, limit);
+		pixel += pitch;
+	}
+
+	// 2x Blinear Scaler
+	// 2x scaler is a specialization of Arb. It works almost identically to Arb
+	// But instead of using Interpolate2x2BlockByAny it uses
+	// Interpolate2x2BlockBy2x without fixed point values used to calculate the
+	// filtering coefficents
 	template <class uintX, class Manip, class uintS>
 	bool BilinearScalerInternal_2x(
-			SDL_Surface* tex, sint32 sx, sint32 sy, sint32 sw, sint32 sh,
-			uint8* pixel, sint32 dw, sint32 dh, sint32 pitch, bool clamp_src) {
-		ignore_unused_variable_warning(dh);
+			SDL_Surface* tex, uint_fast32_t sx, uint_fast32_t sy,
+			uint_fast32_t sw, uint_fast32_t sh, uint8* pixel, uint_fast32_t dw,
+			uint_fast32_t dh, uint_fast32_t pitch, bool clamp_src) {
+		uint_fast32_t      tex_w = tex->w, tex_h = tex->h;
+		const uint_fast8_t blockwidth = 2;
+		// This is the number of lines advanced per xloop
+		const uint_fast8_t linesperxloop = 4;
+		// And this is the number of actual lines read in each
+		// block. The bottom lines of one block is the same as
+		// the top line of the block below it
+		const uint_fast8_t blockheight = linesperxloop + 1;
+
+		const uint_fast8_t destblockheight = 8;
+		const uint_fast8_t destblockwidth  = 2;
+
+		// Number of loops that can run.
+		// this is the number of blocks we can safely scale without
+		// checking for buffer overruns
+		
+		int numyloops = (sh - 1) / linesperxloop;
+		int numxloops = (sw - 1) / blockwidth;
+
 		// Source buffer pointers
-		const int tpitch = tex->pitch / sizeof(uintS);
-		uintS*    texel = static_cast<uintS*>(tex->pixels) + (sy * tpitch + sx);
-		uintS*    tline_end = texel + (sw - 1);
-		uintS*    tex_end   = texel + (sh - 4) * tpitch;
-		int       tex_diff  = (tpitch * 4) - sw;
+		const int    tpitch = tex->pitch / sizeof(uintS);
+		const uintS* texel
+				= static_cast<uintS*>(tex->pixels) + (sy * tpitch + sx);
+		const uintS* xloop_end = texel + 1 + (numxloops * blockwidth);
+		const uintS* yloop_end = texel + (numyloops * linesperxloop) * tpitch;
 
-		uint8     a[4];
-		uint8     b[4];
-		uint8     c[4];
-		uint8     d[4];
-		uint8     e[4];
-		uint8     f[4];
-		uint8     g[4];
-		uint8     h[4];
-		uint8     i[4];
-		uint8     j[4];
-		const int p_diff = (pitch * 8) - (dw * sizeof(uintX));
+		// Absolute limit of the source buffer. Must not read at or beyondthis
+		const uintS* srclimit
+				= static_cast<uintS*>(tex->pixels) + (tex_h * tpitch);
+		int tex_diff = (tpitch * 4) - sw;
 
+		// 2*5 Source RGBA Pixel block being scaled. Alpha values are
+		// currently ignored. abcde are a column and fghij are the other column.
+		// Columns can be used in either order
+		// Initializion values are meaningless
+		uint8 a[4] = "A", f[4] = "F";
+		uint8 b[4] = "B", g[4] = "G";
+		uint8 c[4] = "C", h[4] = "H";
+		uint8 d[4] = "D", i[4] = "I";
+		uint8 e[4] = "E", j[4] = "J";
+
+		// Absolute limit of dest buffer. Must not write beyond this
+		// We only need to use this when performing final y clipping
+		uint8* const dst_limit = pixel + dh * pitch;
+
+		// if no clipping is requested only disable clipping x if the source
+		// actually has the neeeded width to safely read the entire line
+		// unclipped widths not multple of blockwidth always need clipping
 		bool clip_x = true;
-		if (sw + sx < tpitch && !clamp_src) {
-			clip_x    = false;
-			tline_end = texel + (sw + 1);
+		if ((sx + blockwidth + 1 + numxloops * blockwidth) < tex_w && !clamp_src
+			&& !(sw % blockwidth)) {
+			clip_x = false;
+			numxloops++;
+			xloop_end = texel + 1 + (numxloops * blockwidth);
 			tex_diff--;
 		}
 
+		// clip_y
 		bool clip_y = true;
-		if (sh + sy < tex->h && !clamp_src) {
-			clip_y  = false;
-			tex_end = texel + (sh)*tpitch;
+		// if request no clamping, check to see if y remains in the bounds of
+		// the texture. If it does we can disable clipping on y
+		// heights not multple of linesperxloop always need clipping
+		if ((sy + blockheight + numyloops * linesperxloop) < tex_h && !clamp_src
+			&& !(sh % linesperxloop)) {
+			numyloops++;
+			clip_y    = false;
+			yloop_end = texel + (numyloops * linesperxloop) * tpitch;
+		}
+
+		// Check if enough lines for loop. if not then set clip_y and prevent
+		// loop Must have AT LEAST blockheight lines to do a loop
+		if (texel + blockheight * tpitch > srclimit) {
+			yloop_end = texel;
+			clip_y    = true;
 		}
 
 		// Src Loop Y
-		do {
-			Read5(a, b, c, d, e);
+		while (texel != yloop_end) {
+			if (texel > yloop_end) {
+				return false;
+			}
+			// Read first column of 5 lines into abcde
+			ReadTexelsV<Manip>(blockheight, texel, tpitch, a, b, c, d, e);
+			// advance texel pointer by 1 to the next column
 			texel++;
 
-			// Src Loop X
-			do {
-				Read5(f, g, h, i, j);
+			// Src Loop X, loops while there are 2 or more columns available
+			// auto xdiff = xloop_end - (texel + numxloops * blockwidth);
+			// xloop_end  = texel + (numxloops * blockwidth);
+			assert(xloop_end == (texel + numxloops * blockwidth));
+			while (texel != xloop_end) {
+				// Read next column of 5 lines into fghij
+				ReadTexelsV<Manip>(blockheight, texel, tpitch, f, g, h, i, j);
+				// advance texel pointer by 1 to the next column
 				texel++;
 
-				ScalePixel2x(a, b, f, g);
-				ScalePixel2x(b, c, g, h);
-				ScalePixel2x(c, d, h, i);
-				ScalePixel2x(d, e, i, j);
+				// Interpolate with existing abcde as left and just read fghij
+				// as right
+				// Generate all dest pixels for The 4 inputsource pixels
 
-				pixel -= pitch * 8;
-				pixel += sizeof(uintX) * 2;
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						a, b, f, g, pixel, pitch);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						b, c, g, h, pixel, pitch);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						c, d, h, i, pixel, pitch);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						d, e, i, j, pixel, pitch);
 
-				Read5(a, b, c, d, e);
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
+
+				// Read next column of 5 lines into abcde
+				// Keeping existing fghij from above
+				ReadTexelsV<Manip>(blockheight, texel, tpitch, a, b, c, d, e);
+				// advance texel pointer by 1 to the next column
 				texel++;
 
-				ScalePixel2x(f, g, a, b);
-				ScalePixel2x(g, h, b, c);
-				ScalePixel2x(h, i, c, d);
-				ScalePixel2x(i, j, d, e);
+				// Interpolate with existing fghij as left and just read abcde
+				// as right Generate all dest pixels for The 4 input source
+				// pixels
 
-				pixel -= pitch * 8;
-				pixel += sizeof(uintX) * 2;
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						f, g, a, b, pixel, pitch);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						g, h, b, c, pixel, pitch);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						h, i, c, d, pixel, pitch);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						i, j, d, e, pixel, pitch);
 
-			} while (texel != tline_end);
-
-			// Final X (clipping)
-			if (clip_x) {
-				Read5(f, g, h, i, j);
-				texel++;
-
-				ScalePixel2x(a, b, f, g);
-				ScalePixel2x(b, c, g, h);
-				ScalePixel2x(c, d, h, i);
-				ScalePixel2x(d, e, i, j);
-
-				pixel -= pitch * 8;
-				pixel += sizeof(uintX) * 2;
-
-				ScalePixel2x(f, g, f, g);
-				ScalePixel2x(g, h, g, h);
-				ScalePixel2x(h, i, h, i);
-				ScalePixel2x(i, j, i, j);
-
-				pixel -= pitch * 8;
-				pixel += sizeof(uintX) * 2;
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
 			}
+			//	assert(cols == numxloops);
 
-			pixel += p_diff;
+			// Final X (clipping) if  have a source column available
+			if (clip_x) {
+				// Read last column of 5 lines into fghij
+				// if source width is odd we reread the previous column
+				if (sw & 1) {
+					texel--;
+				}
+				ReadTexelsV<Manip>(blockheight, texel, tpitch, f, g, h, i, j);
+				texel++;
+
+				// Interpolate abcde as left and fghij as right
+				//
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						a, b, f, g, pixel, pitch);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						b, c, g, h, pixel, pitch);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						c, d, h, i, pixel, pitch);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						d, e, i, j, pixel, pitch);
+
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
+
+				// odd widths do not need the second column
+				if (!(sw & 1)) {
+					Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+							f, g, f, g, pixel, pitch);
+					Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+							g, h, g, h, pixel, pitch);
+					Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+							h, i, h, i, pixel, pitch);
+					Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+							i, j, i, j, pixel, pitch);
+					// Move the pixel pointer to the start of the next block
+					pixel -= pitch * destblockheight;
+					pixel += sizeof(uintX) * destblockwidth;
+				}
+			}
+			pixel += (pitch * destblockheight) - (dw * sizeof(uintX));
 
 			texel += tex_diff;
-			tline_end += tpitch * 4;
-		} while (texel != tex_end);
+			xloop_end += tpitch * linesperxloop;
+		}
 
 		//
-		// Final Rows - Clipping
+		// Final Rows - Clipped to height
 		//
-
-		// Src Loop Y
 		if (clip_y) {
-			Read5_Clipped(a, b, c, d, e);
+			// Calculate the number of unscaled source lines
+			uint_fast8_t lines_remaining = sh % linesperxloop;
+			if (lines_remaining == 0) {
+				lines_remaining = linesperxloop;
+			}
+
+			// If no clamping was requested and we have pixels available, allow
+			// reading beyond the source rect
+			if (numyloops * linesperxloop + lines_remaining + sy < tex_h
+				&& !clamp_src) {
+				// It doesn't matter if this is bigger than linesperxloop
+				lines_remaining = std::max<uint_fast16_t>(
+						255, tex_h - sy - numyloops * linesperxloop);
+			}
+
+			// Read column 0 of block but clipped to clipping lines
+			a[0] = 0xff;
+			a[1] = 0;
+			a[2] = 0;
+			ReadTexelsV<Manip>(lines_remaining, texel, tpitch, a, b, c, d, e);
 			texel++;
 
 			// Src Loop X
-			do {
-				Read5_Clipped(f, g, h, i, j);
+			while (texel != xloop_end) {
+				ReadTexelsV<Manip>(
+						lines_remaining, texel, tpitch, f, g, h, i, j);
 				texel++;
-				ScalePixel2x(a, b, f, g);
-				ScalePixel2x(b, c, g, h);
-				ScalePixel2x(c, d, h, i);
-				ScalePixel2x(d, e, i, j);
-				pixel -= pitch * 8;
+
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						a, b, f, g, pixel, pitch, dst_limit);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						b, c, g, h, pixel, pitch, dst_limit);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						c, d, h, i, pixel, pitch, dst_limit);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						d, e, i, j, pixel, pitch, dst_limit);
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
 				pixel += sizeof(uintX) * 2;
 
-				Read5_Clipped(a, b, c, d, e);
+				// Read5_Clipped(a, b, c, d, e, 4);
+				a[0] = 0;
+				a[1] = 0xff;
+				a[2] = 0;
+				ReadTexelsV<Manip>(
+						lines_remaining, texel, tpitch, a, b, c, d, e);
 				texel++;
-				ScalePixel2x(f, g, a, b);
-				ScalePixel2x(g, h, b, c);
-				ScalePixel2x(h, i, c, d);
-				ScalePixel2x(i, j, d, e);
-				pixel -= pitch * 8;
-				pixel += sizeof(uintX) * 2;
-			} while (texel != tline_end);
 
-			// Final X (clipping)
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						f, g, a, b, pixel, pitch, dst_limit);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						g, h, b, c, pixel, pitch, dst_limit);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						h, i, c, d, pixel, pitch, dst_limit);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						i, j, d, e, pixel, pitch, dst_limit);
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
+			};
+
+			// Final X (clipping) if have a source column available
+			//
 			if (clip_x) {
-				Read5_Clipped(f, g, h, i, j);
+				// Read last column of 5 lines into fghij
+				if (sw & 1) {
+					// if source width is odd go back a column so we re-read the
+					// column and do not exceed bounds
+					texel--;
+				}
+				ReadTexelsV<Manip>(
+						lines_remaining, texel, tpitch, f, g, h, i, j);
 				texel++;
 
-				ScalePixel2x(a, b, f, g);
-				ScalePixel2x(b, c, g, h);
-				ScalePixel2x(c, d, h, i);
-				ScalePixel2x(d, e, i, j);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						a, b, f, g, pixel, pitch, dst_limit);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						b, c, g, h, pixel, pitch, dst_limit);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						c, d, h, i, pixel, pitch, dst_limit);
+				Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+						d, e, i, j, pixel, pitch, dst_limit);
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
 
-				pixel -= pitch * 8;
-				pixel += sizeof(uintX) * 2;
-
-				ScalePixel2x(f, g, f, g);
-				ScalePixel2x(g, h, g, h);
-				ScalePixel2x(h, i, h, i);
-				ScalePixel2x(i, j, i, j);
-
-				pixel -= pitch * 8;
-				pixel += sizeof(uintX) * 2;
+				if (!(sw & 1)) {
+					Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+							f, g, f, g, pixel, pitch, dst_limit);
+					Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+							g, h, g, h, pixel, pitch, dst_limit);
+					Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+							h, i, h, i, pixel, pitch, dst_limit);
+					Interpolate2x2BlockBy2x<uintX, Manip, uintS>(
+							i, j, i, j, pixel, pitch, dst_limit);
+				}
 			}
-
-			pixel += p_diff;
-
-			texel += tex_diff;
-			tline_end += tpitch * 4;
 		}
 
 		return true;
@@ -184,4 +342,4 @@ namespace Pentagram {
 
 	InstantiateBilinearScalerFunc(BilinearScalerInternal_2x);
 
-}    // namespace Pentagram
+}}    // namespace Pentagram::BilinearScaler

--- a/imagewin/BilinearScalerInternal_Arb.cpp
+++ b/imagewin/BilinearScalerInternal_Arb.cpp
@@ -85,7 +85,7 @@ namespace Pentagram { namespace BilinearScaler {
 
 		// Number of loops that can run.
 		// this is the number of blocks we can safely scale without
-		// checking for buffer overruns
+		// per pixel checking for buffer overruns
 
 		int numyloops = (sh - 1) / linesperxloop;
 		int numxloops = (sw - 1) / blockwidth;

--- a/imagewin/BilinearScalerInternal_Arb.cpp
+++ b/imagewin/BilinearScalerInternal_Arb.cpp
@@ -22,234 +22,547 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "BilinearScalerInternal.h"
 #include "manip.h"
 
-namespace Pentagram {
+namespace Pentagram { namespace BilinearScaler {
 
+	template <
+			class uintX, class Manip, class uintS,
+			typename limit_t = std::nullptr_t>
+	// This takes a 2x2 block and generates the scaled pixels between the texels
+	// The fixed point inputs control how many pixels to generate
+	// and the needed filtering coefficents
+	BSI_FORCE_INLINE uint8* Interpolate2x2BlockByAny(
+			const uint8* const tl, const uint8* const bl, const uint8* const tr,
+			const uint8* const br, uint8*& blockline_start, uint8*& next_block,
+			fixedu1616& pos_y, fixedu1616& pos_x, fixedu1616& end_y,
+			const fixedu1616 end_x, const fixedu1616 add_y,
+			const fixedu1616 add_x, const fixedu1616 block_start_x,
+			const uint_fast32_t pitch, const limit_t limit = nullptr) {
+		uint8*     pixel = blockline_start;
+		fixedu1616 posy = pos_y, posx = pos_x;
+		while (posy < end_y && IsUnclipped(blockline_start, limit)) {
+			// reset posx to block_start_x for each row
+			posx = block_start_x;
+			// Set pixel to blockline_start and increment blockline_start to the
+			// next line
+			pixel = blockline_start;
+			blockline_start += pitch;
+			while (posx < end_x && IsUnclipped(pixel, limit)) {
+				Interpolate2x2BlockTo1<uintX, Manip, uintS>(
+						tl, bl, tr, br, (end_x - posx) >> 8,
+						(end_y - posy) >> 8, pixel, limit);
+				pixel += sizeof(uintX);
+				posx += add_x;
+			};
+			if (!next_block) {
+				next_block = pixel;
+			}
+			posy += add_y;
+		}
+
+		pos_y = posy;
+		pos_x = posx;
+		end_y += 1 << 16;
+		return pixel;
+	}
+
+	// Arbitrary Bilinear Scaler
+	// It works on blocks of 2x5 source pixels at a time. Uses 16.16 Fixed point
+	// to calculate filtering coefficients for each destination pixel
 	template <class uintX, class Manip, class uintS>
 	bool BilinearScalerInternal_Arb(
-			SDL_Surface* tex, sint32 sx, sint32 sy, sint32 sw, sint32 sh,
-			uint8* pixel, sint32 dw, sint32 dh, sint32 pitch, bool clamp_src) {
+			SDL_Surface* tex, uint_fast32_t sx, uint_fast32_t sy,
+			uint_fast32_t sw, uint_fast32_t sh, uint8* pixel, uint_fast32_t dw,
+			uint_fast32_t dh, uint_fast32_t pitch, bool clamp_src) {
+		uint_fast32_t tex_w = tex->w, tex_h = tex->h;
+
+		const uint_fast8_t blockwidth = 2;
+		// This is the number of lines advanced per xloop
+		const uint_fast8_t linesperxloop = 4;
+		// And this is the number of actual lines read in each
+		// block. The bottom lines of one block is the same as
+		// the top line of the block below it
+		const uint_fast8_t blockheight = linesperxloop + 1;
+
+		// Number of loops that can run.
+		// this is the number of blocks we can safely scale without
+		// checking for buffer overruns
+
+		int numyloops = (sh - 1) / linesperxloop;
+		int numxloops = (sw - 1) / blockwidth;
+
 		// Source buffer pointers
-		const int tpitch = tex->pitch / sizeof(uintS);
-		uintS*    texel = static_cast<uintS*>(tex->pixels) + (sy * tpitch + sx);
-		uintS*    tline_end = texel + (sw - 1);
-		uintS*    tex_end   = texel + (sh - 4) * tpitch;
-		int       tex_diff  = (tpitch * 4) - sw;
+		const int    tpitch = tex->pitch / sizeof(uintS);
+		const uintS* texel
+				= static_cast<uintS*>(tex->pixels) + (sy * tpitch + sx);
+		const uintS* xloop_end = texel + 1 + (numxloops * blockwidth);
+		const uintS* yloop_end = texel + (numyloops * linesperxloop) * tpitch;
 
-		uint8 a[4];
-		uint8 b[4];
-		uint8 c[4];
-		uint8 d[4];
-		uint8 e[4];
-		uint8 f[4];
-		uint8 g[4];
-		uint8 h[4];
-		uint8 i[4];
-		uint8 j[4];
+		// Absolute limit of the source buffer. Must not read at or beyondthis
+		const uintS* srclimit
+				= static_cast<uintS*>(tex->pixels) + (tex_h * tpitch);
+		int tex_diff = (tpitch * 4) - sw;
 
-		uint32 pos_y = 0;
-		uint32 pos_x = 0;
+		// 2*5 Source RGBA Pixel block being scaled. Alpha values are
+		// currently ignored. abcde are a column and fghij are the other column.
+		// Columns can be used in either order
+		// Initializion values are meaningless
+		uint8 a[4] = "A", f[4] = "F";
+		uint8 b[4] = "B", g[4] = "G";
+		uint8 c[4] = "C", h[4] = "H";
+		uint8 d[4] = "D", i[4] = "I";
+		uint8 e[4] = "E", j[4] = "J";
 
-		const uint32 add_y = (sh << 16) / dh;
-		const uint32 add_x = (sw << 16) / dw;
+		// Absolute limit of dest buffer. Must not write beyond this
+		uint8* const dst_limit = pixel + dh * pitch;
 
-		uint32 start_x = (sw << 16) - (add_x * dw);
-		uint32 dst_y   = (sh << 16) - (add_y * dh);
-		uint32 end_y   = 1 << 16;
+		// Fixedpoint position increments when advancing dest pixels (this is 1/
+		// scalefactor) effectively means how many source pixels are advanced
+		// per dest pixel written
+		const fixedu1616 add_y = (sh << 16) / dh;
+		const fixedu1616 add_x = (sw << 16) / dw;
 
+		// Limits for block being worked on
+		// start_x and start_y are calculated backward from the last pixel
+		// so the last pixel has no fractional component when
+		// filtering and to limit rounding related problems from the calculation
+		// of the add values above
+		// end_y is the y limit for current block
+		// end_x is the x limit for the current block
+		// After a block is finished the end values are advanced by 1<<16 that represents 1 source pixel
+		fixedu1616 start_x = (sw << 16) - (add_x * dw);
+		fixedu1616 start_y = (sh << 16) - (add_y * dh);
+		fixedu1616 end_y   = 1 << 16;
+		fixedu1616 end_x = 1 << 16;
+
+		// Offset by half a source pixel when doing 0.5x scaling
+		// looks a bit better
 		if (sw == dw * 2) {
 			start_x += 0x8000;
 		}
 		if (sh == dh * 2) {
-			dst_y += 0x8000;
+			start_y += 0x8000;
 		}
 
+		// Current Fixed point position in source buffer 
+		// This is avanced by add values from above when a dest pixel is 
+		// written
+		// Dest pixels will be written while pos_? is less than end_?
+		// The filtering coefficents for dest pixels are calculated using the
+		// fractional part of end_? - pos_?
+		fixedu1616 pos_y = start_y;
+		fixedu1616 pos_x = start_x;
+
+		//This is the dest pointer to the start of the current line of the current block
+		//This gets set to the value of next_block when advancing to the block to right
 		uint8* blockline_start = nullptr;
+		// This is the dest pointer of the top left pixel of the next blocck to the right
 		uint8* next_block      = nullptr;
 
-		//	uint8* pixel_start = pixel;
-
+		// if no clipping is requested only disable clipping x if the source
+		// actually has the neeeded width to safely read the entire line
+		// unclipped widths not multple of blockwidth always need clipping
 		bool clip_x = true;
-		if (sw + sx < tpitch && !clamp_src) {
-			clip_x    = false;
-			tline_end = texel + (sw + 1);
+		if ((sx + blockwidth + 1 + numxloops * blockwidth) < tex_w && !clamp_src
+			&& !(sw % blockwidth)) {
+			clip_x = false;
+			numxloops++;
+			xloop_end = texel + 1 + (numxloops * blockwidth);
 			tex_diff--;
 		}
 
+		// clip_y
 		bool clip_y = true;
-		if (sh + sy < tex->h && !clamp_src) {
-			clip_y  = false;
-			tex_end = texel + (sh)*tpitch;
+		// if request no clamping, check to see if y remains in the bounds of
+		// the texture. If it does we can disable clipping on y
+		// heights not multple of linesperxloop always need clipping
+		if ((sy + blockheight + numyloops * linesperxloop) < tex_h && !clamp_src
+			&& !(sh % linesperxloop)) {
+			numyloops++;
+			clip_y    = false;
+			yloop_end = texel + (numyloops * linesperxloop) * tpitch;
+		}
+
+		// Check if enough lines for loop. if not then set clip_y and prevent
+		// loop Must have AT LEAST blockheight lines to do a loop
+		if (texel + blockheight * tpitch > srclimit) {
+			yloop_end = texel;
+			clip_y    = true;
 		}
 
 		// Src Loop Y
-		do {
-			Read5(a, b, c, d, e);
-			texel++;
+		uint_fast32_t block_start_x = start_x;
+		uint_fast32_t block_start_y = pos_y;
 
-			uint32 end_x = 1 << 16;
-			uint32 dst_x = start_x;
+		while (texel != yloop_end) {
+			// Read first column of 5 lines into abcde
+			ReadTexelsV<Manip>(blockheight, texel, tpitch, a, b, c, d, e);
+			// advance texel pointer by 1 to the next column
+			texel++;
+			end_x = 1 << 16;
+			block_start_x       = start_x;
+			block_start_y       = pos_y;
 
 			next_block = pixel;
+			// Src Loop X, loops while there are 2 or more columns available
+			// auto xdiff = xloop_end - (texel + numxloops * blockwidth);
+			// xloop_end  = texel + (numxloops * blockwidth);
+			assert(xloop_end == (texel + numxloops * blockwidth));
+			while (texel != xloop_end) {
+				pos_y = block_start_y;
 
-			// Src Loop X
-			do {
-				pos_y = dst_y;
-
-				Read5(f, g, h, i, j);
+				// Read next column of 5 lines into fghij
+				ReadTexelsV<Manip>(blockheight, texel, tpitch, f, g, h, i, j);
+				// advance texel pointer by 1 to the next column
 				texel++;
 
 				blockline_start = next_block;
 				next_block      = nullptr;
 
-				ArbInnerLoop(a, b, f, g);
-				ArbInnerLoop(b, c, g, h);
-				ArbInnerLoop(c, d, h, i);
-				ArbInnerLoop(d, e, i, j);
+				// Interpolate with existing abcde as left and just read fghij
+				// as right
+				// Generate all dest pixels for The 4 inputsource pixels
+
+				// a f
+				// b g
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						a, b, f, g, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch);
+				// b g
+				// c h
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						b, c, g, h, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch);
+				// c h
+				// d i
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						c, d, h, i, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch);
+				// d i
+				// e j
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						d, e, i, j, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch);
 
 				end_y -= 4 << 16;
-				dst_x = pos_x;
+				block_start_x = pos_x;
 				end_x += 1 << 16;
-				pos_y = dst_y;
+				pos_y = block_start_y;
 
-				Read5(a, b, c, d, e);
+				// Read next column of 5 lines into abcde
+				// Keeping existing fghij from above
+				ReadTexelsV<Manip>(blockheight, texel, tpitch, a, b, c, d, e);
+				// advance texel pointer by 1 to the next column
 				texel++;
 
 				blockline_start = next_block;
 				next_block      = nullptr;
 
-				ArbInnerLoop(f, g, a, b);
-				ArbInnerLoop(g, h, b, c);
-				ArbInnerLoop(h, i, c, d);
-				ArbInnerLoop(i, j, d, e);
+				// Interpolate with existing fghij as left and just read abcde
+				// as right Generate all dest pixels for The 4 input source
+				// pixels
 
+				// f a
+				// g b
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						f, g, a, b, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch);
+				//  g b
+				//  h c
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						g, h, b, c, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch);
+				// h c
+				// i d
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						h, i, c, d, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch);
+				// i d
+				// j e
+				pixel = Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						i, j, d, e, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch);
 				end_y -= 4 << 16;
-				dst_x = pos_x;
-				end_x += 1 << 16;
-			} while (texel != tline_end);
-
-			// Final X (clipping)
-			if (clip_x) {
-				pos_y = dst_y;
-
-				Read5(f, g, h, i, j);
-				texel++;
-
-				blockline_start = next_block;
-				next_block      = nullptr;
-
-				ArbInnerLoop(a, b, f, g);
-				ArbInnerLoop(b, c, g, h);
-				ArbInnerLoop(c, d, h, i);
-				ArbInnerLoop(d, e, i, j);
-
-				end_y -= 4 << 16;
-				dst_x = pos_x;
-				end_x += 1 << 16;
-				pos_y = dst_y;
-
-				blockline_start = next_block;
-				next_block      = nullptr;
-
-				ArbInnerLoop(f, g, f, g);
-				ArbInnerLoop(g, h, g, h);
-				ArbInnerLoop(h, i, h, i);
-				ArbInnerLoop(i, j, i, j);
-
-				end_y -= 4 << 16;
-				dst_x = pos_x;
+				block_start_x = pos_x;
 				end_x += 1 << 16;
 			}
+			//	assert(cols == numxloops);
+
+			// Final X (clipping) if  have a source column available
+			if (clip_x) {
+				pos_y = block_start_y;
+
+				// Read last column of 5 lines into fghij
+				// if source width is odd we reread the previous column
+				if (sw & 1) {
+					texel--;
+				}
+				ReadTexelsV<Manip>(blockheight, texel, tpitch, f, g, h, i, j);
+				texel++;
+
+				blockline_start = next_block;
+				next_block      = nullptr;
+
+				// Interpolate abcde as left and fghij as right
+				//
+				// a f
+				// b g
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						a, b, f, g, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch);
+				// b g
+				// c h
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						b, c, g, h, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch);
+				// c h
+				// d i
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						c, d, h, i, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch);
+				// d i
+				// e j
+				pixel = Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						d, e, i, j, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch);
+
+				block_start_x = pos_x;
+				end_x += 1 << 16;
+
+				assert(next_block);
+				// odd widths do not need the second column
+				blockline_start = next_block;
+				end_y -= 4 << 16;
+				if (!(sw & 1)) {
+					pos_y      = block_start_y;
+					next_block = nullptr;
+					// Interpolate with fghij as both columns, duplicates right
+					// most source column into right edge of destination but
+					// still interpolates vertically
+
+					// f f
+					// g g
+					Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+							f, g, f, g, blockline_start, next_block, pos_y,
+							pos_x, end_y, end_x, add_y, add_x, block_start_x,
+							pitch);
+					// g g
+					// h h
+					Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+							g, h, g, h, blockline_start, next_block, pos_y,
+							pos_x, end_y, end_x, add_y, add_x, block_start_x,
+							pitch);
+					// h h
+					// i i
+					Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+							h, i, h, i, blockline_start, next_block, pos_y,
+							pos_x, end_y, end_x, add_y, add_x, block_start_x,
+							pitch);
+					// i i
+					// j j
+					pixel = Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+							i, j, i, j, blockline_start, next_block, pos_y,
+							pos_x, end_y, end_x, add_y, add_x, block_start_x,
+							pitch);
+					end_y -= 4 << 16;
+					block_start_x = pos_x;
+					end_x += 1 << 16;
+				}
+			}
+			assert(next_block);
 
 			pixel += pitch - sizeof(uintX) * (dw);
 
-			dst_y = pos_y;
+			block_start_y = pos_y;
 			end_y += 4 << 16;
-
 			texel += tex_diff;
-			tline_end += tpitch * 4;
-		} while (texel != tex_end);
+			xloop_end += tpitch * linesperxloop;
+		}
 
 		//
-		// Final Rows - Clipping
+		// Final Rows - Clipped to height
 		//
-
-		// Src Loop Y
 		if (clip_y) {
-			Read5_Clipped(a, b, c, d, e);
+			// Calculate the number of unscaled source lines
+			uint_fast8_t lines_remaining = sh % linesperxloop;
+			if (lines_remaining == 0) {
+				lines_remaining = linesperxloop;
+			}
+
+			// If no clamping was requested and we have pixels available, allow
+			// reading beyond the source rect
+			if (numyloops * linesperxloop + lines_remaining + sy < tex_h
+				&& !clamp_src) {
+				// It doesn't matter if this is bigger than linesperxloop
+				lines_remaining = std::max<uint_fast16_t>(
+						255, tex_h - sy - numyloops * linesperxloop);
+			}
+
+			// Read column 0 of block but clipped to clipping lines
+			ReadTexelsV<Manip>(lines_remaining, texel, tpitch, a, b, c, d, e);
 			texel++;
 
-			uint32 end_x = 1 << 16;
-			uint32 dst_x = start_x;
+			uint_fast32_t end_x         = 1 << 16;
+			uint_fast32_t block_start_x = start_x;
 
 			next_block = pixel;
 
 			// Src Loop X
-			do {
-				pos_y = dst_y;
+			while (texel != xloop_end) {
+				pos_y = block_start_y;
 
-				Read5_Clipped(f, g, h, i, j);
+				ReadTexelsV<Manip>(
+						lines_remaining, texel, tpitch, f, g, h, i, j);
 				texel++;
 
-				blockline_start = next_block;
+				blockline_start = next_block ? next_block : pixel;
 				next_block      = nullptr;
 
-				ArbInnerLoop(a, b, f, g);
-				ArbInnerLoop(b, c, g, h);
-				ArbInnerLoop(c, d, h, i);
-				ArbInnerLoop(d, e, i, j);
+				// a f
+				// b g
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						a, b, f, g, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch,
+						dst_limit);
+				// b g
+				// c h
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						b, c, g, h, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch,
+						dst_limit);
+				// c h
+				// d i
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						c, d, h, i, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch,
+						dst_limit);
+
+				// d i
+				// e j
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						d, e, i, j, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch,
+						dst_limit);
 
 				end_y -= 4 << 16;
-				dst_x = pos_x;
+				block_start_x = pos_x;
 				end_x += 1 << 16;
-				pos_y = dst_y;
+				pos_y = block_start_y;
 
-				Read5_Clipped(a, b, c, d, e);
+				ReadTexelsV<Manip>(
+						lines_remaining, texel, tpitch, a, b, c, d, e);
 				texel++;
 
-				blockline_start = next_block;
+				blockline_start = next_block ? next_block : pixel;
 				next_block      = nullptr;
+				// assert(IsUnclipped(blockline_start, dst_limit));
 
-				ArbInnerLoop(f, g, a, b);
-				ArbInnerLoop(g, h, b, c);
-				ArbInnerLoop(h, i, c, d);
-				ArbInnerLoop(i, j, d, e);
+				// j a
+				// g b
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						f, g, a, b, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch,
+						dst_limit);
+				//  g b
+				//  h c
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						g, h, b, c, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch,
+						dst_limit);
+				// h c
+				// i d
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						h, i, c, d, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch,
+						dst_limit);
+				// i d
+				// j e
+				pixel = Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						i, j, d, e, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch,
+						dst_limit);
 
 				end_y -= 4 << 16;
-				dst_x = pos_x;
+				block_start_x = pos_x;
 				end_x += 1 << 16;
-			} while (texel != tline_end);
+			};
 
-			// Final X (clipping)
+			// Final X (clipping) if have a source column available
+			//
 			if (clip_x) {
-				pos_y = dst_y;
+				pos_y = block_start_y;
 
-				Read5_Clipped(f, g, h, i, j);
+				// Read last column of 5 lines into fghij
+				if (sw & 1) {
+					// if source width is odd go back a column so we re-read the
+					// column and do not exceed bounds
+					texel--;
+				}
+				ReadTexelsV<Manip>(
+						lines_remaining, texel, tpitch, f, g, h, i, j);
 				texel++;
 
+				blockline_start = next_block ? next_block : pixel;
+				next_block      = nullptr;
+
+				// a f
+				// b g
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						a, b, f, g, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch,
+						dst_limit);
+				// b g
+				// c h
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						b, c, g, h, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch,
+						dst_limit);
+				// c h
+				// d i
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						c, d, h, i, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch,
+						dst_limit);
+				// d i
+				// e j
+				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+						d, e, i, j, blockline_start, next_block, pos_y, pos_x,
+						end_y, end_x, add_y, add_x, block_start_x, pitch,
+						dst_limit);
+
+				end_y -= 4 << 16;
+				block_start_x = pos_x;
+				end_x += 1 << 16;
+				pos_y = block_start_y;
+
 				blockline_start = next_block;
 				next_block      = nullptr;
 
-				ArbInnerLoop(a, b, f, g);
-				ArbInnerLoop(b, c, g, h);
-				ArbInnerLoop(c, d, h, i);
-				ArbInnerLoop(d, e, i, j);
-
-				end_y -= 4 << 16;
-				dst_x = pos_x;
-				end_x += 1 << 16;
-				pos_y = dst_y;
-
-				blockline_start = next_block;
-				next_block      = nullptr;
-
-				ArbInnerLoop(f, g, f, g);
-				ArbInnerLoop(g, h, g, h);
-				ArbInnerLoop(h, i, h, i);
-				ArbInnerLoop(i, j, i, j);
-
-				end_y -= 4 << 16;
-				dst_x = pos_x;
-				end_x += 1 << 16;
+				if (!(sw & 1)) {
+					// f f
+					// g g
+					Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+							f, g, f, g, blockline_start, next_block, pos_y,
+							pos_x, end_y, end_x, add_y, add_x, block_start_x,
+							pitch, dst_limit);
+					// g g
+					// h h
+					Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+							g, h, g, h, blockline_start, next_block, pos_y,
+							pos_x, end_y, end_x, add_y, add_x, block_start_x,
+							pitch, dst_limit);
+					// h h
+					// i i
+					Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+							h, i, h, i, blockline_start, next_block, pos_y,
+							pos_x, end_y, end_x, add_y, add_x, block_start_x,
+							pitch, dst_limit);
+					// i i
+					// j j
+					Interpolate2x2BlockByAny<uintX, Manip, uintS>(
+							i, j, i, j, blockline_start, next_block, pos_y,
+							pos_x, end_y, end_x, add_y, add_x, block_start_x,
+							pitch, dst_limit);
+				}
 			}
 		}
 
@@ -258,4 +571,4 @@ namespace Pentagram {
 
 	InstantiateBilinearScalerFunc(BilinearScalerInternal_Arb);
 
-}    // namespace Pentagram
+}}    // namespace Pentagram::BilinearScaler

--- a/imagewin/BilinearScalerInternal_Arb.cpp
+++ b/imagewin/BilinearScalerInternal_Arb.cpp
@@ -190,8 +190,8 @@ namespace Pentagram { namespace BilinearScaler {
 		}
 
 		// Src Loop Y
-		uint_fast32_t block_start_x = start_x;
-		uint_fast32_t block_start_y = pos_y;
+		fixedu1616    block_start_x = start_x;
+		fixedu1616 block_start_y = pos_y;
 
 		while (texel != yloop_end) {
 			// Read first column of 5 lines into abcde
@@ -204,8 +204,6 @@ namespace Pentagram { namespace BilinearScaler {
 
 			next_block = pixel;
 			// Src Loop X, loops while there are 2 or more columns available
-			// auto xdiff = xloop_end - (texel + numxloops * blockwidth);
-			// xloop_end  = texel + (numxloops * blockwidth);
 			assert(xloop_end == (texel + numxloops * blockwidth));
 			while (texel != xloop_end) {
 				pos_y = block_start_y;
@@ -285,7 +283,6 @@ namespace Pentagram { namespace BilinearScaler {
 				block_start_x = pos_x;
 				end_x += 1 << 16;
 			}
-			//	assert(cols == numxloops);
 
 			// Final X (clipping) if  have a source column available
 			if (clip_x) {
@@ -401,8 +398,8 @@ namespace Pentagram { namespace BilinearScaler {
 			ReadTexelsV<Manip>(lines_remaining, texel, tpitch, a, b, c, d, e);
 			texel++;
 
-			uint_fast32_t end_x         = 1 << 16;
-			uint_fast32_t block_start_x = start_x;
+			end_x         = 1 << 16;
+			block_start_x = start_x;
 
 			next_block = pixel;
 
@@ -454,9 +451,8 @@ namespace Pentagram { namespace BilinearScaler {
 
 				blockline_start = next_block ? next_block : pixel;
 				next_block      = nullptr;
-				// assert(IsUnclipped(blockline_start, dst_limit));
 
-				// j a
+				// f a
 				// g b
 				Interpolate2x2BlockByAny<uintX, Manip, uintS>(
 						f, g, a, b, blockline_start, next_block, pos_y, pos_x,

--- a/imagewin/BilinearScalerInternal_X1Y12.cpp
+++ b/imagewin/BilinearScalerInternal_X1Y12.cpp
@@ -22,69 +22,232 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "BilinearScalerInternal.h"
 #include "manip.h"
 
-namespace Pentagram {
+namespace Pentagram { namespace BilinearScaler {
+	template <
+			class uintX, class Manip, class uintS,
+			typename limit_t = std::nullptr_t>
+	// Scale incoming 1x6 block of pixels to aspect corrected 1x6
+	BSI_FORCE_INLINE void Interpolate1x6BlockByX1Y12(
+			const uint8* const a, const uint8* const b, const uint8* const c,
+			const uint8* const d, const uint8* const e, const uint8* const f,
+			uint8*& pixel, const uint_fast32_t pitch,
+			const limit_t limit = nullptr) {
+		// A nothing source pixel. This can be anything
+		// Using all zeros so the compiler has an easier time optimizing away
+		// the interpolation calculations after inlining
+		const uint8 n[] = {0, 0, 0};
 
+		Interpolate2x2BlockTo1<uintX, Manip, uintS>(
+				a, b, n, n, 256, 256, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo1<uintX, Manip, uintS>(
+				a, b, n, n, 256, (0x500 * 5 / 6) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo1<uintX, Manip, uintS>(
+				b, c, n, n, 256, (0x500 * 4 / 6) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo1<uintX, Manip, uintS>(
+				c, d, n, n, 256, (0x500 * 3 / 6) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo1<uintX, Manip, uintS>(
+				d, e, n, n, 256, (0x500 * 2 / 6) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo1<uintX, Manip, uintS>(
+				e, f, n, n, 256, (0x500 * 1 / 6) & 0xff, pixel, limit);
+		pixel += pitch;
+	}
+
+	// 2x Blinear Scaler with Aspect Correction
+	// It is a modification of the 2xY2.4 scaler.
 	template <class uintX, class Manip, class uintS>
 	bool BilinearScalerInternal_X1Y12(
-			SDL_Surface* tex, sint32 sx, sint32 sy, sint32 sw, sint32 sh,
-			uint8* pixel, sint32 dw, sint32 dh, sint32 pitch, bool clamp_src) {
-		ignore_unused_variable_warning(dh);
+			SDL_Surface* tex, uint_fast32_t sx, uint_fast32_t sy,
+			uint_fast32_t sw, uint_fast32_t sh, uint8* pixel, uint_fast32_t dw,
+			uint_fast32_t dh, uint_fast32_t pitch, bool clamp_src) {
+		uint_fast32_t tex_h = tex->h;
+
+		const uint_fast8_t blockwidth       = 1;
+		const uint_fast8_t blocks_per_xloop = 2;
+		const uint_fast8_t texels_per_xloop = blockwidth * blocks_per_xloop;
+		// This is the number of lines advanced per xloop
+		const uint_fast8_t blockheight = 5;
+
+		// And this is the number of actual lines read in each
+		// block. The bottom lines of one block is the same as
+		// the top line of the block below it
+		const uint_fast8_t actualblockheight = blockheight + 1;
+
+		const uint_fast8_t destblockwidth  = 1;
+		const uint_fast8_t destblockheight = 6;
+
+		// Number of times yloop can run.
+		// this is the number of blocks we can safely scale without
+		// checking for buffer overruns
+		
+		int numyloops = (sh - 1) / blockheight;
+		int numxloops = (sw - 1) / texels_per_xloop;
+
 		// Source buffer pointers
-		const int tpitch = tex->pitch / sizeof(uintS);
-		uintS*    texel = static_cast<uintS*>(tex->pixels) + (sy * tpitch + sx);
-		uintS*    tline_end = texel + (sw);
-		uintS*    tex_end   = texel + (sh - 5) * tpitch;
-		const int tex_diff  = (tpitch * 5) - sw;
+		const int    tpitch = tex->pitch / sizeof(uintS);
+		const uintS* texel
+				= static_cast<uintS*>(tex->pixels) + (sy * tpitch + sx);
+		const uintS* xloop_end = texel + 1 + (numxloops * texels_per_xloop);
+		const uintS* yloop_end = texel + (numyloops * blockheight) * tpitch;
 
-		uint8 a[4];
-		uint8 b[4];
-		uint8 c[4];
-		uint8 d[4];
-		uint8 e[4];
-		uint8 l[4];
-		uint8 cols[6][4];
+		// Absolute limit of the source buffer. Must not read at or beyondthis
+		const uintS* srclimit
+				= static_cast<uintS*>(tex->pixels) + (tex_h * tpitch);
+		int tex_diff = (tpitch * blockheight) - sw;
 
+		// 1*6 Source RGBA Pixel block being scaled. Alpha values are
+		// currently ignored.
+		// Initializion values are meaningless
+		uint8 a[4] = "A";
+		uint8 b[4] = "B";
+		uint8 c[4] = "C";
+		uint8 d[4] = "D";
+		uint8 e[4] = "E";
+		uint8 f[4] = "F";
+
+		// Absolute limit of dest buffer. Must not write beyond this
+		// We only need to use this when performing final y clipping
+		uint8* const dst_limit = pixel + dh * pitch;
+
+		// No x clipping is needed if width is even
+		bool clip_x = true;
+		if (!(sw % texels_per_xloop)) {
+			clip_x = false;
+			numxloops++;
+			xloop_end = texel + (numxloops * texels_per_xloop);
+		}
+
+		// clip_y
 		bool clip_y = true;
-		if (sh + sy < tex->h && !clamp_src) {
-			clip_y  = false;
-			tex_end = texel + (sh)*tpitch;
+		// if request no clamping, check to see if y remains in the bounds of
+		// the texture. If it does we can disable clipping on y
+		// heights not multple of blockheight always need clipping
+		if ((sy + actualblockheight + numyloops * blockheight) < tex_h
+			&& !clamp_src && !(sh % blockheight)) {
+			numyloops++;
+			clip_y    = false;
+			yloop_end = texel + (numyloops * blockheight) * tpitch;
+		}
+
+		// Check if enough lines for loop. if not then set clip_y and prevent
+		// loop Must have AT LEAST actualblockheight lines to do a loop
+		if (texel + actualblockheight * tpitch > srclimit) {
+			yloop_end = texel;
+			clip_y    = true;
 		}
 
 		// Src Loop Y
-		do {
-			// Src Loop X
-			do {
-				Read6(a, b, c, d, e, l);
+		while (texel != yloop_end) {
+			// Src Loop X, loops while there are 2 or more columns available
+			// auto xdiff = xloop_end - (texel + numxloops * texels_per_xloop);
+			// xloop_end  = texel + (numxloops * texels_per_xloop);
+			assert(xloop_end == (texel + numxloops * texels_per_xloop));
+			while (texel != xloop_end) {
+				// Read next column of 5
+				ReadTexelsV<Manip>(
+						actualblockheight, texel, tpitch, a, b, c, d, e, f);
+				// advance texel pointer by 1 to the next column
 				texel++;
 
-				X1xY12xDoCols();
-				X1xY12xInnerLoop();
-				pixel -= pitch * 6 - sizeof(uintX);
+				Interpolate1x6BlockByX1Y12<uintX, Manip, uintS>(
+						a, b, c, d, e, f, pixel, pitch, dst_limit);
 
-			} while (texel != tline_end);
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
 
-			pixel += pitch * 6 - sizeof(uintX) * (dw);
+				// Read next column of 5
+				ReadTexelsV<Manip>(
+						actualblockheight, texel, tpitch, a, b, c, d, e, f);
+				// advance texel pointer by 1 to the next column
+				texel++;
+
+				Interpolate1x6BlockByX1Y12<uintX, Manip, uintS>(
+						a, b, c, d, e, f, pixel, pitch, dst_limit);
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
+			}
+			//	assert(cols == numxloops);
+
+			// Final X (clipping) Doesn't actually do any
+			// clipping just reads and scales the final column if the width is
+			// odd
+			if (clip_x) {
+				ReadTexelsV<Manip>(
+						actualblockheight, texel, tpitch, a, b, c, d, e, f);
+				texel++;
+
+				// Interpolate abcde as left and fghij as right
+				//
+				Interpolate1x6BlockByX1Y12<uintX, Manip, uintS>(
+						a, b, c, d, e, f, pixel, pitch, dst_limit);
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
+			}
+			pixel += (pitch * destblockheight) - (dw * sizeof(uintX));
+
 			texel += tex_diff;
-			tline_end += tpitch * 5;
-
-		} while (texel != tex_end);
+			xloop_end += tpitch * blockheight;
+		}
 
 		//
-		// Final Rows - Clipping
+		// Final Rows - Clipped to height
 		//
-
-		// Src Loop Y
 		if (clip_y) {
+			// Calculate the number of unscaled source lines
+			uint_fast8_t lines_remaining = sh % blockheight;
+			if (lines_remaining == 0) {
+				lines_remaining = blockheight;
+			}
+
+			// If no clamping was requested and we have pixels available, allow
+			// reading beyond the source rect
+			if (numyloops * blockheight + lines_remaining + sy < tex_h
+				&& !clamp_src) {
+				// It doesn't matter if this is bigger than blockheight
+				lines_remaining = std::max<uint_fast16_t>(
+						255, tex_h - sy - numyloops * blockheight);
+			}
+
 			// Src Loop X
-			do {
-				Read6_Clipped(a, b, c, d, e, l);
+			while (texel != xloop_end) {
+				ReadTexelsV<Manip>(
+						lines_remaining, texel, tpitch, a, b, c, d, e, f);
 				texel++;
 
-				X1xY12xDoCols();
-				X1xY12xInnerLoop();
-				pixel -= pitch * 6 - sizeof(uintX);
+				Interpolate1x6BlockByX1Y12<uintX, Manip, uintS>(
+						a, b, c, d, e, f, pixel, pitch, dst_limit);
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
 
-			} while (texel != tline_end);
+				ReadTexelsV<Manip>(
+						lines_remaining, texel, tpitch, a, b, c, d, e, f);
+				texel++;
+
+				Interpolate1x6BlockByX1Y12<uintX, Manip, uintS>(
+						a, b, c, d, e, f, pixel, pitch, dst_limit);
+
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
+			};
+
+			// Final X (clipping) Doesn't actually do any
+			// clipping just reads and scales the final column if the width is
+			// odd
+			if (clip_x) {
+				ReadTexelsV<Manip>(
+						lines_remaining, texel, tpitch, a, b, c, d, e, f);
+				texel++;
+
+				Interpolate1x6BlockByX1Y12<uintX, Manip, uintS>(
+						a, b, c, d, e, f, pixel, pitch, dst_limit);
+			}
 		}
 
 		return true;
@@ -92,4 +255,4 @@ namespace Pentagram {
 
 	InstantiateBilinearScalerFunc(BilinearScalerInternal_X1Y12);
 
-}    // namespace Pentagram
+}}    // namespace Pentagram::BilinearScaler

--- a/imagewin/BilinearScalerInternal_X1Y12.cpp
+++ b/imagewin/BilinearScalerInternal_X1Y12.cpp
@@ -80,9 +80,9 @@ namespace Pentagram { namespace BilinearScaler {
 		const uint_fast8_t destblockwidth  = 1;
 		const uint_fast8_t destblockheight = 6;
 
-		// Number of times yloop can run.
+		// Number of loops that can run.
 		// this is the number of blocks we can safely scale without
-		// checking for buffer overruns
+		// per pixel checking for buffer overruns
 		
 		int numyloops = (sh - 1) / blockheight;
 		int numxloops = (sw - 1) / texels_per_xloop;

--- a/imagewin/BilinearScalerInternal_X1Y12.cpp
+++ b/imagewin/BilinearScalerInternal_X1Y12.cpp
@@ -143,8 +143,6 @@ namespace Pentagram { namespace BilinearScaler {
 		// Src Loop Y
 		while (texel != yloop_end) {
 			// Src Loop X, loops while there are 2 or more columns available
-			// auto xdiff = xloop_end - (texel + numxloops * texels_per_xloop);
-			// xloop_end  = texel + (numxloops * texels_per_xloop);
 			assert(xloop_end == (texel + numxloops * texels_per_xloop));
 			while (texel != xloop_end) {
 				// Read next column of 5
@@ -171,7 +169,6 @@ namespace Pentagram { namespace BilinearScaler {
 				pixel -= pitch * destblockheight;
 				pixel += sizeof(uintX) * destblockwidth;
 			}
-			//	assert(cols == numxloops);
 
 			// Final X (clipping) Doesn't actually do any
 			// clipping just reads and scales the final column if the width is

--- a/imagewin/BilinearScalerInternal_X2Y24.cpp
+++ b/imagewin/BilinearScalerInternal_X2Y24.cpp
@@ -95,7 +95,7 @@ namespace Pentagram { namespace BilinearScaler {
 
 		// Number of loops that can run.
 		// this is the number of blocks we can safely scale without
-		// checking for buffer overruns
+		// per pixel checking for buffer overruns
 		
 		int numyloops = (sh - 1) / linesperxloop;
 		int numxloops = (sw - 1) / blockwidth;

--- a/imagewin/BilinearScalerInternal_X2Y24.cpp
+++ b/imagewin/BilinearScalerInternal_X2Y24.cpp
@@ -22,129 +22,308 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "BilinearScalerInternal.h"
 #include "manip.h"
 
-namespace Pentagram {
+namespace Pentagram { namespace BilinearScaler {
 
+	template <
+			class uintX, class Manip, class uintS,
+			typename limit_t = std::nullptr_t>
+	// Aspect Correct 2x Scale of incoming 2x6 block of pixels to 2x12
+	BSI_FORCE_INLINE void Interpolate6x2BlockByX2Y24(
+			const uint8* const a, const uint8* const b, const uint8* const c,
+			const uint8* const d, const uint8* const e, const uint8* const f,
+			const uint8* const g, const uint8* const h, const uint8* const i,
+			const uint8* const j, const uint8* const k, const uint8* const l,
+			uint8*& pixel, const uint_fast32_t pitch,
+			const limit_t limit = nullptr) {
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				a, b, g, h, 256, 128, 256, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				a, b, g, h, 256, 128, (0x500 * 11 / 12) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				a, b, g, h, 256, 128, (0x500 * 10 / 12) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				b, c, h, i, 256, 128, (0x500 * 9 / 12) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				b, c, h, i, 256, 128, (0x500 * 8 / 12) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				c, d, i, j, 256, 128, (0x500 * 7 / 12) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				c, d, i, j, 256, 128, (0x500 * 6 / 12) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				c, d, i, j, 256, 128, (0x500 * 5 / 12) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				d, e, j, k, 256, 128, (0x500 * 4 / 12) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				d, e, j, k, 256, 128, (0x500 * 3 / 12) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				e, f, k, l, 256, 128, (0x500 * 2 / 12) & 0xff, pixel, limit);
+		pixel += pitch;
+		Interpolate2x2BlockTo2x1<uintX, Manip, uintS>(
+				e, f, k, l, 256, 128, (0x500 * 1 / 12) & 0xff, pixel, limit);
+		pixel += pitch;
+	}
+
+	// 2x Blinear Scaler with Aspect Correction
+	// It is a modification of the basic 2x scaler.
 	template <class uintX, class Manip, class uintS>
 	bool BilinearScalerInternal_X2Y24(
-			SDL_Surface* tex, sint32 sx, sint32 sy, sint32 sw, sint32 sh,
-			uint8* pixel, sint32 dw, sint32 dh, sint32 pitch, bool clamp_src) {
-		ignore_unused_variable_warning(dh);
+			SDL_Surface* tex, uint_fast32_t sx, uint_fast32_t sy,
+			uint_fast32_t sw, uint_fast32_t sh, uint8* pixel, uint_fast32_t dw,
+			uint_fast32_t dh, uint_fast32_t pitch, bool clamp_src) {
+		uint_fast32_t tex_w = tex->w, tex_h = tex->h;
+
+		const uint_fast8_t blockwidth = 2;
+		// This is the number of lines advanced per xloop
+		const uint_fast8_t linesperxloop = 5;
+		// And this is the number of actual lines read in each
+		// block. The bottom lines of one block is the same as
+		// the top line of the block below it
+		const uint_fast8_t blockheight = linesperxloop + 1;
+
+		const uint_fast8_t destblockheight = 12;
+		const uint_fast8_t destblockwidth  = 2;
+
+		// Number of loops that can run.
+		// this is the number of blocks we can safely scale without
+		// checking for buffer overruns
+		
+		int numyloops = (sh - 1) / linesperxloop;
+		int numxloops = (sw - 1) / blockwidth;
+
 		// Source buffer pointers
-		const int tpitch = tex->pitch / sizeof(uintS);
-		uintS*    texel = static_cast<uintS*>(tex->pixels) + (sy * tpitch + sx);
-		uintS*    tline_end = texel + (sw - 1);
-		uintS*    tex_end   = texel + (sh - 5) * tpitch;
-		int       tex_diff  = (tpitch * 5) - sw;
+		const int    tpitch = tex->pitch / sizeof(uintS);
+		const uintS* texel
+				= static_cast<uintS*>(tex->pixels) + (sy * tpitch + sx);
+		const uintS* xloop_end = texel + 1 + (numxloops * blockwidth);
+		const uintS* yloop_end = texel + (numyloops * linesperxloop) * tpitch;
 
-		uint8 a[4];
-		uint8 b[4];
-		uint8 c[4];
-		uint8 d[4];
-		uint8 e[4];
-		uint8 f[4];
-		uint8 g[4];
-		uint8 h[4];
-		uint8 i[4];
-		uint8 j[4];
-		uint8 k[4];
-		uint8 l[4];
-		uint8 cols[2][12][4];
+		// Absolute limit of the source buffer. Must not read at or beyondthis
+		const uintS* srclimit
+				= static_cast<uintS*>(tex->pixels) + (tex_h * tpitch);
+		int tex_diff = (tpitch * linesperxloop) - sw;
 
+		// 2*6 Source RGBA Pixel block being scaled. Alpha values are
+		// currently ignored. abcdef are a column and ghijkl are the other
+		// column. Columns can be used in either order Initializion values are
+		// meaningless
+		uint8 a[4] = "A", g[4] = "G";
+		uint8 b[4] = "B", h[4] = "H";
+		uint8 c[4] = "C", i[4] = "I";
+		uint8 d[4] = "D", j[4] = "J";
+		uint8 e[4] = "E", k[4] = "K";
+		uint8 f[4] = "F", l[4] = "L";
+
+		// Absolute limit of dest buffer. Must not write beyond this
+		uint8* const dst_limit = pixel + dh * pitch;
+
+		// if no clipping is requested only disable clipping x if the source
+		// actually has the neeeded width to safely read the entire line
+		// unclipped widths not multple of blockwidth always need clipping
 		bool clip_x = true;
-		if (sw + sx < tpitch && !clamp_src) {
-			clip_x    = false;
-			tline_end = texel + (sw + 1);
+		if ((sx + blockwidth + 1 + numxloops * blockwidth) < tex_w && !clamp_src
+			&& !(sw % blockwidth)) {
+			clip_x = false;
+			numxloops++;
+			xloop_end = texel + 1 + (numxloops * blockwidth);
 			tex_diff--;
 		}
 
+		// clip_y
 		bool clip_y = true;
-		if (sh + sy < tex->h && !clamp_src) {
-			clip_y  = false;
-			tex_end = texel + (sh)*tpitch;
+		// if request no clamping, check to see if y remains in the bounds of
+		// the texture. If it does we can disable clipping on y
+		// heights not multple of linesperxloop always need clipping
+		if ((sy + blockheight + numyloops * linesperxloop) < tex_h
+			&& !clamp_src && !(sh % linesperxloop)) {
+			numyloops++;
+			clip_y    = false;
+			yloop_end = texel + (numyloops * linesperxloop) * tpitch;
+		}
+
+		// Check if enough lines for loop. if not then set clip_y and prevent
+		// loop Must have AT LEAST blockheight lines to do a loop
+		if (texel + (blockheight)*tpitch > srclimit) {
+			yloop_end = texel;
+			clip_y    = true;
 		}
 
 		// Src Loop Y
-		do {
-			Read6(a, b, c, d, e, l);
+		while (texel != yloop_end) {
+			if (texel > yloop_end) {
+				return true;
+			}
+			// Read first column of 5 lines into abcde
+			ReadTexelsV<Manip>(
+					blockheight, texel, tpitch, a, b, c, d, e, f);
+			// advance texel pointer by 1 to the next column
 			texel++;
 
-			X2xY24xDoColsA();
-
-			// Src Loop X
-			do {
-				Read6(f, g, h, i, j, k);
+			// Src Loop X, loops while there are 2 or more columns available
+			// auto xdiff = xloop_end - (texel + numxloops * blockwidth);
+			// xloop_end  = texel + (numxloops * blockwidth);
+			assert(xloop_end == (texel + numxloops * blockwidth));
+			while (texel != xloop_end) {
+				// Read next column of 5 lines into fghij
+				ReadTexelsV<Manip>(
+						blockheight, texel, tpitch, g, h, i, j, k, l);
+				// advance texel pointer by 1 to the next column
 				texel++;
 
-				X2xY24xDoColsB();
-				X2xY24xInnerLoop(0, 1);
-				pixel -= pitch * 12 - sizeof(uintX) * 2;
+				// Interpolate with existing abcde as left and just read fghij
+				// as right
+				// Generate all dest pixels for The 4 inputsource pixels
 
-				Read6(a, b, c, d, e, l);
+				Interpolate6x2BlockByX2Y24<uintX, Manip, uintS>(
+						a, b, c, d, e, f, g, h, i, j, k, l, pixel, pitch,
+						dst_limit);
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
+
+				// Read next column of 5 lines into abcde
+				// Keeping existing fghij from above
+				ReadTexelsV<Manip>(
+						blockheight, texel, tpitch, a, b, c, d, e, f);
+				// advance texel pointer by 1 to the next column
 				texel++;
 
-				X2xY24xDoColsA();
-				X2xY24xInnerLoop(1, 0);
-				pixel -= pitch * 12 - sizeof(uintX) * 2;
-			} while (texel != tline_end);
+				// Interpolate with existing fghij as left and just read abcde
+				// as right Generate all dest pixels for The 4 input source
+				// pixels
 
-			// Final X (clipping)
+				Interpolate6x2BlockByX2Y24<uintX, Manip, uintS>(
+						g, h, i, j, k, l, a, b, c, d, e, f, pixel, pitch,
+						dst_limit);
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
+			}
+			//	assert(cols == numxloops);
+
+			// Final X (clipping) if  have a source column available
 			if (clip_x) {
-				Read6(f, g, h, i, j, k);
+				// Read last column of 5 lines into fghij
+				// if source width is odd we reread the previous column
+				if (sw & 1) {
+					texel--;
+				}
+				ReadTexelsV<Manip>(
+						blockheight, texel, tpitch, g, h, i, j, k, l);
 				texel++;
 
-				X2xY24xDoColsB();
-				X2xY24xInnerLoop(0, 1);
-				pixel -= pitch * 12 - sizeof(uintX) * 2;
+				// Interpolate abcde as left and fghij as right
+				//
+				Interpolate6x2BlockByX2Y24<uintX, Manip, uintS>(
+						a, b, c, d, e, f, g, h, i, j, k, l, pixel, pitch,
+						dst_limit);
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
 
-				X2xY24xInnerLoop(1, 1);
-				pixel -= pitch * 12 - sizeof(uintX) * 2;
+				// odd widths do not need the second column
+				if (!(sw & 1)) {
+					Interpolate6x2BlockByX2Y24<uintX, Manip, uintS>(
+							g, h, i, j, k, l, g, h, i, j, k, l, pixel, pitch,
+							dst_limit);
+					// Move the pixel pointer to the start of the next block
+					pixel -= pitch * destblockheight;
+					pixel += sizeof(uintX) * destblockwidth;
+				}
+			}
+			pixel += (pitch * destblockheight) - (dw * sizeof(uintX));
+
+			texel += tex_diff;
+			xloop_end += tpitch * linesperxloop;
+		}
+
+		//
+		// Final Rows - Clipped to height
+		//
+		if (clip_y) {
+			// Calculate the number of unscaled source lines
+			uint_fast8_t lines_remaining = sh % linesperxloop;
+			if (lines_remaining == 0) {
+				lines_remaining = linesperxloop;
 			}
 
-			pixel += pitch * 12 - sizeof(uintX) * (dw);
-			texel += tex_diff;
-			tline_end += tpitch * 5;
-		} while (texel != tex_end);
+			// If no clamping was requested and we have pixels available, allow
+			// reading beyond the source rect
+			if (numyloops * linesperxloop + lines_remaining + sy < tex_h
+				&& !clamp_src) {
+				// It doesn't matter if this is bigger than linesperxloop
+				lines_remaining = std::max<uint_fast16_t>(
+						255, tex_h - sy - numyloops * linesperxloop);
+			}
 
-		//
-		// Final Rows - Clipping
-		//
-
-		// Src Loop Y
-		if (clip_y) {
-			Read6_Clipped(a, b, c, d, e, l);
+			// Read column 0 of block but clipped to clipping lines
+			a[0] = 0xff;
+			a[1] = 0;
+			a[2] = 0;
+			ReadTexelsV<Manip>(
+					lines_remaining, texel, tpitch, a, b, c, d, e, f);
 			texel++;
 
-			X2xY24xDoColsA();
-
 			// Src Loop X
-			do {
-				Read6_Clipped(f, g, h, i, j, k);
+			while (texel != xloop_end) {
+				ReadTexelsV<Manip>(
+						lines_remaining, texel, tpitch, g, h, i, j, k, l);
 				texel++;
 
-				X2xY24xDoColsB();
-				X2xY24xInnerLoop(0, 1);
-				pixel -= pitch * 12 - sizeof(uintX) * 2;
+				Interpolate6x2BlockByX2Y24<uintX, Manip, uintS>(
+						a, b, c, d, e, f, g, h, i, j, k, l, pixel, pitch,
+						dst_limit);
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
 
-				Read6_Clipped(a, b, c, d, e, l);
+				ReadTexelsV<Manip>(
+						lines_remaining, texel, tpitch, a, b, c, d, e, f);
 				texel++;
+				// Move the pixel pointer to the start of the next block
+				Interpolate6x2BlockByX2Y24<uintX, Manip, uintS>(
+						g, h, i, j, k, l, a, b, c, d, e, f, pixel, pitch,
+						dst_limit);
 
-				X2xY24xDoColsA();
-				X2xY24xInnerLoop(1, 0);
-				pixel -= pitch * 12 - sizeof(uintX) * 2;
-			} while (texel != tline_end);
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
+			};
 
-			// Final X (clipping)
+			// Final X (clipping) if have a source column available
+			//
 			if (clip_x) {
-				Read6_Clipped(f, g, h, i, j, k);
+				// Read last column of 5 lines into fghij
+				if (sw & 1) {
+					// if source width is odd go back a column so we re-read the
+					// column and do not exceed bounds
+					texel--;
+				}
+				ReadTexelsV<Manip>(
+						lines_remaining, texel, tpitch, g, h, i, j, k, l);
 				texel++;
 
-				X2xY24xDoColsB();
+				Interpolate6x2BlockByX2Y24<uintX, Manip, uintS>(
+						a, b, c, d, e, f, g, h, i, j, k, l, pixel, pitch,
+						dst_limit);
 
-				X2xY24xInnerLoop(0, 1);
-				pixel -= pitch * 12 - sizeof(uintX) * 2;
+				// Move the pixel pointer to the start of the next block
+				pixel -= pitch * destblockheight;
+				pixel += sizeof(uintX) * destblockwidth;
 
-				X2xY24xInnerLoop(1, 1);
-				pixel -= pitch * 12 - sizeof(uintX) * 2;
+				if (!(sw & 1)) {
+					Interpolate6x2BlockByX2Y24<uintX, Manip, uintS>(
+							g, h, i, j, k, l, g, h, i, j, k, l, pixel, pitch,
+							dst_limit);
+				}
 			}
 		}
 
@@ -153,4 +332,4 @@ namespace Pentagram {
 
 	InstantiateBilinearScalerFunc(BilinearScalerInternal_X2Y24);
 
-}    // namespace Pentagram
+}}    // namespace Pentagram::BilinearScaler

--- a/imagewin/BilinearScalerInternal_X2Y24.cpp
+++ b/imagewin/BilinearScalerInternal_X2Y24.cpp
@@ -169,8 +169,6 @@ namespace Pentagram { namespace BilinearScaler {
 			texel++;
 
 			// Src Loop X, loops while there are 2 or more columns available
-			// auto xdiff = xloop_end - (texel + numxloops * blockwidth);
-			// xloop_end  = texel + (numxloops * blockwidth);
 			assert(xloop_end == (texel + numxloops * blockwidth));
 			while (texel != xloop_end) {
 				// Read next column of 5 lines into fghij
@@ -208,7 +206,6 @@ namespace Pentagram { namespace BilinearScaler {
 				pixel -= pitch * destblockheight;
 				pixel += sizeof(uintX) * destblockwidth;
 			}
-			//	assert(cols == numxloops);
 
 			// Final X (clipping) if  have a source column available
 			if (clip_x) {

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -898,10 +898,6 @@ void Image_window::show(int x, int y, int w, int h) {
 	x -= get_start_x();
 	y -= get_start_y();
 
-	// This function always rounds the source rect to be scaled to multiples of 4
-	// Assuming the guard_band is in use and is at least 4, the rectangle will 
-	// never shrink however if there is no guardband the rectangle can shrink 
-	// by upto 3 source pixels
 
 	// we can only include guard band in the buffersize if inter_surface is not
 	// display_surface otherwise scalers will write out of bounds. A separate
@@ -936,13 +932,10 @@ void Image_window::show(int x, int y, int w, int h) {
 	if (w + x > buffer_w) {
 		w = buffer_w - x;
 	}
+
 	if (h + y > buffer_h) {
 		h = buffer_h - y;
 	}
-
-	// Round Down to multiple of 4
-	w &= ~3;
-	h &= ~3;
 
 	// Phase 1 blit from draw_surface to inter_surface
 	if (draw_surface != inter_surface) {
@@ -1157,10 +1150,8 @@ void Image_window::EndPaintIntoGuardBand() {
 }
 
 void Image_window::FillGuardband() {
-
 	auto pixels = static_cast<uint8*>(draw_surface->pixels) + guard_band
 				  + guard_band * draw_surface->pitch;
-
 	// Bottom
 	auto read  = pixels + (ibuf->height - 1) * draw_surface->pitch;
 	auto write = read + draw_surface->pitch;

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -180,6 +180,8 @@ protected:
 	bool          fullscreen;      // Rendering fullscreen.
 	int           game_width;
 	int           game_height;
+	int           real_game_width;
+	int           real_game_height;
 	int           inter_width;
 	int           inter_height;
 
@@ -319,7 +321,8 @@ public:
 			FillMode fmode = AspectCorrectCentre, int fillsclr = point)
 			: ibuf(ib), scale(scl), scaler(sclr), uses_palette(true),
 			  fullscreen(fs), game_width(gamew), game_height(gameh),
-			  fill_mode(fmode), fill_scaler(fillsclr), screen_window(nullptr),
+			  real_game_width(gamew), real_game_height(gameh), fill_mode(fmode),
+			  fill_scaler(fillsclr), screen_window(nullptr),
 			  paletted_surface(nullptr), display_surface(nullptr),
 			  inter_surface(nullptr), draw_surface(nullptr) {
 		static_init();
@@ -444,6 +447,29 @@ public:
 	// Rotate palette colors.
 	virtual void rotate_colors(int first, int num, int upd) {
 		ignore_unused_variable_warning(first, num, upd);
+	}
+
+	// Set things up so gamewin can paint.
+	// This method adjusts buffer dimensions so gamewin can draw into the
+	// guard_band on the right and bottom in order to prevent black lines when
+	// scalers read from the guardband Must call EndPaintIntoGuardBand after calling this
+	// Parmeters are the region to be painted. This will be clipped against
+	// buffer dimension and enlarged into the guardband. If Parameters are
+	// nullptr they are treated as if they are zero when clipping the other
+	// coordinates
+	void BeginPaintIntoGuardBand(int* x, int* y, int* w, int* h);
+
+	// Reset dimension back to normal after calling BeginPaintIntoGuardBand
+	void EndPaintIntoGuardBand();
+
+	// Fill the right and bottom guardband by duplicating edge pixels across it
+	// Used during cinematic sequences
+	void FillGuardband();
+
+	// Show but first fill guardband
+	void ShowFillGuardBand() {
+		FillGuardband();
+		show();
 	}
 
 	/*

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -468,7 +468,6 @@ public:
 	// whether or not we should do guardband painting
 	// Criteria is using a scaler other than point and there is a guardband
 	bool ShouldPaintIntoGuardband() {
-
 		// Only if actually scaling
 		if (draw_surface == display_surface) {
 			return false;

--- a/menulist.cc
+++ b/menulist.cc
@@ -331,6 +331,7 @@ int MenuList::handle_events(Game_window* gwin, Mouse* mouse) {
 
 	} changemouse(mouse);
 
+	gwin->get_win()->FillGuardband();
 	gwin->show(true);
 	mouse->show();
 

--- a/msvcstuff/vs2019/Exult.vcxproj
+++ b/msvcstuff/vs2019/Exult.vcxproj
@@ -205,6 +205,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvcstuff/vs2019/msvc_include.h
+++ b/msvcstuff/vs2019/msvc_include.h
@@ -58,7 +58,10 @@
 #pragma warning(3 : 4189)
 
 #include <windows.h>
-
+#define USE_XBR_SCALER 1
+#define USE_HQ2X_SCALER 1
+#define USE_HQ3X_SCALER 1
+#define USE_HQ4X_SCALER 1
 #define USE_FMOPL_MIDI   1
 #define USE_WINDOWS_MIDI 1
 #define USE_MT32EMU_MIDI 1


### PR DESCRIPTION
After way too many months works here are my scaler related fixes and changes primarily to fix The BlackLine problem in #543 

This set of changes removes Source buffer restrictions from the Bilinear scaler that was a big part of the underlying problem in #543 I also somewhat refactored the Bilinear scaler code replacing Macros with inline functions and added more comments in an attempt to make this code slightly more understandable and maintainable. The bilinear scaler used to require source buffer to have a multiple of 4 pixel alignment and Image_window::show would round down buffer sizes to a multiple of 4 which would affect all scalers when using a game window size that had non multiples of 4. As the round down was only needed for that version of bilinear scaler I removed the round down and the problem is fixed.

Example screenshot of this problem scaling from 327x207 to  1280x960 where a large number of pixels are missing from the right and bottom
![Exult Old Blackline 327x207 to1280x960](https://github.com/user-attachments/assets/f68aa608-1bda-44aa-8e35-d00e3208c694)

What it now looks like
![Exult New No Blackline 327x207 to1280x960](https://github.com/user-attachments/assets/475c8e57-9f6a-4067-a751-d5ffe97ceb02)


This also fixes an unreported similar issue where when using almost any scaler a fine single pixel black line can appear on the right and bottom edge. This problem is caused by scalers reading from the guardband region. I originally added the guardband to prevent worse problems if scalers read out of bounds. I made 2 changes for to fix this fine black line. First change Before rendering the game world the image buffer sizes are altered to allow rendering into the guardband region on the right and bottom. Another change was when rendering non game world screens like game intros I added a method to duplicate edge pixels into the guardband region before performing scaling. This eliminates the problem. See screenshots below.

Screenshot Showing the fine blackline problem on the butterfly screne of the BG Intro (this scene shows it quite well along the grass to my eyes). Look for the black line inside the right and bottom edges of my purple window border Scaling here was 320x200 to 1280x960
![Exult Old Fine Blackline 320x200 to1280x960](https://github.com/user-attachments/assets/02142616-c8e0-43bd-b7c2-3b7eebb0ab7f)

Zoomed in screenshot of the bottom right corner
![Exult Old Fine Blackline 320x200 to1280x960 zoom](https://github.com/user-attachments/assets/b7478f51-2c5a-4948-8191-80eb48766096)

Fine Blackline Fixed
![Exult New No Fine Blackline 320x200 to1280x960](https://github.com/user-attachments/assets/098cbc28-9f03-4408-a782-e203078490d2)

Old version screenshots showing the problems were taken from snapshot 20250113

closes #543