### PR TITLE
Fix SVG attributes for raw display

### DIFF
--- a/desktop/info.exult.exult.studio.svg
+++ b/desktop/info.exult.exult.studio.svg
@@ -1,4 +1,5 @@
-<svg xml:space="preserve" id="svg312" width="512" height="512" version="1.1" viewBox="0 0 200 200">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg id="svg312" width="512" height="512" version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
   <defs id="defs64">
     <radialGradient id="e-9" cx="173.11" cy="50.61" r="12.412" gradientTransform="matrix(.78555 .44895 -.55264 .96698 -.90525 -43.544)" gradientUnits="userSpaceOnUse">
       <stop id="stop37" offset="0" stop-color="#8e8e8e"/>

--- a/desktop/info.exult.exult.svg
+++ b/desktop/info.exult.exult.svg
@@ -1,4 +1,5 @@
-<svg xml:space="preserve" id="svg103" width="512" height="512" version="1.1" viewBox="0 0 200 200">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg id="svg103" width="512" height="512" version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
   <defs id="defs64">
     <radialGradient id="e" cx="173.11" cy="50.610001" r="12.412" gradientTransform="matrix(.78555 .44895 -.55264 .96698 -.90525 -43.544)" gradientUnits="userSpaceOnUse">
       <stop id="stop8" offset="0" stop-color="#8e8e8e"/>


### PR DESCRIPTION
For some reason, the presence of the `xml:space="preserve"` attribute on the main `svg` tag in these two images broke rendering of the files in a browser: https://raw.githubusercontent.com/exult/exult/3ecbcdcc181a9edca13d3201875c04dfc7c9163f/desktop/info.exult.exult.studio.svg

This fixes it: https://raw.githubusercontent.com/fpiesche/exult/622d4d30f7eb853f83cee03dc45943dfe0c5a2d1/desktop/info.exult.exult.studio.svg

I've also added the xmlns attributes for good measure. I don't think they're malformed without them but the consistency is nice to have.