### PR TITLE
A new Exult Studio Mode: Pick for edit

### DIFF
--- a/cheat.h
+++ b/cheat.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2000-2022  The Exult Team
+ *  Copyright (C) 2000-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/cheat.h
+++ b/cheat.h
@@ -49,7 +49,8 @@ public:
 		paint         = 1,    // Left-mouse dragging paints shapes.
 		paint_chunks  = 2,    // Left-dragging paints whole chunks.
 		combo_pick    = 3,    // Left-click adds item to combo.
-		select_chunks = 4     // Select whole chunks.
+		select_chunks = 4,    // Select whole chunks.
+		edit_pick     = 5     // Left-click adds item to selection.
 	};
 
 private:

--- a/exult.cc
+++ b/exult.cc
@@ -5,7 +5,7 @@
  **/
 /*
  *  Copyright (C) 1998-1999  Jeffrey S. Freedman
- *  Copyright (C) 2000-2022  The Exult Team
+ *  Copyright (C) 2000-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/exult.cc
+++ b/exult.cc
@@ -1261,12 +1261,14 @@ static void Select_for_combo(
 		cheat.append_selected(obj);
 		gwin->add_dirty(obj);
 	}
-	if (Object_out(
-				client_socket,
-				toggle ? Exult_server::combo_toggle : Exult_server::combo_pick,
-				nullptr, t.tx, t.ty, t.tz, id.get_shapenum(), id.get_framenum(),
-				0, name)
-		== -1) {
+	if (cheat.get_edit_mode() == Cheat::combo_pick
+		&& Object_out(
+				   client_socket,
+				   toggle ? Exult_server::combo_toggle
+						  : Exult_server::combo_pick,
+				   nullptr, t.tx, t.ty, t.tz, id.get_shapenum(),
+				   id.get_framenum(), 0, name)
+				   == -1) {
 		cout << "Error sending shape to ExultStudio" << endl;
 	}
 }
@@ -1770,7 +1772,9 @@ static void Handle_event(SDL_Event& event) {
 								event, false,
 								(SDL_GetModState() & SDL_KMOD_CTRL) != 0);
 						break;
-					} else if (cheat.get_edit_mode() == Cheat::combo_pick) {
+					} else if (
+							cheat.get_edit_mode() == Cheat::combo_pick
+							|| cheat.get_edit_mode() == Cheat::edit_pick) {
 						Select_for_combo(
 								event, false,
 								(SDL_GetModState() & SDL_KMOD_CTRL) != 0);
@@ -2008,7 +2012,9 @@ static void Handle_event(SDL_Event& event) {
 							event, true,
 							(SDL_GetModState() & SDL_KMOD_CTRL) != 0);
 					break;
-				} else if (cheat.get_edit_mode() == Cheat::combo_pick) {
+				} else if (
+						cheat.get_edit_mode() == Cheat::combo_pick
+						|| cheat.get_edit_mode() == Cheat::edit_pick) {
 					Select_for_combo(
 							event, true,
 							(SDL_GetModState() & SDL_KMOD_CTRL) != 0);

--- a/exult.cc
+++ b/exult.cc
@@ -1230,7 +1230,7 @@ static void Select_chunks(
 }
 
 /*
- *  Select for combo.
+ *  Select for combo and edit
  */
 static void Select_for_combo(
 		SDL_Event& event,
@@ -1261,6 +1261,7 @@ static void Select_for_combo(
 		cheat.append_selected(obj);
 		gwin->add_dirty(obj);
 	}
+	// only send the data if we are in combo mode
 	if (cheat.get_edit_mode() == Cheat::combo_pick
 		&& Object_out(
 				   client_socket,

--- a/mapedit/exult_studio.glade
+++ b/mapedit/exult_studio.glade
@@ -2495,6 +2495,17 @@
                         <signal name="activate" handler="on_paint_with_chunks1_activate" swapped="no"/>
                       </object>
                     </child>
+                     <child>
+                      <object class="GtkRadioMenuItem" id="pick_for_edit1">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Pick for edit</property>
+                        <property name="use-underline">True</property>
+                        <property name="active">True</property>
+                        <property name="group">move1</property>
+                        <signal name="activate" handler="on_pick_for_edit1_activate" swapped="no"/>
+                      </object>
+                    </child>
                     <child>
                       <object class="GtkRadioMenuItem" id="pick_for_combo1">
                         <property name="visible">True</property>

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2000-2022 The Exult Team
+Copyright (C) 2000-2025 The Exult Team
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -104,8 +104,8 @@ GameManager*   gamemanager       = nullptr;
 
 // Mode menu items:
 constexpr static const std::array mode_names{
-		"move1", "paint1", "paint_with_chunks1", "pick_for_combo1",
-		"select_chunks1"};
+		"move1",           "paint1",         "paint_with_chunks1",
+		"pick_for_combo1", "select_chunks1", "pick_for_edit1"};
 
 enum ExultFileTypes {
 	ShapeArchive = 1,
@@ -382,6 +382,14 @@ C_EXPORT void on_select_chunks1_activate(
 	ignore_unused_variable_warning(user_data);
 	if (gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menuitem))) {
 		ExultStudio::get_instance()->set_edit_mode(4);
+	}
+}
+
+C_EXPORT void on_pick_for_edit1_activate(
+		GtkMenuItem* menuitem, gpointer user_data) {
+	ignore_unused_variable_warning(user_data);
+	if (gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menuitem))) {
+		ExultStudio::get_instance()->set_edit_mode(5);
 	}
 }
 

--- a/mouse.cc
+++ b/mouse.cc
@@ -315,11 +315,10 @@ void Mouse::set_speed_cursor() {
 			cursor = med_combat_arrows[0];
 			break;    // Med. N red arrow.
 		case Cheat::combo_pick:
-			cursor = greenselect;
-			break;
 		case Cheat::select_chunks:
+		case Cheat::edit_pick:
 			cursor = greenselect;
-			break;    // Nice to have somethin else.
+			break;    // Nice to have something else.
 		}
 	} else if (Combat::is_paused()) {
 		cursor = short_combat_arrows[0];    // Short N red arrow.

--- a/server/servemsg.h
+++ b/server/servemsg.h
@@ -9,7 +9,7 @@
 #define INCL_SERVEMSG 1
 
 /*
-Copyright (C) 2000-2022 The Exult Team
+Copyright (C) 2000-2025 The Exult Team
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/server/servemsg.h
+++ b/server/servemsg.h
@@ -93,6 +93,7 @@ namespace Exult_server {
 		drag_combo         = 44,    // Begin drag of a Combo.
 		drag_npc           = 45,    // Begin drag of a NPC.
 		drag_chunk         = 46,    // Begin drag of a Chunk.
+		edit_pick          = 47,    // Selecting Shapes for editing.
 		usecode_debugging  = 128
 	};
 

--- a/server/server.cc
+++ b/server/server.cc
@@ -5,7 +5,7 @@
  **/
 
 /*
-Copyright (C) 2001-2022 The Exult Team
+Copyright (C) 2001-2025 The Exult Team
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/server/server.cc
+++ b/server/server.cc
@@ -372,7 +372,7 @@ static void Handle_client_message(
 	}
 	case Exult_server::set_edit_mode: {
 		const int md = little_endian::Read2(ptr);
-		if (md >= 0 && md <= 4) {
+		if (md >= 0 && md <= 5) {
 			cheat.set_edit_mode(static_cast<Cheat::Map_editor_mode>(md));
 		}
 		break;


### PR DESCRIPTION
Allows mass selecting objs without the need to hold down CTRL.

Basically the same as Pick for combo, except it doesn't open a new Combo