### PR TITLE
Ctrl-doubleclick opens basic properties in Exult Studio

### DIFF
--- a/actors.cc
+++ b/actors.cc
@@ -2278,6 +2278,10 @@ bool Actor::figure_weapon_pos(
  *  Run usecode when double-clicked.
  */
 void Actor::activate(int event) {
+	// If event==2, open basic properties instead of NPC editor
+	if (event == 2 && edit_basic_properties()) {
+		return;
+	}
 	if (edit()) {
 		return;
 	}
@@ -2362,6 +2366,12 @@ bool Actor::edit() {
 	}
 #endif
 	return false;
+}
+
+bool Actor::edit_basic_properties() {
+	// Call the base Game_object::edit() to open basic properties
+	// instead of the Actor-specific editor
+	return Game_object::edit();
 }
 
 /*
@@ -4194,10 +4204,9 @@ int Actor::figure_hit_points(
 	if (explodes && !explosion) {    // Explosions shouldn't explode again.
 									 // Time to explode.
 		const Tile_coord offset(0, 0, get_info().get_3d_height() / 2);
-		eman->add_effect(
-				std::make_unique<Explosion_effect>(
-						get_tile() + offset, nullptr, 0, weapon_shape,
-						ammo_shape, attacker));
+		eman->add_effect(std::make_unique<Explosion_effect>(
+				get_tile() + offset, nullptr, 0, weapon_shape, ammo_shape,
+				attacker));
 		// The explosion will handle the damage.
 		return -1;
 	}

--- a/actors.h
+++ b/actors.h
@@ -508,7 +508,8 @@ public:
 	void paint() override;
 	// Run usecode function.
 	void activate(int event = 1) override;
-	bool edit() override;    // Edit in ExultStudio.
+	bool edit() override;            // Edit in ExultStudio.
+	bool edit_basic_properties();    // Edit basic properties in ExultStudio.
 	// Saved from ExultStudio.
 	static void update_from_studio(unsigned char* data, int datalen);
 	// Drop another onto this.

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -2498,7 +2498,9 @@ void Game_window::double_clicked(
 	cout << "Object name is " << obj->get_name() << endl;
 #endif
 	usecode->init_conversation();
-	obj->activate();
+	// Check if CTRL is pressed to open basic properties instead
+	const bool ctrl_pressed = (SDL_GetModState() & SDL_KMOD_CTRL) != 0;
+	obj->activate(ctrl_pressed ? 2 : 1);
 	npc_prox->wait(4);    // Delay "barking" for 4 secs.
 }
 
@@ -2989,7 +2991,8 @@ void Game_window::setup_game(bool map_editing) {
 	}
 	// During the first scene do not show the UI elements,
 	// unless the Avatar is free to move (possibly in mods).
-	if ((GAME_BG && !usecode->get_global_flag_bool(Usecode_machine::did_first_scene))
+	if ((GAME_BG
+		 && !usecode->get_global_flag_bool(Usecode_machine::did_first_scene))
 		|| (GAME_SI
 			&& !usecode->get_global_flag_bool(
 					Usecode_machine::si_did_first_scene))
@@ -3261,10 +3264,9 @@ bool Game_window::is_hostile_nearby() const {
 }
 
 bool Game_window::failed_copy_protection() {
-	const bool confused = main_actor->get_flag(Obj_flags::confused);
-	const bool failureFlag
-			= usecode->get_global_flag_bool(
-							 Usecode_machine::failed_copy_protect);
+	const bool confused    = main_actor->get_flag(Obj_flags::confused);
+	const bool failureFlag = usecode->get_global_flag_bool(
+			Usecode_machine::failed_copy_protect);
 	return (GAME_SI && confused) || (GAME_BG && failureFlag);
 }
 

--- a/objs/barge.cc
+++ b/objs/barge.cc
@@ -761,9 +761,13 @@ void Barge_object::paint() {
  *  Edit in ExultStudio.
  */
 
-void Barge_object::activate(int /* event */
-) {
-	edit();
+void Barge_object::activate(int event) {
+	// If event==2, open basic properties instead of barge editor
+	if (event == 2) {
+		edit_basic_properties();
+	} else {
+		edit();
+	}
 }
 
 /*
@@ -791,6 +795,12 @@ bool Barge_object::edit() {
 	}
 #endif
 	return false;
+}
+
+bool Barge_object::edit_basic_properties() {
+	// Call the base Game_object::edit() to open basic properties
+	// instead of the Barge-specific editor
+	return Game_object::edit();
 }
 
 /*

--- a/objs/barge.h
+++ b/objs/barge.h
@@ -135,7 +135,8 @@ public:
 	// Render.
 	void paint() override;
 	void activate(int event = 1) override;
-	bool edit() override;    // Edit in ExultStudio.
+	bool edit() override;            // Edit in ExultStudio.
+	bool edit_basic_properties();    // Edit basic properties in ExultStudio.
 	// Saved from ExultStudio.
 	static void update_from_studio(unsigned char* data, int datalen);
 	// Step onto an (adjacent) tile.

--- a/objs/contain.cc
+++ b/objs/contain.cc
@@ -456,6 +456,10 @@ bool Container_game_object::show_gump(int event) {
  */
 
 void Container_game_object::activate(int event) {
+	// If event==2, open basic properties instead of container editor
+	if (event == 2 && edit_basic_properties()) {
+		return;
+	}
 	if (edit()) {
 		return;    // Map-editing.
 	}
@@ -493,6 +497,12 @@ bool Container_game_object::edit() {
 	}
 #endif
 	return false;
+}
+
+bool Container_game_object::edit_basic_properties() {
+	// Call the base Game_object::edit() to open basic properties
+	// instead of the Container-specific editor
+	return Game_object::edit();
 }
 
 /*

--- a/objs/contain.h
+++ b/objs/contain.h
@@ -119,7 +119,8 @@ public:
 	bool         show_gump(int event = 1);
 	// Run usecode function.
 	void activate(int event = 1) override;
-	bool edit() override;    // Edit in ExultStudio.
+	bool edit() override;            // Edit in ExultStudio.
+	bool edit_basic_properties();    // Edit basic properties in ExultStudio.
 	// Saved from ExultStudio.
 	static void update_from_studio(unsigned char* data, int datalen);
 	int         get_weight() override;

--- a/objs/egg.cc
+++ b/objs/egg.cc
@@ -1194,8 +1194,11 @@ void Egg_object::paint() {
  *  Run usecode when double-clicked.
  */
 
-void Egg_object::activate(int /* event */
-) {
+void Egg_object::activate(int event) {
+	// If event==2, open basic properties instead of egg editor
+	if (event == 2 && edit_basic_properties()) {
+		return;
+	}
 	if (!edit()) {
 		hatch(nullptr, false);
 	}
@@ -1235,6 +1238,12 @@ bool Egg_object::edit() {
 	}
 #endif
 	return false;
+}
+
+bool Egg_object::edit_basic_properties() {
+	// Call the base Game_object::edit() to open basic properties
+	// instead of the Egg-specific editor
+	return Game_object::edit();
 }
 
 /*

--- a/objs/egg.h
+++ b/objs/egg.h
@@ -198,7 +198,8 @@ public:
 	void paint() override;
 	// Run usecode function.
 	void activate(int event = 1) override;
-	bool edit() override;    // Edit in ExultStudio.
+	bool edit() override;            // Edit in ExultStudio.
+	bool edit_basic_properties();    // Edit basic properties in ExultStudio.
 	// Saved from ExultStudio.
 	static void update_from_studio(unsigned char* data, int datalen);
 


### PR DESCRIPTION
When in map edit mode, ctrl-doubleclick on NPCs, eggs, barges and container open the basic Exult Studio properties, instead of their editor.