### PR TITLE
Restrict Dynamic_container_gump to shapes with snap zones configured

### DIFF
--- a/gumps/Dynamic_container_gump.cc
+++ b/gumps/Dynamic_container_gump.cc
@@ -479,5 +479,6 @@ void Dynamic_container_gump::paint() {
 
 bool Dynamic_container_gump::has_config(int shapenum) {
 	const Gump_info* info = Gump_info::get_gump_info(shapenum);
-	return info && info->has_area;
+	// Only use Dynamic_container_gump when snap zones are configured
+	return info && info->has_area && info->has_snap_zones();
 }

--- a/gumps/Gump_manager.cc
+++ b/gumps/Gump_manager.cc
@@ -49,7 +49,7 @@
 #include "touchui.h"
 #include "ucmachine.h"
 
-#include <iostream>    // debug by tgw - to be removed when dynamic gumps working
+#include <iostream>
 
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
@@ -327,7 +327,6 @@ void Gump_manager::add_gump(
 		if (!new_gump && obj->as_container()) {
 			// Check if this gump shape has container_area in gump_info.txt
 			if (Dynamic_container_gump::has_config(shapenum)) {
-				std::cerr << "[GumpManager] Using Dynamic_container_gump for shape " << shapenum << std::endl;
 				new_gump = new Dynamic_container_gump(obj->as_container(), x, y, shapenum);
 			} else {
 				new_gump = new Container_gump(obj->as_container(), x, y, shapenum);


### PR DESCRIPTION
Only use Dynamic_container_gump when the gump info has both an area and snap zones configured, preventing unintended fallback to dynamic layout for shapes that lack snap zone data. Also removes leftover debug output.