### PR TITLE
Fixed timing problem with paused animations 

### DIFF
--- a/tqueue.cc
+++ b/tqueue.cc
@@ -1,7 +1,7 @@
 /*
  *  tqueue.cc - A queue of time-based events for animation.
  *
- *  Copyright (C) 2000-2022  The Exult Team
+ *  Copyright (C) 2000-2026  The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -62,11 +62,12 @@ void Time_queue::add(
 		uint32 t, std::shared_ptr<Time_sensitive> obj, uintptr ud) {
 	obj->queue_cnt++;    // It's going in, no matter what.
 	Queue_entry newent;
-	uint32 added_pause_time = 0;
+	uint32      added_pause_time = 0;
 	if (paused && !obj->always) {    // Paused?
 		// Messy, but we need to fix time.
 		t -= SDL_GetTicks() - pause_time;
-		added_pause_time = pause_time;  // Track which pause cycle this belongs to
+		added_pause_time
+				= pause_time;    // Track which pause cycle this belongs to
 	}
 	newent.set(t, nullptr, ud, obj, added_pause_time);
 	auto insertionPoint = std::upper_bound(data.begin(), data.end(), newent);
@@ -80,11 +81,12 @@ void Time_queue::add(
 ) {
 	obj->queue_cnt++;    // It's going in, no matter what.
 	Queue_entry newent;
-	uint32 added_pause_time = 0;
+	uint32      added_pause_time = 0;
 	if (paused && !obj->always) {    // Paused?
 		// Messy, but we need to fix time.
 		t -= SDL_GetTicks() - pause_time;
-		added_pause_time = pause_time;  // Track which pause cycle this belongs to
+		added_pause_time
+				= pause_time;    // Track which pause cycle this belongs to
 	}
 	newent.set(t, obj, ud, nullptr, added_pause_time);
 	auto insertionPoint = std::upper_bound(data.begin(), data.end(), newent);
@@ -297,9 +299,9 @@ void Time_queue::resume(uint32 curtime) {
 	if (paused == 0 || --paused > 0) {    // Only unpause when stack empty.
 		return;                           // Not paused.
 	}
-	const int diff = curtime - pause_time;
-	const uint32 current_pause_time = pause_time;  // Save before clearing
-	pause_time     = 0;
+	const int    diff               = curtime - pause_time;
+	const uint32 current_pause_time = pause_time;    // Save before clearing
+	pause_time                      = 0;
 	if (diff < 0) {    // Should not happen.
 		return;
 	}
@@ -307,8 +309,8 @@ void Time_queue::resume(uint32 curtime) {
 	for (auto& it : data) {
 		Time_sensitive* obj = it.handler ? it.handler : it.sp_handler.get();
 		if (obj && !obj->always && it.pause_added == current_pause_time) {
-			it.time += diff;    // Push entries ahead.
-			it.pause_added = 0; // Mark as adjusted
+			it.time += diff;       // Push entries ahead.
+			it.pause_added = 0;    // Mark as adjusted
 		}
 	}
 }

--- a/tqueue.h
+++ b/tqueue.h
@@ -1,7 +1,7 @@
 /*
  *  tqueue.h - A queue of time-based events for animation.
  *
- *  Copyright (C) 2000-2022 The Exult Team
+ *  Copyright (C) 2000-2026 The Exult Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -66,15 +66,16 @@ struct Queue_entry {
 			sp_handler;    // Shared pointer to object to activate
 	uintptr udata;         // Data to pass to handler.
 	uint32  time;          // Time when this is due.
-	uint32  pause_added = 0;  // pause_time when this was added (0 if not paused)
+	uint32  pause_added
+			= 0;    // pause_time when this was added (0 if not paused)
 
 	inline void set(
 			uint32 t, Time_sensitive* h, uintptr ud,
 			std::shared_ptr<Time_sensitive> sp, uint32 pause_t = 0) {
-		time       = t;
-		handler    = h;
-		udata      = ud;
-		sp_handler = sp;
+		time        = t;
+		handler     = h;
+		udata       = ud;
+		sp_handler  = sp;
 		pause_added = pause_t;
 	}
 };


### PR DESCRIPTION
In usecode cutscenes with…many conversations each pause/resume stacked resulting in the animation happening much later after really resuming the game.

Fixes #878 wave animations