### PR TITLE
Hide UI during SI's scripted crystal ball scenes.

### DIFF
--- a/usecode/conversation.cc
+++ b/usecode/conversation.cc
@@ -131,12 +131,16 @@ void Conversation::init_faces() {
 	for (Npc_face_info*& finfo : face_info) {
 		delete finfo;
 		finfo = nullptr;
-		if (touchui != nullptr) {
-			touchui->showGameControls();
-		}
-		if (!Face_stats::Visible() && !ShortcutBar_gump::Visible()) {
-			Face_stats::ShowGump();
-			ShortcutBar_gump::ShowGump();
+		// only restore the UI if the Avatar is the main actor so crystal ball
+		// scenes remain UI free
+		if (gwin->get_camera_actor() == gwin->get_main_actor()) {
+			if (touchui != nullptr) {
+				touchui->showGameControls();
+			}
+			if (!Face_stats::Visible() && !ShortcutBar_gump::Visible()) {
+				Face_stats::ShowGump();
+				ShortcutBar_gump::ShowGump();
+			}
 		}
 	}
 	num_faces       = 0;
@@ -343,13 +347,17 @@ void Conversation::remove_slot_face(int slot) {
 			}
 		}
 		last_face_shown = j - 1;
-		if (touchui != nullptr && num_faces == 0) {
-			touchui->showGameControls();
-		}
-		if (!Face_stats::Visible() && !ShortcutBar_gump::Visible()
-			&& num_faces == 0) {
-			Face_stats::ShowGump();
-			ShortcutBar_gump::ShowGump();
+		// only restore the UI if the Avatar is the main actor so crystal ball
+		// scenes remain UI free
+		if (gwin->get_camera_actor() == gwin->get_main_actor()) {
+			if (touchui != nullptr && num_faces == 0) {
+				touchui->showGameControls();
+			}
+			if (!Face_stats::Visible() && !ShortcutBar_gump::Visible()
+				&& num_faces == 0) {
+				Face_stats::ShowGump();
+				ShortcutBar_gump::ShowGump();
+			}
 		}
 	}
 }

--- a/usecode/intrinsics.cc
+++ b/usecode/intrinsics.cc
@@ -3010,6 +3010,7 @@ USECODE_INTRINSIC(get_party_list2) {
 USECODE_INTRINSIC(set_camera) {
 	ignore_unused_variable_warning(num_parms);
 	// Set_camera(actor)
+	gumpman->close_all_gumps();
 	Actor* actor = as_actor(get_item(parms[0]));
 	if (actor) {
 		gwin->set_camera_actor(actor);
@@ -3022,7 +3023,24 @@ USECODE_INTRINSIC(set_camera) {
 			activate_cached(t);    // Mar-10-01 - For Test of Love.
 		}
 	}
-
+	// toggling game controls and face/shortcut bar for SI crystal ball scenes
+	if (actor == gwin->get_main_actor()) {
+		if (touchui != nullptr) {
+			touchui->showGameControls();
+		}
+		if (!Face_stats::Visible() && !ShortcutBar_gump::Visible()) {
+			Face_stats::ShowGump();
+			ShortcutBar_gump::ShowGump();
+		}
+	} else {
+		if (touchui != nullptr) {
+			touchui->hideGameControls();
+		}
+		if (Face_stats::Visible() || ShortcutBar_gump::Visible()) {
+			Face_stats::HideGump();
+			ShortcutBar_gump::HideGump();
+		}
+	}
 	return no_ret;
 }
 


### PR DESCRIPTION
Also close all gumps as these were shown during the scenes if opened before.


This works for the Batlin/Cantra and the planetary (cat) scene. No adverse effects on other scripted SI scenes (tested wall of lights, Petra body switch), though these still show the UI.
If you have any idea what to test, additionally, please let me know.