### PR TITLE
Mobile pause button when combat allows pausing

### DIFF
--- a/android/app/src/main/java/info/exult/ExultActivity.java
+++ b/android/app/src/main/java/info/exult/ExultActivity.java
@@ -118,32 +118,33 @@ public class ExultActivity extends SDLActivity {
 			RelativeLayout.LayoutParams pauseLp
 					= (RelativeLayout.LayoutParams)
 							  m_pauseTextView.getLayoutParams();
-			final boolean hasRel
-					= pauseLp.getRule(RelativeLayout.RIGHT_OF) != 0
-					  || pauseLp.getRule(RelativeLayout.LEFT_OF) != 0;
+			final int gap = dpToPx(12);
 
-			if (!hasRel) {
-				final int                   gap = dpToPx(12);
-				RelativeLayout.LayoutParams escLp
-						= (RelativeLayout.LayoutParams)
-								  m_escTextView.getLayoutParams();
+			// Anchor next to ESC based on its current side
+			RelativeLayout.LayoutParams escLp
+					= (RelativeLayout.LayoutParams)
+							  m_escTextView.getLayoutParams();
 
-				if (escLp.getRule(RelativeLayout.ALIGN_PARENT_LEFT) != 0) {
-					// ESC on left -> Pause to its right
-					pauseLp.addRule(
-							RelativeLayout.RIGHT_OF, m_escTextView.getId());
-					pauseLp.leftMargin  = gap;
-					pauseLp.rightMargin = 0;
-				} else {
-					// ESC on right -> Pause to its left
-					pauseLp.addRule(
-							RelativeLayout.LEFT_OF, m_escTextView.getId());
-					pauseLp.rightMargin = gap;
-					pauseLp.leftMargin  = 0;
-				}
-				m_pauseTextView.setText(GLYPH_PAUSE);
-				m_pauseTextView.setLayoutParams(pauseLp);
+			// Clear conflicting rules so RIGHT_OF/LEFT_OF take effect
+			pauseLp.removeRule(RelativeLayout.ALIGN_PARENT_LEFT);
+			pauseLp.removeRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+			pauseLp.removeRule(RelativeLayout.RIGHT_OF);
+			pauseLp.removeRule(RelativeLayout.LEFT_OF);
+
+			if (escLp.getRule(RelativeLayout.ALIGN_PARENT_LEFT) != 0) {
+				// ESC on left -> Pause to its right
+				pauseLp.addRule(RelativeLayout.RIGHT_OF, m_escTextView.getId());
+				pauseLp.leftMargin  = gap;
+				pauseLp.rightMargin = 0;
+			} else {
+				// ESC on right -> Pause to its left
+				pauseLp.addRule(RelativeLayout.LEFT_OF, m_escTextView.getId());
+				pauseLp.rightMargin = gap;
+				pauseLp.leftMargin  = 0;
 			}
+			m_pauseTextView.setLayoutParams(pauseLp);
+
+			m_pauseTextView.setText(GLYPH_PAUSE);
 			m_pauseTextView.setVisibility(View.VISIBLE);
 		});
 	}

