### PR TITLE
waiter and tend_shop schedules will interrupt if a bell is rung.

### DIFF
--- a/objs/objs.cc
+++ b/objs/objs.cc
@@ -68,6 +68,9 @@ using std::ostream;
 using std::rand;
 using std::string;
 
+// Global flag for desk-bell activation
+Game_object_weak bell_just_rung;
+
 /*
  *  Determines the object's usecode function.
  */
@@ -1003,6 +1006,11 @@ void Game_object::activate(int event) {
 		gumpman->add_gump(this, gump);
 		return;
 	}
+
+	if (get_shapenum() == 675 && get_framenum() == 20) {
+		bell_just_rung = weak_from_this();
+	}
+
 	ucmachine->call_usecode(
 			get_usecode(), this,
 			static_cast<Usecode_machine::Usecode_events>(event));

--- a/objs/objs.h
+++ b/objs/objs.h
@@ -659,4 +659,6 @@ public:
 	void write_ifix(ODataSource* ifix, bool v2) override;
 };
 
+extern Game_object_weak bell_just_rung;
+
 #endif

--- a/schedule.h
+++ b/schedule.h
@@ -43,15 +43,29 @@ using Game_object_vector = std::vector<Game_object*>;
  */
 class Schedule : public Game_singletons {
 protected:
-	Actor*     npc;                            // Who this controls.
-	Tile_coord blocked;                        // Tile where actor was blocked.
-	Tile_coord start_pos;                      // When schedule created.
-	short      prev_type;                      // Actor's previous schedule.
-	int        street_maintenance_failures;    // # times failed to find path.
-	long       street_maintenance_time;        // Time (msecs) when last tried.
+	Actor*     npc;                             // Who this controls.
+	Tile_coord blocked;                         // Tile where actor was blocked.
+	Tile_coord start_pos;                       // When schedule created.
+	short      prev_type;                       // Actor's previous schedule.
+	int        street_maintenance_failures;     // # times failed to find path.
+	long       street_maintenance_time;         // Time (msecs) when last tried.
+	bool       interrupted_for_bell = false;    // Currently responding to bell.
+	Tile_coord pre_interrupt_pos;    // Position before bell interrupt.
+
+	// Handle the bell interrupt state machine. Returns true if still
+	// interrupted.
+	bool handle_bell_interrupt();
+
 public:
 	Schedule(Actor* n);
 	virtual ~Schedule() = default;
+
+	bool is_interrupted_for_bell() const {
+		return interrupted_for_bell;
+	}
+
+	// Check and handle bell rings (called from now_what()).
+	virtual bool try_respond_to_bell(int max_distance = 20);
 
 	int get_prev_type() const {
 		return prev_type;
@@ -358,6 +372,7 @@ protected:
 	Tile_coord center;    // Center of rectangle.
 	int        dist;      // Distance in tiles to roam in each
 						  //   dir.
+
 public:
 	Loiter_schedule(Actor* n, int d = 12);
 	void now_what() override;    // Now what should NPC do?


### PR DESCRIPTION
NPCs will go to the bell, wait a bit and then return to their previous spot and continue. Can be adapted for other schedules but the games only has a few bells on the counter, some in shops, one in a tavern.

@wench @marzojr @Dragon-Baroque let me know if I should add this. It's not an original feature but was a feature request quite a while ago https://sourceforge.net/p/exult/feature-requests/195/. I think it makes sense but it's a bit of code on top for a bit silly feature :)