### PR TITLE
Better error handling in parsing keybindings

### DIFF
--- a/keys.h
+++ b/keys.h
@@ -100,7 +100,7 @@ public:
 
 private:
 	void ParseText(char* text, int len);
-	void ParseLine(char* line);
+	void ParseLine(char* line, int lineNumber);
 	void FillParseMaps();
 };
 


### PR DESCRIPTION
The keybinding parser should have printed out line numbers on errors but didn't. Now it prints the line number and the offending line itself.
Also fixes a problem when parsing pathkeys: empty lines were no longer skipped.