--- a/android/app/src/main/java/info/exult/ExultActivity.java
+++ b/android/app/src/main/java/info/exult/ExultActivity.java
@@ -52,8 +52,8 @@ public class ExultActivity extends SDLActivity {
 	private static final int DPAD_MARGIN_V_DP
 			= 90;    // vertical inset from bottom
 	// Glyphs for pause/play button
-	private static final String GLYPH_PAUSE = "\u23F8";    // ⏸
-	private static final String GLYPH_PLAY  = "\u25B6";    // ⏵
+	private static final String GLYPH_PAUSE = "\u23F8\uFE0F";    // ⏸
+	private static final String GLYPH_PLAY  = "\u25B6\uFE0F";    // ⏵
 
 	/**
 	 * This method clears the console buffer.
@@ -141,6 +141,7 @@ public class ExultActivity extends SDLActivity {
 					pauseLp.rightMargin = gap;
 					pauseLp.leftMargin  = 0;
 				}
+				m_pauseTextView.setText(GLYPH_PAUSE);
 				m_pauseTextView.setLayoutParams(pauseLp);
 			}
 			m_pauseTextView.setVisibility(View.VISIBLE);

--- a/android/lib/include/TouchUI_Android.h
+++ b/android/lib/include/TouchUI_Android.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021-2022  The Exult Team
+ *  Copyright (C) 2021-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -31,11 +31,14 @@ public:
 	void hideGameControls() final;
 	void showButtonControls() final;
 	void hideButtonControls() final;
+	void showPauseControls() final;
+	void hidePauseControls() final;
 	void onDpadLocationChanged() final;
 
 	static TouchUI_Android* getInstance();
 	void                    setVirtualJoystick(Sint16 x, Sint16 y);
 	void                    sendEscapeKeypress();
+	void                    sendPauseKeypress();
 
 private:
 	static TouchUI_Android* m_instance;
@@ -45,6 +48,8 @@ private:
 	jmethodID               m_hideGameControlsMethod;
 	jmethodID               m_showButtonControlsMethod;
 	jmethodID               m_hideButtonControlsMethod;
+	jmethodID               m_showPauseControlsMethod;
+	jmethodID               m_hidePauseControlsMethod;
 	SDL_Joystick*           m_joystick;
 	jmethodID               m_promptForNameMethod;
 };

--- a/android/lib/src/TouchUI_Android.cc
+++ b/android/lib/src/TouchUI_Android.cc
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021-2022  The Exult Team
+ *  Copyright (C) 2021-2025  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -46,6 +46,14 @@ extern "C" JNIEXPORT void JNICALL
 	touchUI->sendEscapeKeypress();
 }
 
+extern "C" JNIEXPORT void JNICALL
+		Java_info_exult_ExultActivity_sendPauseKeypress(
+				JNIEnv* env, jobject self) {
+	ignore_unused_variable_warning(env, self);
+	auto* touchUI = TouchUI_Android::getInstance();
+	touchUI->sendPauseKeypress();
+}
+
 extern "C" JNIEXPORT void JNICALL Java_info_exult_ExultActivity_setName(
 		JNIEnv* env, jobject self, jstring javaName) {
 	ignore_unused_variable_warning(self);
@@ -76,6 +84,17 @@ void TouchUI_Android::sendEscapeKeypress() {
 	SDL_PushEvent(&event);
 }
 
+void TouchUI_Android::sendPauseKeypress() {
+	SDL_Event event = {};
+	event.key.key   = SDLK_SPACE;    // act like pressing space
+
+	event.type = SDL_EVENT_KEY_DOWN;
+	SDL_PushEvent(&event);
+
+	event.type = SDL_EVENT_KEY_UP;
+	SDL_PushEvent(&event);
+}
+
 TouchUI_Android::TouchUI_Android() {
 	m_instance    = this;
 	m_jniEnv      = static_cast<JNIEnv*>(SDL_GetAndroidJNIEnv());
@@ -91,6 +110,10 @@ TouchUI_Android::TouchUI_Android() {
 			jclass, "showButtonControls", "(Ljava/lang/String;)V");
 	m_hideButtonControlsMethod
 			= m_jniEnv->GetMethodID(jclass, "hideButtonControls", "()V");
+	m_showPauseControlsMethod
+			= m_jniEnv->GetMethodID(jclass, "showPauseControls", "()V");
+	m_hidePauseControlsMethod
+			= m_jniEnv->GetMethodID(jclass, "hidePauseControls", "()V");
 	m_promptForNameMethod = m_jniEnv->GetMethodID(
 			jclass, "promptForName", "(Ljava/lang/String;)V");
 
@@ -167,6 +190,14 @@ void TouchUI_Android::showButtonControls() {
 
 void TouchUI_Android::hideButtonControls() {
 	m_jniEnv->CallVoidMethod(m_exultActivityObject, m_hideButtonControlsMethod);
+}
+
+void TouchUI_Android::showPauseControls() {
+	m_jniEnv->CallVoidMethod(m_exultActivityObject, m_showPauseControlsMethod);
+}
+
+void TouchUI_Android::hidePauseControls() {
+	m_jniEnv->CallVoidMethod(m_exultActivityObject, m_hidePauseControlsMethod);
 }
 
 void TouchUI_Android::onDpadLocationChanged() {}

--- a/exult.cc
+++ b/exult.cc
@@ -2074,14 +2074,20 @@ static void Handle_event(SDL_Event& event) {
 				last_b1_click = curtime;
 			}
 
-			if (gwin->get_touch_pathfind() && !click_handled
-				&& (curtime - last_b1down_click > 500) && avatar_can_act
-				&& gwin->main_actor_can_act_charmed() && !dragging
-				&& !gump_man->find_gump(x, y, false)) {
-				gwin->start_actor_along_path(
-						x, y, Mouse::mouse()->avatar_speed);
-				dragging = dragged = false;
-				break;
+			if (!click_handled && (curtime - last_b1down_click > 500)) {
+				if (touchui != nullptr && Combat::is_paused()
+					&& gwin->in_combat()) {
+					gwin->paused_combat_select(x, y);
+					break;
+				}
+				if (gwin->get_touch_pathfind() && avatar_can_act
+					&& gwin->main_actor_can_act_charmed() && !dragging
+					&& !gump_man->find_gump(x, y, false)) {
+					gwin->start_actor_along_path(
+							x, y, Mouse::mouse()->avatar_speed);
+					dragging = dragged = false;
+					break;
+				}
 			}
 
 			if (!click_handled && avatar_can_act && left_down_x - 1 <= x

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -790,9 +790,15 @@ void Game_window::toggle_combat() {
 			if (targ && targ->get_flag(Obj_flags::in_party)) {
 				act->set_target(nullptr);
 			}
+			if (touchui != nullptr && Combat::mode != Combat::original) {
+				touchui->showPauseControls();
+			}
 		}
 	} else {                 // Ending combat.
 		Combat::resume();    // Make sure not still paused.
+		if (touchui != nullptr && Combat::mode != Combat::original) {
+			touchui->hidePauseControls();
+		}
 	}
 	if (g_shortcutBar) {
 		g_shortcutBar->set_changed();

--- a/ios/GamePadView.m
+++ b/ios/GamePadView.m
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010, 2011, 2015  Chaoji Li
- * Copyright (C) 2016-2022 The Exult Team
+ * Copyright (C) 2016-2025 The Exult Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -38,13 +38,13 @@ const double gVJoyRadius = 80.0;    // max-radius of vjoy
 
 /** DPadView */
 @implementation DPadView
-@synthesize     backgroundImage;
-@synthesize     images;
-@synthesize     vjoyIsActive;       // true when the vjoy is active
-@synthesize     vjoyCenter;         // center of the vjoy
-@synthesize     vjoyCurrent;        // current position of the vjoy
-@synthesize     vjoyGamepad;        // the vjoy's SDL_Gamepad
-@synthesize     vjoyInputSource;    // where vjoy input is coming from
+@synthesize backgroundImage;
+@synthesize images;
+@synthesize vjoyIsActive;       // true when the vjoy is active
+@synthesize vjoyCenter;         // center of the vjoy
+@synthesize vjoyCurrent;        // current position of the vjoy
+@synthesize vjoyGamepad;        // the vjoy's SDL_Gamepad
+@synthesize vjoyInputSource;    // where vjoy input is coming from
 
 - (id)initWithFrame:(CGRect)frame {
 	self = [super initWithFrame:frame];
@@ -52,18 +52,20 @@ const double gVJoyRadius = 80.0;    // max-radius of vjoy
 		self.backgroundColor = [UIColor clearColor];
 		self.backgroundImage = [UIImage imageNamed:@"joythumb-glass.png"];
 
-		SDL_VirtualJoystickTouchpadDesc virtual_touchpad = { 1, { 0, 0, 0 } };
-		SDL_VirtualJoystickSensorDesc virtual_sensor = { SDL_SENSOR_ACCEL, 0.0f };
+		SDL_VirtualJoystickTouchpadDesc virtual_touchpad = {
+				1, {0, 0, 0}
+        };
+		SDL_VirtualJoystickSensorDesc virtual_sensor = {SDL_SENSOR_ACCEL, 0.0f};
 		SDL_VirtualJoystickDesc       desc;
 
 		SDL_INIT_INTERFACE(&desc);
-		desc.type       = SDL_JOYSTICK_TYPE_GAMEPAD;
-		desc.naxes      = SDL_GAMEPAD_AXIS_COUNT;
-		desc.nbuttons   = SDL_GAMEPAD_BUTTON_COUNT;
-		desc.ntouchpads = 1;
-		desc.touchpads  = &virtual_touchpad;
-		desc.nsensors   = 1;
-		desc.sensors    = &virtual_sensor;
+		desc.type              = SDL_JOYSTICK_TYPE_GAMEPAD;
+		desc.naxes             = SDL_GAMEPAD_AXIS_COUNT;
+		desc.nbuttons          = SDL_GAMEPAD_BUTTON_COUNT;
+		desc.ntouchpads        = 1;
+		desc.touchpads         = &virtual_touchpad;
+		desc.nsensors          = 1;
+		desc.sensors           = &virtual_sensor;
 		SDL_JoystickID vjoy_id = SDL_AttachVirtualJoystick(&desc);
 		if (!vjoy_id) {
 			printf("SDL_AttachVirtualJoystick failed: %s\n", SDL_GetError());
@@ -113,11 +115,11 @@ const double gVJoyRadius = 80.0;    // max-radius of vjoy
 - (void)reset {
 	self.vjoyIsActive = false;
 	SDL_SetJoystickVirtualAxis(
-			SDL_GetGamepadJoystick(self.vjoyGamepad),
-			SDL_GAMEPAD_AXIS_LEFTX, 0);
+			SDL_GetGamepadJoystick(self.vjoyGamepad), SDL_GAMEPAD_AXIS_LEFTX,
+			0);
 	SDL_SetJoystickVirtualAxis(
-			SDL_GetGamepadJoystick(self.vjoyGamepad),
-			SDL_GAMEPAD_AXIS_LEFTY, 0);
+			SDL_GetGamepadJoystick(self.vjoyGamepad), SDL_GAMEPAD_AXIS_LEFTY,
+			0);
 	self.vjoyCenter = self.vjoyCurrent = CGPointMake(0, 0);
 	self.vjoyInputSource               = nil;
 	[self updateViewTransform];
@@ -230,13 +232,13 @@ const double gVJoyRadius = 80.0;    // max-radius of vjoy
 
 /** GamePadButton */
 @implementation GamePadButton
-@synthesize     pressed;
-@synthesize     keyCodes;
-@synthesize     style;
-@synthesize     title;
-@synthesize     images;
-@synthesize     textColor;
-@synthesize     delegate;
+@synthesize pressed;
+@synthesize keyCodes;
+@synthesize style;
+@synthesize title;
+@synthesize images;
+@synthesize textColor;
+@synthesize delegate;
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent*)event {
 	if (self.style == GamePadButtonStyleCircle) {

--- a/ios/GamePadView.m
+++ b/ios/GamePadView.m
@@ -300,12 +300,11 @@ const double gVJoyRadius = 80.0;    // max-radius of vjoy
 - (void)drawRect:(CGRect)rect {
 	NSUInteger bkgIndex;
 	UIColor*   color = nil;
+	color            = [self.textColor colorWithAlphaComponent:0.8];
 
 	if (!self.pressed) {
-		color    = [self.textColor colorWithAlphaComponent:0.3];
 		bkgIndex = 0;
 	} else {
-		color    = [self.textColor colorWithAlphaComponent:0.8];
 		bkgIndex = 1;
 	}
 

--- a/ios/include/ios_utils.h
+++ b/ios/include/ios_utils.h
@@ -31,6 +31,8 @@ public:
 	void hideGameControls() final;
 	void showButtonControls() final;
 	void hideButtonControls() final;
+	void showPauseControls() final;
+	void hidePauseControls() final;
 	void onDpadLocationChanged() final;
 };
 

--- a/touchui.h
+++ b/touchui.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015  Chaoji Li
- * Copyright (C) 2015-2022  The Exult Team
+ * Copyright (C) 2015-2025  The Exult Team
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -54,6 +54,8 @@ public:
 	virtual void hideGameControls()              = 0;
 	virtual void showButtonControls()            = 0;
 	virtual void hideButtonControls()            = 0;
+	virtual void showPauseControls()             = 0;
+	virtual void hidePauseControls()             = 0;
 	virtual void onDpadLocationChanged()         = 0;
 };
 


### PR DESCRIPTION
Android and iOS now have a button to pause combat, right next to the ESC button. When paused a long touch on a party member selects them so you can direct them at a target to attack (same as right click on the desktop).
Also fixed the issue on iOS that didn't properly switch the ESC button when the dpad screen location was changed to the left side. Additionally the dpad had no margin when on the left side.

Fixes #784 and #785
<img width="909" height="426" alt="image" src="https://github.com/user-attachments/assets/6dc55ff8-9773-4185-90bb-beed3c69f257" />
