### PR TITLE
Fix new game

### DIFF
--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -2740,8 +2740,8 @@ int ExultStudio::prompt(
 	GList*     toplevels = gtk_window_list_toplevels();
 	for (GList* l = toplevels; l != nullptr; l = l->next) {
 		GtkWindow* win = GTK_WINDOW(l->data);
-		// Don't use the dialog itself as parent, and check for focus
-		if (win != GTK_WINDOW(dlg) && gtk_window_has_toplevel_focus(win)) {
+		// Don't use the dialog itself as parent, and check for active window
+		if (win != GTK_WINDOW(dlg) && gtk_window_is_active(win)) {
 			parent = win;
 			break;
 		}


### PR DESCRIPTION
Creating a new game hung:
- Config is written to disk before loading the game
- GTK events are processed after `set_game_path()`
- Shape info files are checked for existence before trying to read them (preventing the hang for new games)
- Server connection is checked before sending reload messages
- Transient parent dialog check prevents GTK warnings

Also using `gtk_window_is_active()` instead of `gtk_window_has_toplevel_focus()` for compatibility with GTK4 porting