### PR TITLE
SI Fixes Ophidian Plaque Quality 149 Fix

### DIFF
--- a/content/sifixes/src/items/plaque_ophidian.uc
+++ b/content/sifixes/src/items/plaque_ophidian.uc
@@ -1,0 +1,41 @@
+/*
+ *
+ *  Copyright (C) 2026  The Exult Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+/*  
+ *  2026-03-15 One of the Ophidian plaques in the original shows the spelling
+ *  error "CHOAS AND ORDER". This changes just that one plaque.
+ */
+
+void shapeOphidianPlaque shape#(0x2C5) ()
+{
+	var quality;
+	var show_text;
+
+	quality = UI_get_item_quality(item);
+
+	// Error in the release: "CHOAS AND ORDER"
+	if (quality == 149)
+	{
+		show_text = ["PLACE HERE", "THE CUBES", "OF BOTH", "CHAOS AND ORDER"];
+		UI_display_runes(49, show_text);
+	}
+
+	else {
+		shapeOphidianPlaque.original();	}
+}

--- a/content/sifixes/src/usecode.uc
+++ b/content/sifixes/src/usecode.uc
@@ -139,6 +139,8 @@
 #include "items/hourglass.uc"
 // Fixes the missing face for Smith in the Dream Realm.
 #include "items/nightmare.uc"
+// Fixes a spelling error "Choas" -> "Chaos"
+#include "items/plaque_ophidian.uc"
 // Can no longer get to Test of Purity from SS
 #include "items/pillar.uc"
 // Iolo, Shamino and Dupre refuse blue potions in Spinebreaker mountains


### PR DESCRIPTION
There's a minor spelling error "choas" on Ophidian plaque quality 149. This fix corrects the spelling.

<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/7c700d5e-7f61-44fe-a380-96de6e5f1877" />

<img width="802" height="321" alt="image" src="https://github.com/user-attachments/assets/96be38d9-7aeb-4bc5-832f-745be363aec0" />

Testing:
Start a new game.
Teleport to Sunrise Isle's antechamber south of the black Serpent Statue (or create shape 709 on the map and set quality to 149).
Set "Read" on the Avatar's NPC property (F2 -> N -> 0 -> N -> ⬆️ -> 34 -> S -> Escape out of the menu).
Double-click the plaque on the pedestal.