### PR TITLE
Combat tracks fixes

### DIFF
--- a/audio/Audio.cc
+++ b/audio/Audio.cc
@@ -539,55 +539,6 @@ bool Audio::start_music(
 	return false;
 }
 
-void Audio::start_music_combat(Combat_song song, bool continuous) {
-#ifdef DEBUG
-	cout << formatTicks() << "Audio subsystem request: Combat Music start "
-		 << int(song) << endl;
-#endif
-	if (!audio_enabled || !music_enabled || !mixer || !mixer->getMidiPlayer()) {
-		return;
-	}
-
-	int num = -1;
-
-	switch (song) {
-	case CSBattle_Over:
-		num = Audio::game_music(9);
-		break;
-
-	case CSAttacked1:
-		num = Audio::game_music(11);
-		break;
-
-	case CSAttacked2:
-		num = Audio::game_music(12);
-		break;
-
-	case CSVictory:
-		num = Audio::game_music(15);
-		break;
-
-	case CSRun_Away:
-		num = Audio::game_music(16);
-		break;
-
-	case CSDanger:
-		num = Audio::game_music(10);
-		break;
-
-	case CSHidden_Danger:
-		num = Audio::game_music(18);
-		break;
-
-	default:
-		CERR("Error: Unable to Find combat track for song " << song << ".");
-		break;
-	}
-
-	mixer->getMidiPlayer()->start_music(
-			num, continuous && music_looping != LoopingType::Never);
-}
-
 void Audio::stop_music() {
 #ifdef DEBUG
 	cout << formatTicks() << "Audio subsystem request: Music stop" << endl;

--- a/audio/Audio.h
+++ b/audio/Audio.h
@@ -55,19 +55,6 @@ class Tile_coord;
 #define MAX_SOUND_FALLOFF 24
 
 /*
- *	Music:
- */
-enum Combat_song {
-	CSBattle_Over,
-	CSAttacked1,
-	CSAttacked2,
-	CSVictory,
-	CSRun_Away,
-	CSDanger,
-	CSHidden_Danger
-};
-
-/*
  *	This is a resource-management class for SFX. Maybe make it a
  *	template class and use for other resources also?
  *	Based on code by Sam Lantinga et al on:
@@ -167,7 +154,6 @@ public:
 	bool start_music(
 			const std::string& fname, int num, bool continuous = false,
 			MyMidiPlayer::ForceType force = MyMidiPlayer::Force_None);
-	void start_music_combat(Combat_song song, bool continuous);
 	void stop_music();
 	int  play_sound_effect(
 			 int num, int volume = AUDIO_MAX_VOLUME, int balance = 0,

--- a/combat.h
+++ b/combat.h
@@ -115,6 +115,7 @@ public:
 	void        now_what() override;    // Npc calls this when it's done
 	void im_dormant() override;         // Npc calls this when it goes dormant.
 	static void start_music_combat(Combat_song song, bool continuous);
+	static void danger_music();
 	void ending(int newtype) override;    // Switching to another schedule.
 	void set_weapon(bool removed = false) override;    // Set weapon info.
 	void set_hand_to_hand();

--- a/combat.h
+++ b/combat.h
@@ -30,6 +30,20 @@ class Game_object;
 class Spellbook_object;
 
 /*
+ *	Combat Music:
+ */
+enum Combat_song {
+	CSBattle_Over,
+	CSAttacked1,
+	CSAttacked2,
+	CSVictory,
+	CSRun_Away,
+	CSDanger,
+	CSHidden_Danger,
+	CSAvatar_died
+};
+
+/*
  *  Combat schedule:
  */
 class Combat_schedule : public Schedule {
@@ -100,6 +114,7 @@ public:
 	static void stop_attacking_invisible(Game_object* npc);
 	void        now_what() override;    // Npc calls this when it's done
 	void im_dormant() override;         // Npc calls this when it goes dormant.
+	static void start_music_combat(Combat_song song, bool continuous);
 	void ending(int newtype) override;    // Switching to another schedule.
 	void set_weapon(bool removed = false) override;    // Set weapon info.
 	void set_hand_to_hand();

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -3186,9 +3186,7 @@ bool Game_window::is_hostile_nearby() const {
 	 * get_nearby_npcs, but on the other hand, its a negligible point.
 	 */
 	Actor_vector nearby;
-	if (!cheat.in_god_mode()) {
-		get_nearby_npcs(nearby);
-	}
+	get_nearby_npcs(nearby);
 
 	bool nearby_hostile = false;
 	for (auto& actor : nearby) {

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -1404,7 +1404,13 @@ void Game_window::read() {
 	setup_load_palette();
 
 	clear_world(true);    // Wipe clean.
-	read_gwin();          // Read our data.
+
+	// Re-add background noise to queue after clear_world() removed it
+	if (background_noise) {
+		tqueue->add(Game::get_ticks() + 5000, background_noise);
+	}
+
+	read_gwin();    // Read our data.
 	// DON'T do anything that might paint()
 	// before calling read_npcs!!
 	setup_game(cheat.in_map_editor());    // Read NPC's, usecode.

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -164,7 +164,15 @@ void Background_noise::handle_event(unsigned long curtime, uintptr udata) {
 	const int     weather        = gwin->get_effects()->get_weather();
 	const bool    nighttime      = bghour < 6 || bghour > 20;
 	const bool    nearby_hostile = gwin->is_hostile_nearby();
-	if (nearby_hostile && !gwin->in_combat()) {
+	MyMidiPlayer* player         = Audio::get_ptr()->get_midi();
+	if (laststate == DangerNear && !nearby_hostile) {
+		// Immediately play hidden danger music when hostiles disappear
+		if (player) {
+			Audio::get_ptr()->start_music(Audio::game_music(18), true);
+		}
+		laststate    = Outside;    // Reset state
+		currentstate = Outside;    // Set to normal state
+	} else if (nearby_hostile && !gwin->in_combat()) {
 		currentstate = DangerNear;
 	} else if (gwin->is_in_dungeon()) {
 		currentstate = Dungeon;
@@ -178,7 +186,6 @@ void Background_noise::handle_event(unsigned long curtime, uintptr udata) {
 		currentstate = Outside;
 	}
 
-	MyMidiPlayer* player = Audio::get_ptr()->get_midi();
 	// The background sfx tracks only play for Digital Music, MT32emu,
 	// MT32/FakeMT32 FMOpl is not sounding acceptable even though the original
 	// used it.

--- a/keyactions.cc
+++ b/keyactions.cc
@@ -555,7 +555,7 @@ int get_walking_speed(const int* params) {
 	int          speed;
 	if (parm == 2) {
 		speed = Mouse::slow_speed_factor;
-	} else if (gwin->in_combat() || gwin->is_hostile_nearby()) {
+	} else if (gwin->in_combat() || (gwin->is_hostile_nearby()  && !cheat.in_god_mode())) {
 		speed = Mouse::medium_combat_speed_factor;
 	} else {
 		speed = parm == 1 ? Mouse::medium_speed_factor

--- a/mouse.cc
+++ b/mouse.cc
@@ -400,7 +400,7 @@ void Mouse::set_speed_cursor() {
 							  -static_cast<float>(dy) / half_size));
 		}
 
-		const bool      nearby_hostile        = gwin->is_hostile_nearby();
+		const bool      nearby_hostile        = gwin->is_hostile_nearby() && !cheat.in_god_mode();
 		bool            has_active_nohalt_scr = false;
 		Usecode_script* scr                   = nullptr;
 		Actor*          act                   = gwin->get_main_actor();


### PR DESCRIPTION
Move start_music_combat from Audio code to combat code (fixes #734).
When monsters attack while danger music is playing transition to track 11 (fixes #725).
Running away from monsters plays track 18 (partially fix for #723.
is_hostile_nearby() will work even if the player is in god mode, which allows danger music to play in god mode.
Moved danger music into combat.cc but it's still being polled in gamewin's Background_noise::handle_event(). This gives finer control over the danger tracks, for example only playing it once.