### PR TITLE
Face_stats and ShortcutBar_gump have new functions: show, hide and bool visible

### DIFF
--- a/exult.cc
+++ b/exult.cc
@@ -31,6 +31,7 @@
 #include "Audio.h"
 #include "AudioMixer.h"
 #include "Configuration.h"
+#include "Face_stats.h"
 #include "Gump_button.h"
 #include "Gump_manager.h"
 #include "Scroll_gump.h"
@@ -688,21 +689,6 @@ int exult_main(const char* runpath) {
 
 	Mouse mouse(gwin);
 	Mouse::mouse()->set_shape(Mouse::hand);
-
-	if (touchui != nullptr) {
-		touchui->showButtonControls();
-		// TODO(Marzo): This is probably the wrong place for this
-		Usecode_machine* usecode = Game_window::get_instance()->get_usecode();
-		if ((GAME_BG
-			 && !usecode->get_global_flag(Usecode_machine::did_first_scene))
-			|| (GAME_SI
-				&& !usecode->get_global_flag(
-						Usecode_machine::si_did_first_scene))) {
-			touchui->hideGameControls();
-		} else {
-			touchui->showGameControls();
-		}
-	}
 
 	const int result = Play();    // start game
 
@@ -2813,6 +2799,10 @@ void Wizard_eye(long msecs    // Length of time in milliseconds.
 			touchui->showButtonControls();
 			touchui->hideGameControls();
 		}
+		if (Face_stats::Visible() && ShortcutBar_gump::Visible()) {
+			Face_stats::HideGump();
+			ShortcutBar_gump::HideGump();
+		}
 
 		Delay();    // Wait a fraction of a second.
 
@@ -2909,6 +2899,10 @@ void Wizard_eye(long msecs    // Length of time in milliseconds.
 		}
 		if (touchui != nullptr) {
 			touchui->showGameControls();
+		}
+		if (!Face_stats::Visible() && !ShortcutBar_gump::Visible()) {
+			Face_stats::ShowGump();
+			ShortcutBar_gump::ShowGump();
 		}
 	}
 

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -81,6 +81,7 @@
 #include "utils.h"
 #include "version.h"
 #include "virstone.h"
+#include "touchui.h"
 
 #include <cstdarg>
 #include <cstdio>
