### PR TITLE
Mods override skip_splash and force_digital_music

### DIFF
--- a/exult.cc
+++ b/exult.cc
@@ -1051,12 +1051,27 @@ static void Init() {
 		bool skip_splash;
 		config->value("config/gameplay/skip_splash", skip_splash);
 
+		// Check for mod overriding skip_splash
+		bool force_skip_splash = false;
+		if (gamemanager) {
+			ModManager* current_game_mgr
+					= gamemanager->find_game(Game::get_gametitle());
+			if (current_game_mgr && !Game::get_modtitle().empty()) {
+				BaseGameInfo* current_mod = current_game_mgr->get_mod(
+						Game::get_modtitle(), false);
+				ModInfo* mod_info = dynamic_cast<ModInfo*>(current_mod);
+				if (mod_info && mod_info->has_force_skip_splash_set()) {
+					force_skip_splash = mod_info->get_force_skip_splash();
+				}
+			}
+		}
+
 		// Make sure we have a proper palette before playing the intro.
 		gwin->get_pal()->load(
 				BUNDLE_CHECK(BUNDLE_EXULT_FLX, EXULT_FLX),
 				EXULT_FLX_EXULT0_PAL);
 		gwin->get_pal()->apply();
-		if (!skip_splash
+		if ((!skip_splash && !force_skip_splash)
 			&& (Game::get_game_type() != EXULT_DEVEL_GAME
 				|| U7exists(INTRO_DAT))) {
 			if (midi) {

--- a/game.cc
+++ b/game.cc
@@ -421,6 +421,20 @@ bool Game::show_menu(bool skip) {
 
 	top_menu();
 	MenuList* menu = nullptr;
+	// Check for mod override
+	bool force_skip_splash = false;
+	if (gamemanager) {
+		ModManager* current_game_mgr
+				= gamemanager->find_game(Game::get_gametitle());
+		if (current_game_mgr && !Game::get_modtitle().empty()) {
+			BaseGameInfo* current_mod
+					= current_game_mgr->get_mod(Game::get_modtitle(), false);
+			ModInfo* mod_info = dynamic_cast<ModInfo*>(current_mod);
+			if (mod_info && mod_info->has_force_skip_splash_set()) {
+				force_skip_splash = mod_info->get_force_skip_splash();
+			}
+		}
+	}
 
 	constexpr static const std::array menuchoices{0x04, 0x05, 0x08, 0x06,
 												  0x11, 0x12, 0x07};
@@ -437,6 +451,11 @@ bool Game::show_menu(bool skip) {
 			menu       = new MenuList();
 			int offset = 0;
 			for (size_t i = 0; i < menuchoices.size(); i++) {
+				// Skip the introduction option if a mod force_skip_splash
+				if (i == 0 && force_skip_splash) {
+					continue;
+				}
+
 				if ((i != 4 && i != 5)
 					|| (i == 4 && U7exists("<SAVEGAME>/quotes.flg"))
 					|| (i == 5 && U7exists("<SAVEGAME>/endgame.flg"))) {

--- a/gamemgr/modmgr.cc
+++ b/gamemgr/modmgr.cc
@@ -215,6 +215,29 @@ ModInfo::ModInfo(
 			"<" + system_path_tag + "_SAVEGAME>", get_system_path(savedir));
 	U7mkdir(savedir.c_str(), 0755);
 
+	config_path = "mod_info/skip_splash";
+	string skip_splash_str;
+	has_force_skip_splash = modconfig.key_exists(config_path);
+	if (has_force_skip_splash) {
+		modconfig.value(config_path, skip_splash_str);
+		force_skip_splash
+				= (skip_splash_str == "yes" || skip_splash_str == "true");
+	} else {
+		force_skip_splash = false;
+	}
+
+	config_path = "mod_info/force_digital_music";
+	string force_digital_music_str;
+	has_force_digital_music = modconfig.key_exists(config_path);
+	if (has_force_digital_music) {
+		modconfig.value(config_path, force_digital_music_str);
+		force_digital_music
+				= (force_digital_music_str == "yes"
+				   || force_digital_music_str == "true");
+	} else {
+		force_digital_music = false;
+	}
+
 #ifdef DEBUG_PATHS
 	cout << "path prefix of " << cfgname << " mod " << mod_title
 		 << " is: " << system_path_tag << endl;
@@ -226,6 +249,9 @@ ModInfo::ModInfo(
 		 << " patch directory to: " << get_system_path(patchdir) << endl;
 	cout << "setting " << cfgname
 		 << " source directory to: " << get_system_path(sourcedir) << endl;
+	cout << "setting " << cfgname
+		 << " Force Skip Splash to: " << (force_skip_splash ? "yes" : "no")
+		 << endl;
 #endif
 }
 

--- a/gamemgr/modmgr.h
+++ b/gamemgr/modmgr.h
@@ -158,6 +158,10 @@ class ModInfo : public BaseGameInfo {
 protected:
 	std::string configfile;
 	bool        compatible;
+	bool        force_skip_splash;
+	bool        has_force_skip_splash;
+	bool        force_digital_music;
+	bool        has_force_digital_music;
 
 public:
 	ModInfo(Exult_Game game, Game_Language lang, const std::string& name,
@@ -172,6 +176,22 @@ public:
 		cfg  = new Configuration(configfile, "modinfo");
 		root = "mod_info/";
 		return true;
+	}
+
+	bool get_force_skip_splash() const {
+		return force_skip_splash;
+	}
+
+	bool has_force_skip_splash_set() const {
+		return has_force_skip_splash;
+	}
+
+	bool get_force_digital_music() const {
+		return force_digital_music;
+	}
+
+	bool has_force_digital_music_set() const {
+		return has_force_digital_music;
 	}
 };
 


### PR DESCRIPTION
mods can override the skip_splash setting (mod_info/skip_splash) to disable the intro in case the mod is a total conversion that has nothing to do with the original game anymore.

There is also the option to force digital music (mod_info/force_digital_music) which is not doing anything yet.