### PR TITLE
Integrated installers

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -43,7 +43,7 @@ jobs:
             echo HAVE_ANDROID_SNAPSHOT=false >> $GITHUB_ENV
             echo Couldn\'t find exult-snapshot-signed.apk for Android snapshot. No release will be made
           fi
-          echo "GITHUB_REF=v1.13.0.$(date --utc +'%Y%m%d')" >> $GITHUB_ENV
+          echo "GITHUB_REF=v1.13.1.$(date --utc +'%Y%m%d')" >> $GITHUB_ENV
       - name: Install SSH key
         if: ${{ (env.HAVE_WINDOWS_SNAPSHOT == 'true' && env.HAVE_ANDROID_SNAPSHOT == 'true')}}
         uses: shimataro/ssh-key-action@v2

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,4 +1,4 @@
-VERSION:=1.13.0git
+VERSION:=1.13.1git
 
 MAIN_OBJS:=actions.o \
 	actorio.o \

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([Exult],[1.13.0git],[],[exult],[https://exult.info/])
+AC_INIT([Exult],[1.13.1git],[],[exult],[https://exult.info/])
 AC_CONFIG_SRCDIR([exult.cc])
 
 # ---------------------------------------------------------------------

--- a/files/crc.cc
+++ b/files/crc.cc
@@ -121,11 +121,13 @@ static inline uint32 crc32_internal(IDataSource&& in) {
 // 	return crc32_internal(IBufferDataView(s, len));
 // }
 
-uint32 crc32(const char* filename) {
+uint32 crc32(const char* filename, bool quiet) {
 	IFileDataSource crcfile(filename);
 	if (!crcfile.good()) {
-		std::cerr << "Could not open file '" << get_system_path(filename)
+		if (!quiet) {
+			std::cerr << "Could not open file '" << get_system_path(filename)
 				  << std::endl;
+		}
 		return 0;
 	}
 

--- a/files/crc.h
+++ b/files/crc.h
@@ -3,6 +3,6 @@
 
 #include "common_types.h"
 
-uint32 crc32(const char* filename);
+uint32 crc32(const char* filename, bool quiet=false);
 
 #endif

--- a/files/zip/unzip.cc
+++ b/files/zip/unzip.cc
@@ -1283,7 +1283,6 @@ int ZEXPORT unzExtractAllToPath(unzFile unzipfile, const char* destpath) {
 	outpath.reserve(max_filename);
 	if (error == UNZ_OK) {
 		do {
-
 			error = unzGetCurrentFileInfo(
 					unzipfile, &fileinfo, filepath,
 					nullptr, 0, nullptr, 0);
@@ -1360,7 +1359,6 @@ int ZEXPORT unzExtractAllToPath(unzFile unzipfile, const char* destpath) {
 					return UNZ_UNKNOWNFILEERROR;
 				}
 			}
-
 		} while ((error = unzGoToNextFile(unzipfile)) == UNZ_OK);
 		if (error == UNZ_END_OF_LIST_OF_FILE) {
 			error = UNZ_OK;

--- a/gamedat.cc
+++ b/gamedat.cc
@@ -721,8 +721,8 @@ bool Game_window::get_saveinfo_zip(
 		return false;
 	}
 
-	const std::string filestr   = get_system_path(fname);
-	unzFile           unzipfile = unzOpen(filestr.c_str());
+	IFileDataSource ds(fname);
+	unzFile         unzipfile = unzOpen(&ds);
 	if (!unzipfile) {
 		return false;
 	}
@@ -861,8 +861,8 @@ bool Game_window::restore_gamedat_zip(
 	}
 	// Display red plasma during load...
 	setup_load_palette();
-	const std::string filestr   = get_system_path(fname);
-	unzFile           unzipfile = unzOpen(filestr.c_str());
+	IFileDataSource ds(fname);
+	unzFile         unzipfile = unzOpen(&ds);
 	if (!unzipfile) {
 		return false;
 	}

--- a/gamemgr/modmgr.cc
+++ b/gamemgr/modmgr.cc
@@ -451,7 +451,7 @@ ModManager::ModManager(
 	}
 
 	const string mainshp     = static_dir + "/mainshp.flx";
-	const uint32 crc         = crc32(mainshp.c_str());
+	const uint32 crc         = crc32(mainshp.c_str(), true);
 	auto         unknown_crc = [crc](const char* game) {
         cerr << "Warning: Unknown CRC for mainshp.flx: 0x" << std::hex << crc
              << std::dec << std::endl;
@@ -641,7 +641,7 @@ void ModManager::gather_mods() {
 		return;
 	}
 
-	U7ListFiles(pathname + "/*.cfg", filenames);
+	U7ListFiles(pathname + "/*.cfg", filenames, true);
 	const int num_mods = filenames.size();
 
 	if (num_mods > 0) {

--- a/gamemgr/modmgr.cc
+++ b/gamemgr/modmgr.cc
@@ -315,7 +315,6 @@ string get_game_identity(
 		return title.c_str();
 #endif
 	else {
-
 		ds->seek(0x54);    // Get to where file count sits.
 		const size_t numfiles = ds->read4();
 		ds->seek(0x80);    // Get to file info.
@@ -714,7 +713,6 @@ int ModManager::InstallModZip(
 		if (filepath.size() > 1 && filepath[filepath.size() - 1] == '/') {
 			dirs.insert(filepath.substr(0, filepath.size() - 1));
 		}
-
 	} while (unzGoToNextFile(unzipfile) == UNZ_OK);
 
 	if (cfgs.empty()) {
@@ -1079,7 +1077,6 @@ int ModManager::InstallModZip(
 						return -17;
 					}
 				}
-
 			} while ((error = unzGoToNextFile(unzipfile)) == UNZ_OK);
 			if (error != UNZ_END_OF_LIST_OF_FILE) {
 				std::cerr << "InstallMod: error extracting files "

--- a/gamemgr/modmgr.cc
+++ b/gamemgr/modmgr.cc
@@ -422,11 +422,9 @@ ModManager::ModManager(
 	}
 	const string initgam_path(static_dir + "/initgame.dat");
 	found = U7exists(initgam_path);
-
-	string static_identity;
-	string id = get_game_identity(initgam_path.c_str(), cfgname);
+	
+	std::string id = static_identity = get_game_identity(initgam_path.c_str(), cfgname);
 	if (found) {
-		static_identity = get_game_identity(initgam_path.c_str(), cfgname);
 		if (static_identity != "ULTIMA7" && static_identity != "FORGE"
 			&& static_identity != "SERPENT ISLE"
 			&& static_identity != "SILVER SEED") {

--- a/gamemgr/modmgr.h
+++ b/gamemgr/modmgr.h
@@ -30,6 +30,7 @@
 #include <vector>
 
 extern Configuration* config;
+class GameManager;
 
 class BaseGameInfo {
 protected:
@@ -174,6 +175,8 @@ public:
 		return compatible;
 	}
 
+	static bool is_mod_compatible(const std::string& modversion);
+
 	bool get_config_file(Configuration*& cfg, std::string& root) override {
 		cfg  = new Configuration(configfile, "modinfo");
 		root = "mod_info/";
@@ -267,6 +270,11 @@ public:
 		root = "config/disk/game/" + cfgname + "/";
 		return false;
 	}
+
+	static int InstallModZip(
+			std::string& zipfilename, ModManager* game_override,
+			GameManager* gamemanager);
+
 	const std::string& getIdentity() {
 		return static_identity;
 	}

--- a/gamemgr/modmgr.h
+++ b/gamemgr/modmgr.h
@@ -208,6 +208,7 @@ public:
 class ModManager : public BaseGameInfo {
 protected:
 	std::vector<ModInfo> modlist;
+	std::string          static_identity;
 
 public:
 	ModManager(
@@ -265,6 +266,9 @@ public:
 		cfg  = config;
 		root = "config/disk/game/" + cfgname + "/";
 		return false;
+	}
+	const std::string& getIdentity() {
+		return static_identity;
 	}
 };
 

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.13.0</string>
+	<string>1.13.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ios/include/config.h
+++ b/ios/include/config.h
@@ -10,13 +10,13 @@
 #define PACKAGE_TARNAME "exult"
 
 /* Package Version */
-#define VERSION "1.13.0git"
+#define VERSION "1.13.1git"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.13.0git"
+#define PACKAGE_VERSION "1.13.1git"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "Exult 1.13.0git"
+#define PACKAGE_STRING "Exult 1.13.1git"
 
 /* Define to the home page for this package. */
 #define PACKAGE_URL "https://exult.info/"

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -1301,8 +1301,14 @@ C_EXPORT void on_gameselect_ok_clicked(
 		// Create mod cfg file:
 		const string  cfgfile = pathname + ".cfg";
 		Configuration modcfg(cfgfile, "modinfo");
-		modcfg.set("mod_info/display_string", modmenustr, true);
-		modcfg.set("mod_info/required_version", VERSION, true);
+		modcfg.set("mod_info/display_string", modmenustr, false);
+		modcfg.set("mod_info/required_version", VERSION, false);		
+		modcfg.set("mod_info/game_identity", game->getIdentity(), false);
+		modcfg.set("mod_info/patch", "__MOD_PATH__/patch", false);
+		modcfg.set("mod_info/source", "__MOD_PATH__/patch", false);
+		modcfg.set("mod_info/skip_splash", "no", false);
+		modcfg.set("mod_info/clean_menu", "no", false);
+		modcfg.set("mod_info/force_digital_music", "no", true);
 
 		// Add mod to base game's list:
 		game->add_mod(modtitle, cfgfile);

--- a/msvcstuff/vs2019/msvc_include.h
+++ b/msvcstuff/vs2019/msvc_include.h
@@ -1,7 +1,7 @@
 #pragma once
 #define NOMINMAX
 
-#define VERSION       "1.13.0git"
+#define VERSION       "1.13.1git"
 #define EXULT_DATADIR "data/"
 
 #ifdef _DEBUG

--- a/tools/aseprite_plugin/package.json
+++ b/tools/aseprite_plugin/package.json
@@ -2,7 +2,7 @@
   "name": "exult-shp",
   "displayName": "Ultima VII SHP Format",
   "description": "Import and export Ultima VII SHP files",
-  "version": "1.13.0git",
+  "version": "1.13.1git",
   "author": {
     "name": "The Exult Team"
   },

--- a/win32/crash.cc
+++ b/win32/crash.cc
@@ -347,7 +347,7 @@ void WindowsInstallCrashHandler() {
 						true);
 			}
 		}
-		std::cerr << "Installing Windows crash Handler with " << value
+		std::cout << "Installing Windows crash Handler with " << value
 				  << " minidumps" << std::endl;
 		// Adds an Unhandled Exception Handler. This will replace the one
 		// installed by the runtime. This will catch all Win32 Exceptions that
@@ -366,7 +366,7 @@ void WindowsInstallCrashHandler() {
 		std::set_terminate(terminatehandler);
 
 	} else {
-		std::cerr << "Debugger Attached, Not Installing Windows crash Handler"
+		std::cout << "Debugger Attached, Not Installing Windows crash Handler"
 				  << std::endl;
 	}
 	// DoCrash();

--- a/win32/exconfig.rc
+++ b/win32/exconfig.rc
@@ -6,7 +6,7 @@
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENA)
 #ifdef _WIN32
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_AUS
-#pragma code_page(1252)
+#pragma code_page(65001) // UTF-8
 #endif //_WIN32
 
 
@@ -38,7 +38,7 @@ BEGIN
             VALUE "FileDescription", "Exult Config Helper DLL for InnoSetup\0"
             VALUE "FileVersion", "1.13.1git\0"
             VALUE "InternalName", "exconfig\0"
-            VALUE "LegalCopyright", "Copyright � 2024\0"
+            VALUE "LegalCopyright", "Copyright © 2025\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "exconfig.dll\0"
             VALUE "PrivateBuild", "\0"

--- a/win32/exconfig.rc
+++ b/win32/exconfig.rc
@@ -17,8 +17,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_AUS
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,13,0,0
- PRODUCTVERSION 1,13,0,0
+ FILEVERSION 1,13,1,0
+ PRODUCTVERSION 1,13,1,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -36,14 +36,14 @@ BEGIN
             VALUE "Comments", "\0"
             VALUE "CompanyName", "\0"
             VALUE "FileDescription", "Exult Config Helper DLL for InnoSetup\0"
-            VALUE "FileVersion", "1.13.0git\0"
+            VALUE "FileVersion", "1.13.1git\0"
             VALUE "InternalName", "exconfig\0"
-            VALUE "LegalCopyright", "Copyright © 2024\0"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2024\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "exconfig.dll\0"
             VALUE "PrivateBuild", "\0"
             VALUE "ProductName", "Exult\0"
-            VALUE "ProductVersion", "1.13.0git\0"
+            VALUE "ProductVersion", "1.13.1git\0"
             VALUE "SpecialBuild", "\0"
         END
     END

--- a/win32/exult_installer.iss
+++ b/win32/exult_installer.iss
@@ -1,12 +1,12 @@
 [Setup]
 AppName=Exult
-AppVerName=Exult 1.13.0git Snapshot
+AppVerName=Exult 1.13.1git Snapshot
 AppPublisher=The Exult Team
 AppPublisherURL=https://exult.info/
 AppSupportURL=https://exult.info/
 AppUpdatesURL=https://exult.info/
 ; Setup exe version number:
-VersionInfoVersion=1.13.0
+VersionInfoVersion=1.13.1
 DisableDirPage=no
 DefaultDirName={code:GetExultInstDir|{autopf}\Exult}
 DisableProgramGroupPage=no

--- a/win32/exult_shpplugin_installer.iss
+++ b/win32/exult_shpplugin_installer.iss
@@ -29,7 +29,7 @@ AppPublisherURL=https://exult.info/
 AppSupportURL=https://exult.info/
 AppUpdatesURL=https://exult.info/
 ; Setup exe version number:
-VersionInfoVersion=1.13.0
+VersionInfoVersion=1.13.1
 DisableDirPage=yes
 DefaultDirName="{userappdata}\gimp\3.0\plug-ins\u7shp"
 DisableProgramGroupPage=yes

--- a/win32/exult_studio_installer.iss
+++ b/win32/exult_studio_installer.iss
@@ -6,7 +6,7 @@ AppPublisherURL=https://exult.info/
 AppSupportURL=https://exult.info/
 AppUpdatesURL=https://exult.info/
 ; Setup exe version number:
-VersionInfoVersion=1.13.0
+VersionInfoVersion=1.13.1
 DisableDirPage=no
 DefaultDirName={autopf}\Exult
 DisableProgramGroupPage=no

--- a/win32/exult_tools_installer.iss
+++ b/win32/exult_tools_installer.iss
@@ -6,7 +6,7 @@ AppPublisherURL=https://exult.info/
 AppSupportURL=https://exult.info/
 AppUpdatesURL=https://exult.info/
 ; Setup exe version number:
-VersionInfoVersion=1.13.0
+VersionInfoVersion=1.13.1
 DisableDirPage=no
 DefaultDirName={autopf}\Exult\Tools
 DisableProgramGroupPage=yes

--- a/win32/exultico.rc
+++ b/win32/exultico.rc
@@ -38,8 +38,8 @@ IDI_ICON1               ICON    DISCARDABLE     "exult.ico"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,13,0,0
- PRODUCTVERSION 1,13,0,0
+ FILEVERSION 1,13,1,0
+ PRODUCTVERSION 1,13,1,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -56,12 +56,12 @@ BEGIN
         BEGIN
             //VALUE "CompanyName", "The Exult Team\0"
             VALUE "FileDescription", "Exult Ultima VII Engine\0"
-            VALUE "FileVersion", "1.13.0git\0"
+            VALUE "FileVersion", "1.13.1git\0"
             VALUE "InternalName", "Exult\0"
             VALUE "LegalCopyright", "Copyright © 1998-2025\0"
             VALUE "OriginalFilename", "Exult.exe\0"
             VALUE "ProductName", "Exult Ultima VII Engine\0"
-            VALUE "ProductVersion", "1.13.0git\0"
+            VALUE "ProductVersion", "1.13.1git\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/win32/exultstudioico.rc
+++ b/win32/exultstudioico.rc
@@ -38,8 +38,8 @@ IDI_ICON1               ICON    DISCARDABLE     "exultstudio.ico"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,13,0,0
- PRODUCTVERSION 1,13,0,0
+ FILEVERSION 1,13,1,0
+ PRODUCTVERSION 1,13,1,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -56,12 +56,12 @@ BEGIN
         BEGIN
             //VALUE "CompanyName", "The Exult Team\0"
             VALUE "FileDescription", "Exult Studio\0"
-            VALUE "FileVersion", "1.13.0git\0"
+            VALUE "FileVersion", "1.13.1git\0"
             VALUE "InternalName", "Exult Studio\0"
             VALUE "LegalCopyright", "Copyright © 1998-2025\0"
             VALUE "OriginalFilename", "exult_studio.exe\0"
             VALUE "ProductName", "Exult Studio\0"
-            VALUE "ProductVersion", "1.13.0git\0"
+            VALUE "ProductVersion", "1.13.1git\0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
This PR is to add integrated mod and data installers into Exult itself.

This primary drive was to remove the need to use Windows shell code in our Windows Installer to unzip the mods and data that would not work in wine.
closes #746 

2 new command line options are added `--installdata <zipfile>` and `--installmod <zipfile>`

`--insatalldata` is quite simple, all it does is extract the zip file argument into `<data>`

`--installmod` does quit a bit more, it looks in the root of the zip for modcfg files.  For each modcfg found, it checks Required_version and prints a warning if the mod is incompatible, but it will still install the mod as Exult itself Shouldn't show incompatible mods in the menu. It will then attempt to figure out what game to install the mod to by getting the identity from the mods initgame file if it has one. For mods that do not change the map and so do not have an initgame, it will attempt to get the identity from a new modcfg field game_identity.  After identifying the game, installmod will delete any existing mod patch files if there were any and then extract the mods data from this zip. When extracting the files, the process will rename the mod patch files so they match the case of the files in `<static>`. --installmod can be combined with `--bg` `--fov` `--si` `--ss` or `--game` to force choose what game to install a mod to overriding auto detection using identity. It will print a warning if the user tries to force installation of a mod into an incompatible game but will allow it. Force choosing the game is required if the mod does not have an initgame and does not have game_identity set (this would be needed for graphics only mods that can be used with any game). The install mod code can install multiple mods from a single zip file provided they are all in the root of the zip with a unique name and are well formed. If there are multiple mods they can all be for different games, so a single zip could contain multiple different versions of the same mod for different games, or be a mod pack of completely unrelated mods

These changes bumps the version to 1.31.1 Partly because of the recent changes by @DominusExult  to modcfg as well as to give me the ability to use the exult version number in the windows installer to detect if installmod and installdata are support

In order to make game_identity  in modcfg somewhat useful, I altered Exult studio so when creating  a new mod it appropriately sets game_identity. I also took the opportunity to have Exult_studio save out default values for some of the other modcfg fields that modders might find useful. It now also saves defaults for `patch`, `source` and the recently added fields `skip_splash`, `clean_menu` and `force_digital_music` as we don't really document any of this stuff anywhere

I lastly updated the Windows installer to use --installdata and --installmod.  In the event that the user has selected to install mods or data but has deselected to install exult, the installer will check the version of the already installed version of Exult. If it is older than 1.13.1 or wasn't installed, the installer will fallback to the old Windows shell method to extract the zips. InnoSetup 6.4 is now required as it seems I am using a scripting function that was added in 6.4

The windows installer now has a few important behavioral changes. Firstly it will now report errors if the user tries to install the mods and they do not have the expansions. All our mods require the expansions, previously the installer would install the mods and Exult would fail when trying to start a new game in a mod because the identities didn't match. This also makes sure the mods get installed to the correct games if you have all 4 games version installed. Previously if you had both the  expanded and unexpanded games, the old Windows installer code would install the FoV mods to the `<blackgate>` and SS mods to `<serpentisle>` regardless of what games they actually are. Now Exult installs mods to the correct game. Secondly if the user has made a mod file read only the new installation procedure will get an error while the old shell method would silently  overwrite read only files. Mods and data can now be installed in wine provided Exult is also being installed or the existing exult install is 1.13.1 or newer.

This also makes makes quite a few changes to the unzip code. Instead of opening a zip file from afilename and using a FILE* the unzip code now uses IDataSource* also to read zip files store in a memory buffer. This change was done so I could load a mods initgame into memory and read identity from it and initgame will most likely be a zip file and I didn't want to write out initgame to a temporary file just so the unzip code could read it to get the identity.

Changed the `get_game_identity` function to take an IDataSource* and added an overload with the old filename argument to maintain compatibility with existing code

I split off the code that checks modcfg required_version compatibility out of the `ModInfo` constructor into it's own static method so I could use it in the mod Installer without needing to duplicate code

`ModManager` now stores `static_identity` in a member variable 

`--installmod` and `--installdata` should be usable on any operating system though for most users they would need to be run as root or Administrator. No idea how it would interact with a containerized version of Exult like a flatpak

Made a few changes to clean up `stderr` output so when using `--installmod` and `--installdata` `stderr` will only contain fatal errors not benign errors or other informational messages