### PR TITLE
A new default folder "demo" for a demo game.

### DIFF
--- a/fnames.h
+++ b/fnames.h
@@ -2,7 +2,7 @@
  *  fnames.h - Names of data files for Exult.
  *
  *  Copyright (C) 1999  Jeffrey S. Freedman
- *  Copyright (C) 2000-2022  The Exult Team
+ *  Copyright (C) 2000-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -189,6 +189,7 @@
 #define CFG_SI_ES_NAME "islaserpiente"
 #define CFG_SS_NAME    "silverseed"
 #define CFG_SIB_NAME   "serpentbeta"
+#define CFG_DEMO_NAME  "demo"
 
 // U7 game titles in "exult.cfg":
 #define CFG_BG_TITLE    "ULTIMA VII\nTHE BLACK GATE"
@@ -200,6 +201,7 @@
 #define CFG_SI_ES_TITLE "ULTIMA VII PART 2\nLA ISLA SERPIENTE"
 #define CFG_SS_TITLE    "ULTIMA VII PART 2\nTHE SILVER SEED"
 #define CFG_SIB_TITLE   "ULTIMA VII PART 2\nSERPENT ISLE BETA"
+#define CFG_DEMO_TITLE  "EXULT\nDEMO GAME"
 
 // Exult SFX Packages:
 #define SFX_ROLAND_BG  "sqsfxbg.flx"

--- a/gamedat.cc
+++ b/gamedat.cc
@@ -1,7 +1,7 @@
 /*
  *  gamedat.cc - Create gamedat files from a savegame.
  *
- *  Copyright (C) 2000-2022  The Exult Team
+ *  Copyright (C) 2000-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -201,7 +201,10 @@ void Game_window::restore_gamedat(const char* fname    // Name of savegame file.
 	// trailing slash
 	IFileDataSource in(fname);
 	if (!in.good()) {
-		if (!Game::is_editing()) {    // Ok if map-editing.
+		if (!Game::is_editing()
+			&& Game::get_game_type()
+					   != EXULT_DEVEL_GAME) {    // Ok if map-editing or devel
+												 // game.
 			throw file_read_exception(fname);
 		}
 		std::cerr << "Warning (map-editing): Couldn't open '" << fname << "'"

--- a/gamemgr/modmgr.h
+++ b/gamemgr/modmgr.h
@@ -1,7 +1,7 @@
 /*
  *  modmgr.h - Mod manager for Exult.
  *
- *  Copyright (C) 2006-2022  The Exult Team
+ *  Copyright (C) 2006-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -246,6 +246,7 @@ protected:
 	ModManager*             si;
 	ModManager*             ss;
 	ModManager*             sib;
+	ModManager*             dev;
 	std::vector<ModManager> games;
 	void                    print_found(
 							   ModManager* game, const char* flex, const char* title,
@@ -286,6 +287,10 @@ public:
 		return sib != nullptr;
 	}
 
+	bool is_devel_installed() const {
+		return dev != nullptr;
+	}
+
 	ModManager* find_game(const std::string& name);
 
 	ModManager* get_bg() {
@@ -306,6 +311,10 @@ public:
 
 	ModManager* get_sib() {
 		return sib;
+	}
+
+	ModManager* get_devel() {
+		return dev;
 	}
 
 	int  find_game_index(const std::string& name);

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -1512,6 +1512,10 @@ void ExultStudio::set_game_path(const string& gamename, const string& modname) {
 		if (!(basegame = gamemanager->get_ss())) {
 			cerr << "Silver Seed not found." << endl;
 		}
+	} else if (gamename == CFG_DEMO_NAME) {
+		if (!(basegame = gamemanager->get_devel())) {
+			cerr << "Demo Game not found." << endl;
+		}
 	} else {
 		if ((curr_game = gamemanager->find_game_index(gamename)) < 0) {
 			cerr << "Game '" << gamename << "' not found." << endl;


### PR DESCRIPTION
Devel games will now always load even if there is no initgame.dat (yet). There are more cases that Exult will throw an exception if a file is missing and a devel game is not set to editing but this one is most important. If a static identity is not one of the U7 games it is now assumed that a game is of the type EXULT_DEVEL_GAME otherwise Exult would become very unstable. In #557 is a zipped up demo game.

This is a draft pull request as it really needs to be reviewed.