### PR TITLE
Allow setting z for schedules.

### DIFF
--- a/actors.cc
+++ b/actors.cc
@@ -5207,7 +5207,7 @@ void Npc_actor::set_schedule_time_type(int time, int type) {
  *  Set schedule location.
  */
 
-void Npc_actor::set_schedule_time_location(int time, int x, int y) {
+void Npc_actor::set_schedule_time_location(int time, int x, int y, int z) {
 	int i;
 
 	for (i = 0; i < num_schedules; i++) {
@@ -5227,11 +5227,11 @@ void Npc_actor::set_schedule_time_location(int time, int x, int y) {
 					schedules[i].get_time());
 		}
 
-		scheds[num_schedules].set(x, y, 0, 0, static_cast<unsigned char>(time));
+		scheds[num_schedules].set(x, y, z, 0, static_cast<unsigned char>(time));
 		set_schedules(scheds, num_schedules + 1);
 	} else {    // Did find it
 		schedules[i].set(
-				x, y, 0, schedules[i].get_type(),
+				x, y, z, schedules[i].get_type(),
 				static_cast<unsigned char>(time));
 	}
 }

--- a/actors.h
+++ b/actors.h
@@ -816,8 +816,8 @@ public:
 		ignore_unused_variable_warning(time, type);
 	}
 
-	virtual void set_schedule_time_location(int time, int x, int y) {
-		ignore_unused_variable_warning(time, x, y);
+	virtual void set_schedule_time_location(int time, int x, int y, int z = 0) {
+		ignore_unused_variable_warning(time, x, y, z);
 	}
 
 	virtual void remove_schedule(int time) {
@@ -921,7 +921,7 @@ public:
 	// Set schedule list.
 	void set_schedules(Schedule_change* list, int cnt) override;
 	void set_schedule_time_type(int time, int type) override;
-	void set_schedule_time_location(int time, int x, int y) override;
+	void set_schedule_time_location(int time, int x, int y, int z = 0) override;
 	void remove_schedule(int time) override;
 	void get_schedules(Schedule_change*& list, int& cnt) const override;
 	// Move and change frame.

--- a/usecode/intrinsics.cc
+++ b/usecode/intrinsics.cc
@@ -3434,7 +3434,8 @@ USECODE_INTRINSIC(run_schedule) {
 
 USECODE_INTRINSIC(modify_schedule) {
 	ignore_unused_variable_warning(num_parms);
-	// modify_schedule ( npc, time, activity, [x, y] )
+	// modify_schedule ( npc, time, activity, [x, y] ) or
+	// modify_schedule ( npc, time, activity, [x, y, z] )
 
 	Actor* actor = as_actor(get_item(parms[0]));
 
@@ -3447,9 +3448,13 @@ USECODE_INTRINSIC(modify_schedule) {
 	const int sched = parms[2].get_int_value();
 	const int tx    = parms[3].get_elem(0).get_int_value();
 	const int ty    = parms[3].get_elem(1).get_int_value();
+	// Optional z coordinate (defaults to 0 for backward compatibility).
+	const int tz = (parms[3].get_array_size() >= 3)
+						   ? parms[3].get_elem(2).get_int_value()
+						   : 0;
 
 	actor->set_schedule_time_type(time, sched);
-	actor->set_schedule_time_location(time, tx, ty);
+	actor->set_schedule_time_location(time, tx, ty, tz);
 
 	return no_ret;
 }


### PR DESCRIPTION
For fullfilling @KnightCaptainU7 feature request in #638 this code allows an optional z position value. As this is optional, it shouldn't break existing usecode, and neither existing schedules as z=0 is the default. I've only done limited testing. I presume that NPCs won't actually climb stairs and rather teleport :(
(most likely there are a lot of other factors to think of that I haven't yet though of)

Again, @marzojr it would be great if you could review this and say nay or aye :)