### PR TITLE
Fix for #728 - in game shape browser not handling patched vga files

### DIFF
--- a/cheat_screen.cc
+++ b/cheat_screen.cc
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2000-2022  The Exult Team
+ *  Copyright (C) 2000-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -165,8 +165,8 @@ void CheatScreen::show_screen() {
 	const str_int_pair& pal_tuple_patch
 			= game->get_resource("palettes/patch/0");
 	pal.load(pal_tuple_static.str, pal_tuple_patch.str, pal_tuple_static.num);
-	
-	// init fontcolor transform table, default does nothing 
+
+	// init fontcolor transform table, default does nothing
 	for (size_t i = 0; i < std::size(fontcolor.colors); i++) {
 		fontcolor.colors[i] = i;
 	}
@@ -210,7 +210,6 @@ void CheatScreen::show_screen() {
 
 	pal.apply();
 
-
 	const int remaps[] = {
 			5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5 - 1,
 	};
@@ -222,7 +221,7 @@ void CheatScreen::show_screen() {
 	};
 
 	pal.Generate_remap_xformtable(hovertable.colors, hoverremaps);
-	
+
 	// Make sure the font colour is properly remapped
 	if (fontcolor[0]) {
 		highlighttable.colors[fontcolor[0]] = highlighttable.colors[8];
@@ -2025,6 +2024,7 @@ void CheatScreen::NPCActivate(Actor* actor, int& num) {
 		case SDLK_C:                        // Change shape
 			if (state.input[0] == 'b') {    // Browser
 				int n;
+				clear_buttons();    // Clear all button states before browser
 				if (!cheat.get_browser_shape(i, n)) {
 					state.SetMode(CP_WrongShapeFile);
 					break;
@@ -2666,6 +2666,7 @@ void CheatScreen::FlagActivate(Actor* actor) {
 
 		if (state.input[0] == 'b') {    // Browser
 			int n;
+			clear_buttons();    // Clear all button states before browser
 			if (!cheat.get_browser_shape(i, n)) {
 				state.SetMode(CP_WrongShapeFile);
 				break;

--- a/cheat_screen.h
+++ b/cheat_screen.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2000-2022  The Exult Team
+ *  Copyright (C) 2000-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -66,6 +66,10 @@ public:
 		if (g == grabbed) {
 			g = nullptr;
 		}
+	}
+
+	void clear_buttons() {
+		buttons_down.clear();
 	}
 
 private:


### PR DESCRIPTION
In game shape browser can show shapes of patched vga files (fixes #728).

Cheat screen will not wait for the release of the key B after you used the shape browser to change shape or to polymorph.