### PR TITLE
Hide UI elements (face stats, shortcuts bar, virtual joystick) during the first scenes in BG and SI

### DIFF
--- a/exult.cc
+++ b/exult.cc
@@ -687,8 +687,9 @@ int exult_main(const char* runpath) {
 		touchui->showButtonControls();
 		// TODO(Marzo): This is probably the wrong place for this
 		Usecode_machine* usecode = Game_window::get_instance()->get_usecode();
-		if (!usecode->get_global_flag(Usecode_machine::did_first_scene)
-			&& GAME_BG) {
+		if ((GAME_BG
+			 && !usecode->get_global_flag(Usecode_machine::did_first_scene))
+			|| (GAME_SI && !usecode->get_global_flag(3))) {
 			touchui->hideGameControls();
 		} else {
 			touchui->showGameControls();

--- a/exult.cc
+++ b/exult.cc
@@ -689,7 +689,9 @@ int exult_main(const char* runpath) {
 		Usecode_machine* usecode = Game_window::get_instance()->get_usecode();
 		if ((GAME_BG
 			 && !usecode->get_global_flag(Usecode_machine::did_first_scene))
-			|| (GAME_SI && !usecode->get_global_flag(3))) {
+			|| (GAME_SI
+				&& !usecode->get_global_flag(
+						Usecode_machine::si_did_first_scene))) {
 			touchui->hideGameControls();
 		} else {
 			touchui->showGameControls();

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -7,7 +7,7 @@
 /*
  *
  *  Copyright (C) 1998-1999  Jeffrey S. Freedman
- *  Copyright (C) 2000-2022  The Exult Team
+ *  Copyright (C) 2000-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -1148,8 +1148,8 @@ void Game_window::set_camera_actor(Actor* a) {
 bool Game_window::scroll_if_needed(Tile_coord t) {
 	bool scrolled = false;
 	// 1 lift = 1/2 tile.
-	const int tx = DECR_TILE(t.tx,t.tz / 2);
-	const int ty = DECR_TILE(t.ty,t.tz / 2);
+	const int tx = DECR_TILE(t.tx, t.tz / 2);
+	const int ty = DECR_TILE(t.ty, t.tz / 2);
 	if (Tile_coord::gte(DECR_TILE(scroll_bounds.x), tx)) {
 		view_left();
 		scrolled = true;
@@ -1393,7 +1393,7 @@ void Game_window::write(bool nopaint) {
 	}
 	for (auto* map : maps) {
 		if (map) {
-			map->write_ireg(); // Write ireg files.
+			map->write_ireg();    // Write ireg files.
 		}
 	}
 	write_npcs();              // Write out npc.dat.
@@ -2902,7 +2902,7 @@ void Game_window::setup_game(bool map_editing) {
 	usecode->read();    // Read the usecode flags
 	cycle_load_palette();
 
-	if (Game::get_game_type() == BLACK_GATE && !map_editing) {
+	if (GAME_BG && !map_editing) {
 		string yn;    // Override from config. file.
 		// Skip intro. scene?
 		config->value("config/gameplay/skip_intro", yn, "no");
@@ -3145,10 +3145,10 @@ void Game_window::setup_load_palette() {
 		return;
 	}
 
-	if (Game::get_game_type() == BLACK_GATE) {
+	if (GAME_BG) {
 		plasma_start_color = BG_PLASMA_START_COLOR;
 		plasma_cycle_range = BG_PLASMA_CYCLE_RANGE;
-	} else {    // Default: if (Game::get_game_type()==SERPENT_ISLE)
+	} else {    // Default: if (GAME_SI)
 		plasma_start_color = SI_PLASMA_START_COLOR;
 		plasma_cycle_range = SI_PLASMA_CYCLE_RANGE;
 	}
@@ -3159,9 +3159,9 @@ void Game_window::setup_load_palette() {
 		   plasma_start_color + plasma_cycle_range - 1);
 
 	// Load the palette
-	if (Game::get_game_type() == BLACK_GATE) {
+	if (GAME_BG) {
 		pal->load(INTROPAL_DAT, PATCH_INTROPAL, 2);
-	} else if (Game::get_game_type() == SERPENT_ISLE) {
+	} else if (GAME_SI) {
 		pal->load(MAINSHP_FLX, PATCH_MAINSHP, 1);
 	}
 

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -2950,9 +2950,17 @@ void Game_window::setup_game(bool map_editing) {
 	set_all_dirty();
 	painted = true;                     // Main loop uses this.
 	gump_man->close_all_gumps(true);    // Kill gumps.
-	Face_stats::load_config(config);
-	if (using_shortcutbar()) {
-		g_shortcutBar = new ShortcutBar_gump(0, 0);
+	// During the first scene do not show the UI elements,
+	// unless the Avatar is free to move (possibly in mods).
+	if ((GAME_BG && usecode->get_global_flag(Usecode_machine::did_first_scene))
+		|| (GAME_SI
+			&& usecode->get_global_flag(Usecode_machine::si_did_first_scene))
+		|| (!main_actor_dont_move() && main_actor_can_act()
+			&& main_actor_can_act_charmed())) {
+		Face_stats::load_config(config);
+		if (using_shortcutbar()) {
+			g_shortcutBar = new ShortcutBar_gump(0, 0);
+		}
 	}
 
 	// Set palette for time-of-day.

--- a/gumps/Face_stats.cc
+++ b/gumps/Face_stats.cc
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2001-2022 The Exult Team
+Copyright (C) 2001-2025 The Exult Team
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -31,6 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "game.h"
 #include "gamewin.h"
 #include "party.h"
+#include "ucmachine.h"
 
 #define PALETTE_INDEX_RED   22
 #define PALETTE_INDEX_GREEN 64
@@ -589,9 +590,22 @@ Face_stats* Face_stats::self = nullptr;
 
 // Creates if doesn't already exist
 void Face_stats::CreateGump() {
-	if (!self) {
-		self = new Face_stats();
-		gumpman->add_gump(self);
+	Usecode_machine* usecode = Game_window::get_instance()->get_usecode();
+	bool             in_first_scene
+			= (GAME_BG
+			   && !usecode->get_global_flag(Usecode_machine::did_first_scene))
+			  || (GAME_SI && !usecode->get_global_flag(3));
+	if (in_first_scene) {
+		if (self) {
+			gumpman->close_gump(self);
+			self = nullptr;
+		}
+	} else {
+		// Show face stats in all other cases
+		if (!self) {
+			self = new Face_stats();
+			gumpman->add_gump(self);
+		}
 	}
 }
 
@@ -619,6 +633,19 @@ void Face_stats::AdvanceState() {
 
 // Used for updating mana bar when magic value changes and when gwin resizes
 void Face_stats::UpdateButtons() {
+	Usecode_machine* usecode = Game_window::get_instance()->get_usecode();
+	bool             in_first_scene
+			= (GAME_BG
+			   && !usecode->get_global_flag(Usecode_machine::did_first_scene))
+			  || (GAME_SI && !usecode->get_global_flag(3));
+	if (in_first_scene) {
+		if (self) {
+			gumpman->close_gump(self);
+			self = nullptr;
+		}
+		return;
+	}
+
 	if (!self) {
 		return;
 	} else {

--- a/gumps/Face_stats.cc
+++ b/gumps/Face_stats.cc
@@ -31,7 +31,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "game.h"
 #include "gamewin.h"
 #include "party.h"
-#include "ucmachine.h"
 
 #define PALETTE_INDEX_RED   22
 #define PALETTE_INDEX_GREEN 64
@@ -590,22 +589,9 @@ Face_stats* Face_stats::self = nullptr;
 
 // Creates if doesn't already exist
 void Face_stats::CreateGump() {
-	Usecode_machine* usecode = Game_window::get_instance()->get_usecode();
-	bool             in_first_scene
-			= (GAME_BG
-			   && !usecode->get_global_flag(Usecode_machine::did_first_scene))
-			  || (GAME_SI && !usecode->get_global_flag(3));
-	if (in_first_scene) {
-		if (self) {
-			gumpman->close_gump(self);
-			self = nullptr;
-		}
-	} else {
-		// Show face stats in all other cases
-		if (!self) {
-			self = new Face_stats();
-			gumpman->add_gump(self);
-		}
+	if (!self) {
+		self = new Face_stats();
+		gumpman->add_gump(self);
 	}
 }
 
@@ -633,19 +619,6 @@ void Face_stats::AdvanceState() {
 
 // Used for updating mana bar when magic value changes and when gwin resizes
 void Face_stats::UpdateButtons() {
-	Usecode_machine* usecode = Game_window::get_instance()->get_usecode();
-	bool             in_first_scene
-			= (GAME_BG
-			   && !usecode->get_global_flag(Usecode_machine::did_first_scene))
-			  || (GAME_SI && !usecode->get_global_flag(3));
-	if (in_first_scene) {
-		if (self) {
-			gumpman->close_gump(self);
-			self = nullptr;
-		}
-		return;
-	}
-
 	if (!self) {
 		return;
 	} else {

--- a/gumps/ShortcutBar_gump.cc
+++ b/gumps/ShortcutBar_gump.cc
@@ -301,11 +301,6 @@ ShortcutBar_gump::ShortcutBar_gump(int placex, int placey)
 	assert(init == 0); // Protect against re-entry
 	init = true;*/
 
-	Usecode_machine* usecode = Game_window::get_instance()->get_usecode();
-	bool             in_first_scene
-			= (GAME_BG
-			   && !usecode->get_global_flag(Usecode_machine::did_first_scene))
-			  || (GAME_SI && !usecode->get_global_flag(3));
 	if (ShortcutBar_gump::eventType == std::numeric_limits<uint32>::max()) {
 		ShortcutBar_gump::eventType = SDL_RegisterEvents(1);
 	}
@@ -319,10 +314,8 @@ ShortcutBar_gump::ShortcutBar_gump(int placex, int placey)
 		buttonItem.pushed = false;
 	}
 	createButtons();
-	if (!in_first_scene) {
-		gumpman->add_gump(this);
-		has_changed = true;
-	}
+	gumpman->add_gump(this);
+	has_changed = true;
 }
 
 ShortcutBar_gump::~ShortcutBar_gump() {

--- a/gumps/ShortcutBar_gump.cc
+++ b/gumps/ShortcutBar_gump.cc
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2011-2024 The Exult Team
+Copyright (C) 2011-2025 The Exult Team
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -301,6 +301,11 @@ ShortcutBar_gump::ShortcutBar_gump(int placex, int placey)
 	assert(init == 0); // Protect against re-entry
 	init = true;*/
 
+	Usecode_machine* usecode = Game_window::get_instance()->get_usecode();
+	bool             in_first_scene
+			= (GAME_BG
+			   && !usecode->get_global_flag(Usecode_machine::did_first_scene))
+			  || (GAME_SI && !usecode->get_global_flag(3));
 	if (ShortcutBar_gump::eventType == std::numeric_limits<uint32>::max()) {
 		ShortcutBar_gump::eventType = SDL_RegisterEvents(1);
 	}
@@ -314,8 +319,10 @@ ShortcutBar_gump::ShortcutBar_gump(int placex, int placey)
 		buttonItem.pushed = false;
 	}
 	createButtons();
-	gumpman->add_gump(this);
-	has_changed = true;
+	if (!in_first_scene) {
+		gumpman->add_gump(this);
+		has_changed = true;
+	}
 }
 
 ShortcutBar_gump::~ShortcutBar_gump() {

--- a/usecode/Makefile.am
+++ b/usecode/Makefile.am
@@ -1,7 +1,8 @@
 AM_CPPFLAGS = -I$(top_srcdir)/headers -I$(top_srcdir) -I$(top_srcdir)/files -I$(top_srcdir)/imagewin \
 		-I$(top_srcdir)/shapes -I$(top_srcdir)/objs -I$(top_srcdir)/audio -I$(top_srcdir)/audio/midi_drivers \
 		-I$(top_srcdir)/gumps -I$(top_srcdir)/tools -I$(top_srcdir)/shapes/shapeinf \
-		-I$(top_srcdir)/server $(SDL_CFLAGS) $(OGG_CFLAGS) $(INCDIRS) \
+		-I$(top_srcdir)/server -I$(top_srcdir)/conf \
+		$(SDL_CFLAGS) $(OGG_CFLAGS) $(INCDIRS) \
 		$(WINDOWING_SYSTEM) $(DEBUG_LEVEL) $(OPT_LEVEL) $(WARNINGS) $(CPPFLAGS)
 
 noinst_LTLIBRARIES = libusecode.la

--- a/usecode/ucinternal.cc
+++ b/usecode/ucinternal.cc
@@ -2,7 +2,7 @@
  *  ucinternal.cc - Interpreter for usecode.
  *
  *  Copyright (C) 1999  Jeffrey S. Freedman
- *  Copyright (C) 2000-2022  The Exult Team
+ *  Copyright (C) 2000-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,9 +25,11 @@
 #endif
 
 #include "Audio.h"
+#include "Face_stats.h"
 #include "Gump.h"
 #include "Gump_manager.h"
 #include "Notebook_gump.h"
+#include "ShortcutBar_gump.h"
 #include "Text_gump.h"
 #include "actions.h"
 #include "actors.h"
@@ -2720,6 +2722,25 @@ int Usecode_internal::run() {
 					// ++++KLUDGE for Monk Isle:
 					if (offset == 0x272 && GAME_SI) {
 						gflags[offset] = 0;
+					}
+					// ++++KLUDGE for reactivating Face Stats and shortcut bar
+					// after the first scene
+					if ((offset == 0x3b && GAME_BG)
+						|| (offset == 0x03 && GAME_SI)) {
+						int facestats_mode = -1;
+						config->value(
+								"config/gameplay/facestats", facestats_mode,
+								-1);
+						if (facestats_mode >= 0) {
+							Face_stats::CreateGump();
+						}
+						if (g_shortcutBar
+							&& !gumpman->find_gump(
+									g_shortcutBar->get_x(),
+									g_shortcutBar->get_y())) {
+							gumpman->add_gump(g_shortcutBar);
+							g_shortcutBar->set_changed();
+						}
 					}
 				}
 				break;

--- a/usecode/ucinternal.cc
+++ b/usecode/ucinternal.cc
@@ -2725,21 +2725,25 @@ int Usecode_internal::run() {
 					}
 					// ++++KLUDGE for reactivating Face Stats and shortcut bar
 					// after the first scene
-					if ((offset == 0x3b && GAME_BG)
-						|| (offset == 0x03 && GAME_SI)) {
+					if ((offset == Usecode_machine::did_first_scene && GAME_BG)
+						|| (offset == Usecode_machine::si_did_first_scene
+							&& GAME_SI)) {
 						int facestats_mode = -1;
 						config->value(
 								"config/gameplay/facestats", facestats_mode,
 								-1);
 						if (facestats_mode >= 0) {
-							Face_stats::CreateGump();
+							Face_stats::load_config(config);
 						}
-						if (g_shortcutBar
-							&& !gumpman->find_gump(
-									g_shortcutBar->get_x(),
-									g_shortcutBar->get_y())) {
-							gumpman->add_gump(g_shortcutBar);
-							g_shortcutBar->set_changed();
+						if (gwin->using_shortcutbar()) {
+							if (!g_shortcutBar) {
+								g_shortcutBar = new ShortcutBar_gump(0, 0);
+							} else if (!gumpman->find_gump(
+											   g_shortcutBar->get_x(),
+											   g_shortcutBar->get_y())) {
+								gumpman->add_gump(g_shortcutBar);
+								g_shortcutBar->set_changed();
+							}
 						}
 					}
 				}

--- a/usecode/ucmachine.h
+++ b/usecode/ucmachine.h
@@ -71,7 +71,8 @@ public:
 	};
 
 	enum Global_flag_names {
-		did_first_scene       = 0x3b,    // Went through 1st scene with Iolo.
+		si_did_first_scene = 0x03,    // After Iolo's talk at the start of SI.
+		did_first_scene    = 0x3b,    // Went through 1st scene with Iolo.
 		have_trinsic_password = 0x3d,
 		found_stable_key      = 0x3c,
 		left_trinsic          = 0x57,


### PR DESCRIPTION
Hide UI elements (face stats, shortcuts bar, virtual joystick) during the first scenes in BG and SI.
When the respective global flags are set (0x3b in BG and 0x03 in SI) these are shown if configured to.