### PR TITLE
CI: clang format check (informational only)

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -13,6 +13,5 @@ jobs:
       - name: Clang-Format
         uses: jidicula/clang-format-action@v4.16.0
         with:
-          fallback-style: file
           clang-format-version: 19
         continue-on-error: true


### PR DESCRIPTION
Does a dry run of clang-format on *.cc and *.h files.

Relates to #906 