@@ -2950,16 +2951,27 @@ void Game_window::setup_game(bool map_editing) {
 	set_all_dirty();
 	painted = true;                     // Main loop uses this.
 	gump_man->close_all_gumps(true);    // Kill gumps.
+	Face_stats::load_config(config);
+	if (using_shortcutbar()) {
+		g_shortcutBar = new ShortcutBar_gump(0, 0);
+	}
+	if (touchui != nullptr) {
+		touchui->showButtonControls();
+		touchui->showGameControls();
+	}
 	// During the first scene do not show the UI elements,
 	// unless the Avatar is free to move (possibly in mods).
-	if ((GAME_BG && usecode->get_global_flag(Usecode_machine::did_first_scene))
+	if ((GAME_BG && !usecode->get_global_flag(Usecode_machine::did_first_scene))
 		|| (GAME_SI
-			&& usecode->get_global_flag(Usecode_machine::si_did_first_scene))
-		|| (!main_actor_dont_move() && main_actor_can_act()
-			&& main_actor_can_act_charmed())) {
-		Face_stats::load_config(config);
-		if (using_shortcutbar()) {
-			g_shortcutBar = new ShortcutBar_gump(0, 0);
+			&& !usecode->get_global_flag(Usecode_machine::si_did_first_scene))
+		|| (main_actor_dont_move() && !main_actor_can_act()
+			&& !main_actor_can_act_charmed())) {
+		if (touchui != nullptr) {
+			touchui->hideGameControls();
+		}
+		if (Face_stats::Visible() && ShortcutBar_gump::Visible()) {
+			Face_stats::HideGump();
+			ShortcutBar_gump::HideGump();
 		}
 	}
 

--- a/gumps/Face_stats.cc
+++ b/gumps/Face_stats.cc
@@ -587,6 +587,34 @@ Container_game_object* Face_stats::find_actor(int mx, int my) {
 int         Face_stats::mode = 0;
 Face_stats* Face_stats::self = nullptr;
 
+// Hide the gump without destroying it
+void Face_stats::HideGump() {
+	if (self) {
+		gumpman->remove_gump(self);
+	}
+}
+
+// Show the gump if it exists
+void Face_stats::ShowGump() {
+	if (self) {
+		gumpman->add_gump(self);
+	}
+}
+
+// Check if the gump is currently visible
+bool Face_stats::Visible() {
+	if (!self) {
+		return false;
+	}
+
+	for (auto it = gumpman->begin(); it != gumpman->end(); it++) {
+		if (*it == self) {
+			return true;
+		}
+	}
+	return false;
+}
+
 // Creates if doesn't already exist
 void Face_stats::CreateGump() {
 	if (!self) {

--- a/gumps/Face_stats.h
+++ b/gumps/Face_stats.h
@@ -90,6 +90,9 @@ public:
 	static void RemoveGump();
 	static void AdvanceState();
 	static void UpdateButtons();
+	static void HideGump();
+	static void ShowGump();
+	static bool Visible();
 	static void save_config(Configuration* config);
 	static void load_config(Configuration* config);
 };

--- a/gumps/ShortcutBar_gump.cc
+++ b/gumps/ShortcutBar_gump.cc
@@ -82,6 +82,35 @@ void ShortcutBar_gump::update_gump() {
 	}
 }
 
+// Hide the gump without destroying it
+void ShortcutBar_gump::HideGump() {
+	if (g_shortcutBar) {
+		gumpman->remove_gump(
+				g_shortcutBar);
+	}
+}
+
+// Show the gump if it exists
+void ShortcutBar_gump::ShowGump() {
+	if (g_shortcutBar) {
+		gumpman->add_gump(g_shortcutBar);
+	}
+}
+
+// Check if the gump is currently visible
+bool ShortcutBar_gump::Visible() {
+	if (!g_shortcutBar) {
+		return false;
+	}
+
+	for (auto it = gumpman->begin(); it != gumpman->end(); it++) {
+		if (*it == g_shortcutBar) {
+			return true;
+		}
+	}
+	return false;
+}
+
 /*
  * To align button shapes vertically, we need to micro-manage the shapeOffsetY
  * values to shift shapes up or down.

--- a/gumps/ShortcutBar_gump.h
+++ b/gumps/ShortcutBar_gump.h
@@ -112,7 +112,10 @@ public:
 		has_changed = true;
 	}
 
-	void check_for_updates(int shnum);
+	void        check_for_updates(int shnum);
+	static void HideGump();
+	static void ShowGump();
+	static bool Visible();
 
 private:
 	ShortcutBarButtonItem buttonItems[MAX_SHORTCUT_BAR_ITEMS];

--- a/usecode/conversation.cc
+++ b/usecode/conversation.cc
@@ -31,6 +31,8 @@
 #include "mouse.h"
 #include "touchui.h"
 #include "useval.h"
+#include "Face_stats.h"
+#include "ShortcutBar_gump.h"
 
 using std::size_t;
 using std::string;
@@ -130,6 +132,10 @@ void Conversation::init_faces() {
 		finfo = nullptr;
 		if (touchui != nullptr) {
 			touchui->showGameControls();
+		}
+		if (!Face_stats::Visible() && !ShortcutBar_gump::Visible()) {
+			Face_stats::ShowGump();
+			ShortcutBar_gump::ShowGump();
 		}
 	}
 	num_faces       = 0;
@@ -247,6 +253,10 @@ void Conversation::show_face(int shape, int frame, int slot) {
 	if (touchui != nullptr) {
 		touchui->hideGameControls();
 	}
+	if (Face_stats::Visible() && ShortcutBar_gump::Visible()) {
+		Face_stats::HideGump();
+		ShortcutBar_gump::HideGump();
+	}
 	gwin->get_win()->clear_clip();
 }
 
@@ -331,6 +341,10 @@ void Conversation::remove_slot_face(int slot) {
 		last_face_shown = j - 1;
 		if (touchui != nullptr && num_faces == 0) {
 			touchui->showGameControls();
+		}
+		if (!Face_stats::Visible() && !ShortcutBar_gump::Visible() && num_faces == 0) {
+			Face_stats::ShowGump();
+			ShortcutBar_gump::ShowGump();
 		}
 	}
 }

--- a/usecode/ucinternal.cc
+++ b/usecode/ucinternal.cc
@@ -2728,22 +2728,13 @@ int Usecode_internal::run() {
 					if ((offset == Usecode_machine::did_first_scene && GAME_BG)
 						|| (offset == Usecode_machine::si_did_first_scene
 							&& GAME_SI)) {
-						int facestats_mode = -1;
-						config->value(
-								"config/gameplay/facestats", facestats_mode,
-								-1);
-						if (facestats_mode >= 0) {
-							Face_stats::load_config(config);
+						if (touchui != nullptr) {
+							touchui->showGameControls();
 						}
-						if (gwin->using_shortcutbar()) {
-							if (!g_shortcutBar) {
-								g_shortcutBar = new ShortcutBar_gump(0, 0);
-							} else if (!gumpman->find_gump(
-											   g_shortcutBar->get_x(),
-											   g_shortcutBar->get_y())) {
-								gumpman->add_gump(g_shortcutBar);
-								g_shortcutBar->set_changed();
-							}
+						if (!Face_stats::Visible()
+							&& !ShortcutBar_gump::Visible()) {
+							Face_stats::ShowGump();
+							ShortcutBar_gump::ShowGump();
 						}
 					}
 				}


### PR DESCRIPTION
Thus reworked the previous commits to hide the UI gumps during the first scene. Now also hiding the gumps during conversations and casting Wizard's Eye. Creation of the touchUI controls moved over from exult.cc to gamewin.cc.
Fixes #771 