### PR TITLE
Fixed extended_intro option requiring a restart

### DIFF
--- a/gamewin.h
+++ b/gamewin.h
@@ -148,7 +148,7 @@ class Game_window {
 	uint8        use_shortcutbar;    // 0 = no, 1 = trans, 2 = yes
 	Pixel_colors outline_color;
 	bool         sb_hide_missing;
-	bool         extended_intro;
+	bool         extended_intro;	// option to use SI's extended intro
 
 	// Touch Options
 	bool item_menu;

--- a/gumps/GameDisplayOptions_gump.cc
+++ b/gumps/GameDisplayOptions_gump.cc
@@ -262,6 +262,7 @@ void GameDisplayOptions_gump::save_settings() {
 	config->set(
 			"config/gameplay/extended_intro", extended_intro ? "yes" : "no",
 			false);
+	gwin->set_extended_intro(extended_intro);
 	config->set(
 			"config/gameplay/skip_splash", menu_intro ? "yes" : "no", false);
 	if (sman->can_use_paperdolls()


### PR DESCRIPTION
Previously, changing the "Use extended SI intro" option would update the config file but not the current Game_window instance, meaning it would not reflect changes until exult was restarded. This change simply makes sure the Game_window is updated to reflect the option.