### PR TITLE
Adding play_scene intrinsic.

### DIFF
--- a/docs/exult_intrinsics.txt
+++ b/docs/exult_intrinsics.txt
@@ -3237,6 +3237,12 @@ obj->obj_sprite_effect(int sprite, int rel_x, int rel_y, int vel_x, int vel_y,
               the sprite frame will go through all of its frames. If negative,
               the sprite will go through all of its frames *once*.
 
+string UI_play_scene(string text)
+    Plays scripted cutscene after checking whether the files text_info.txt and 
+    text.flx exist in the patch folder.
+  Parameters:
+    text    The base name of the cutscene files.
+
 ================================================================================
 OTHER INTRINSICS
 ================================================================================

--- a/palette.h
+++ b/palette.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2000-2022  The Exult Team
+ *  Copyright (C) 2000-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -137,6 +137,10 @@ public:
 	}
 
 	void set_palette(const unsigned char palnew[768]);
+
+	int get_palette_index() const {
+		return palette;
+	}
 
 	static void set_border(int r, int g, int b) {
 		border[0] = r;

--- a/usecode/bgintrinsics.h
+++ b/usecode/bgintrinsics.h
@@ -3,7 +3,7 @@
  *
  *  Note:   This is used in the virtual machine and the Usecode compiler.
  *
- *  Copyright (C) 2001-2022  The Exult Team
+ *  Copyright (C) 2001-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -244,7 +244,7 @@ USECODE_INTRINSIC_PTR(get_random),                               // 0x00
 		USECODE_INTRINSIC_PTR(close_gumps2),             // 0xd8
 		USECODE_INTRINSIC_PTR(close_gump2),              // 0xd9
 		USECODE_INTRINSIC_PTR(game_day),                 // 0xda (Exult)
-		USECODE_INTRINSIC_PTR(UNKNOWN),                  // 0xdb
+		USECODE_INTRINSIC_PTR(play_scene),               // 0xdb (Exult)
 		USECODE_INTRINSIC_PTR(UNKNOWN),                  // 0xdc
 		USECODE_INTRINSIC_PTR(UNKNOWN),                  // 0xdd
 		USECODE_INTRINSIC_PTR(UNKNOWN),                  // 0xde

--- a/usecode/intrinsics.cc
+++ b/usecode/intrinsics.cc
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2000-2022  The Exult Team
+ *  Copyright (C) 2000-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -50,6 +50,7 @@
 #include "mouse.h"
 #include "palette.h"
 #include "party.h"
+#include "playscene.h"
 #include "ready.h"
 #include "rect.h"
 #include "schedule.h"
@@ -3055,6 +3056,35 @@ USECODE_INTRINSIC(play_sound_effect2) {
 	cout << "Sound effect(2) " << parms[0].get_int_value()
 		 << " request in usecode" << endl;
 #endif
+	return no_ret;
+}
+
+USECODE_INTRINSIC(play_scene) {
+	if (num_parms < 1) {
+		return no_ret;
+	}
+
+	const char* scene_name_str = parms[0].get_str_value();
+	if (!scene_name_str) {
+		return no_ret;
+	}
+
+	std::string scene_name(scene_name_str);
+	if (scene_available(scene_name)) {
+		// fade outs in scenes will screw up the palette, so we save current
+		// palette index and restore it after the scene is played.
+		int prev_palette = gwin->get_pal()->get_palette_index();
+		// Pause the queue.
+		gwin->get_tqueue()->pause(Game::get_ticks());
+		play_scene(scene_name);
+
+		// Restore the palette index.
+		gwin->get_pal()->load(PALETTES_FLX, PATCH_PALETTES, prev_palette);
+		gwin->get_pal()->apply(true);
+		// Resume the queue.
+		gwin->get_tqueue()->resume(Game::get_ticks());
+	}
+
 	return no_ret;
 }
 

--- a/usecode/sibetaintrinsics.h
+++ b/usecode/sibetaintrinsics.h
@@ -3,7 +3,7 @@
  *
  *  Note:   This is used in the virtual machine and the Usecode compiler.
  *
- *  Copyright (C) 2016-2022  The Exult Team
+ *  Copyright (C) 2016-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -247,7 +247,7 @@ USECODE_INTRINSIC_PTR(get_random),                               // 0x00
 		USECODE_INTRINSIC_PTR(close_gumps2),             // 0xd8
 		USECODE_INTRINSIC_PTR(close_gump2),              // 0xd9
 		USECODE_INTRINSIC_PTR(game_day),                 // 0xda (Exult)
-		USECODE_INTRINSIC_PTR(UNKNOWN),                  // 0xdb
+		USECODE_INTRINSIC_PTR(play_scene),               // 0xdb (Exult)
 		USECODE_INTRINSIC_PTR(UNKNOWN),                  // 0xdc
 		USECODE_INTRINSIC_PTR(UNKNOWN),                  // 0xdd
 		USECODE_INTRINSIC_PTR(UNKNOWN),                  // 0xde

--- a/usecode/siintrinsics.h
+++ b/usecode/siintrinsics.h
@@ -3,7 +3,7 @@
  *
  *  Note:   This is used in the virtual machine and the Usecode compiler.
  *
- *  Copyright (C) 2001-2022  The Exult Team
+ *  Copyright (C) 2001-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -257,7 +257,7 @@ USECODE_INTRINSIC_PTR(get_random),                               // 0x00
 		USECODE_INTRINSIC_PTR(close_gumps2),             // 0xd9
 		USECODE_INTRINSIC_PTR(close_gump2),              // 0xda
 		USECODE_INTRINSIC_PTR(game_day),                 // 0xdb (Exult)
-		USECODE_INTRINSIC_PTR(UNKNOWN),                  // 0xdc
+		USECODE_INTRINSIC_PTR(play_scene),               // 0xdc (Exult)
 		USECODE_INTRINSIC_PTR(UNKNOWN),                  // 0xdd
 		USECODE_INTRINSIC_PTR(UNKNOWN),                  // 0xde
 		USECODE_INTRINSIC_PTR(UNKNOWN),                  // 0xdf

--- a/usecode/ucinternal.h
+++ b/usecode/ucinternal.h
@@ -5,7 +5,7 @@
  *  be included within .cc's in the 'usecode' directory.
  *
  *
- *  Copyright (C) 2001-2022  The Exult Team
+ *  Copyright (C) 2001-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -422,6 +422,7 @@ class Usecode_internal : public Usecode_machine {
 	USECODE_INTRINSIC_DECL(remove_spell);
 	USECODE_INTRINSIC_DECL(create_barge_object);
 	USECODE_INTRINSIC_DECL(in_usecode_path);
+	USECODE_INTRINSIC_DECL(play_scene);
 
 	/*
 	 *  Other private methods:


### PR DESCRIPTION
With this you can start a scripted scene during the game. It will save the palette and restore it afterwards as fade outs in scenes really messes with the current palette. Additionally the queue is suspended during playback.