### PR TITLE
Smooth scrolling fixes

### DIFF
--- a/exult.cc
+++ b/exult.cc
@@ -41,6 +41,7 @@
 #include "VideoOptions_gump.h"
 #include "actors.h"
 #include "args.h"
+#include "barge.h"
 #include "cheat.h"
 #include "combat_opts.h"
 #include "crc.h"
@@ -1335,6 +1336,14 @@ static void Handle_events() {
 	 */
 	int last_x = -1;
 	int last_y = -1;
+	// Interpolation duration (ms) for the current smooth-scroll
+	// segment. Captured when the scroll actually changes so the glide always
+	// runs at the speed of the step that produced it.
+	int lerp_mswait = 0;
+	// True once the final catch-up glide has been shortened after the camera
+	// actor stopped (see the stop-skate handling below). Reset on each new
+	// step so it only ever fires once per stop.
+	bool lerp_stop_anchored = false;
 	while (!quitting_time) {
 #ifdef USE_EXULTSTUDIO
 		Server_delay();    // Handle requests.
@@ -1429,13 +1438,10 @@ static void Handle_events() {
 			gwin->get_gump_man()->update_gumps();
 		}
 
-		if (lerp && !gwin->get_moving_barge()) {
+		if (lerp) {
 			// Always repaint,
-			Actor* act    = gwin->get_camera_actor();
-			int    mswait = (act->get_frame_time() * lerp) / 100;
-			if (mswait <= 0) {
-				mswait = (gwin->get_std_delay() * lerp) / 100;
-			}
+			Actor*        act   = gwin->get_camera_actor();
+			Barge_object* barge = gwin->get_moving_barge();
 
 			// Force a reset if position changed
 			if (last_x != gwin->get_scrolltx() || last_y != gwin->get_scrollty()) {
@@ -1443,9 +1449,44 @@ static void Handle_events() {
 				// gwin->get_scrolltx(), last_y, gwin->get_scrollty());
 				gwin->lerp_reset();
 				last_repaint = ticks;
+				// A real step happened, so any pending stop-glide shortening no
+				// longer applies; allow it to fire again once we next stop.
+				lerp_stop_anchored = false;
+				const int ft = (barge && barge->contains(gwin->get_main_actor()))
+									   ? barge->get_frame_time()
+									   : act->get_frame_time();
+				if (ft > 0) {
+					lerp_mswait = (ft * lerp) / 100;
+				}
 			}
 			last_x = gwin->get_scrolltx();
 			last_y = gwin->get_scrollty();
+
+			int mswait = lerp_mswait;
+			if (mswait <= 0) {
+				mswait = (gwin->get_std_delay() * lerp) / 100;
+			}
+
+			// Shorten the final catch-up glide once the camera actor has
+			// stopped.
+			if (!lerp_stop_anchored && lerp_mswait > 0 && !gwin->is_moving()) {
+				const int stopwait = (gwin->get_std_delay() * lerp) / 100;
+				if (stopwait > 0 && stopwait < mswait) {
+					int factor = ((ticks - last_repaint) * 0x10000) / mswait;
+					if (factor < 0) {
+						factor = 0;
+					}
+					if (factor > 0x10000) {
+						factor = 0x10000;
+					}
+					// Pick last_repaint so the factor is unchanged right now but
+					// advances at the faster (stopwait) rate from here on.
+					last_repaint = ticks - (factor * stopwait) / 0x10000;
+					lerp_mswait  = stopwait;
+					mswait       = stopwait;
+				}
+				lerp_stop_anchored = true;
+			}
 
 			// Is lerping (smooth scrolling) enabled
 			if (mswait && ticks < (last_repaint + mswait * 2)) {

--- a/exult.cc
+++ b/exult.cc
@@ -1452,9 +1452,7 @@ static void Handle_events() {
 				// A real step happened, so any pending stop-glide shortening no
 				// longer applies; allow it to fire again once we next stop.
 				lerp_stop_anchored = false;
-				const int ft = (barge && barge->contains(gwin->get_main_actor()))
-									   ? barge->get_frame_time()
-									   : act->get_frame_time();
+				const int ft = (barge && barge->contains(gwin->get_main_actor())) ? barge->get_frame_time() : act->get_frame_time();
 				if (ft > 0) {
 					lerp_mswait = (ft * lerp) / 100;
 				}

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -643,11 +643,13 @@ void Game_window::set_moving_barge(Barge_object* b) {
 		if (!b->contains(main_actor)) {
 			b->set_to_gather();
 		}
+		landing_barge = nullptr;    // Boarding cancels any pending landing glide.
 	} else if (!b && moving_barge) {
 		moving_barge->done();    // No longer 'barging'.
 		// Smooth scroll: prevent jerkiness on offboarding, especially the flying carpet.
 		scrolltx_lp = scrolltx_l = scrolltx;
 		scrollty_lp = scrollty_l = scrollty;
+		landing_barge = moving_barge;
 	}
 	moving_barge = b;
 }
@@ -945,6 +947,7 @@ void Game_window::clear_world(bool restoremapedit) {
 	npcs.resize(0);    // NPC's already deleted above.
 	bodies.resize(0);
 	moving_barge       = nullptr;    // Get out of barge mode.
+	landing_barge      = nullptr;
 	special_light      = 0;          // Clear out light spells.
 	ambient_light      = false;      // And ambient lighting.
 	infravision_active = false;
@@ -1243,6 +1246,9 @@ void Game_window::get_shape_location(const Game_object* obj, int& x, int& y) {
 			apply_avpos = true;
 		} else if (actor && actor->is_in_party() && lerping_enabled) {
 			// Apply the same lerping offset to party members
+			apply_avpos = true;
+		} else if (landing_barge && lerping_enabled && landing_barge->is_grouped_member(obj)) {
+			// Keep party and barge in sync during landing.
 			apply_avpos = true;
 		}
 	}
@@ -1693,6 +1699,8 @@ void Game_window::start_actor_alt(
 		int winx, int winy,    // Mouse position to aim for.
 		int speed              // Msecs. between frames.
 ) {
+	// Avatar can move, don't sync the barge anymore.
+	landing_barge = nullptr;
 	int  ax;
 	int  ay;
 	bool blocked[8];
@@ -1919,7 +1927,8 @@ void Game_window::teleport_party(
 	const Tile_coord oldpos = main_actor->get_tile();
 	main_actor->set_action(nullptr);    // Definitely need this, or you may
 	//   step back to where you came from.
-	moving_barge = nullptr;    // Calling 'done()' could be risky...
+	moving_barge  = nullptr;    // Calling 'done()' could be risky...
+	landing_barge = nullptr;
 	int       i;
 	const int cnt = party_man->get_count();
 	if (!skip_eggs) {

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -1136,6 +1136,11 @@ void Game_window::set_camera_actor(Actor* a) {
  */
 
 bool Game_window::scroll_if_needed(Tile_coord t) {
+	if (suppress_barge_recenter) {
+		// Change lift of a barge without recentering the view,
+		// afterwards the next move recenters.
+		return false;
+	}
 	bool scrolled = false;
 	// 1 lift = 1/2 tile.
 	const int tx = DECR_TILE(t.tx, t.tz / 2);
@@ -1155,6 +1160,20 @@ bool Game_window::scroll_if_needed(Tile_coord t) {
 		scrolled = true;
 	}
 	return scrolled;
+}
+
+/*
+ *  Change lift of a barge without recentering the view.
+ */
+
+void Game_window::barge_lift_move(Game_object* obj, const Tile_coord& t) {
+	if (!obj->as_barge()) {
+		obj->move(t);
+		return;
+	}
+	suppress_barge_recenter = true;
+	obj->move(t);
+	suppress_barge_recenter = false;
 }
 
 /*

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -645,6 +645,9 @@ void Game_window::set_moving_barge(Barge_object* b) {
 		}
 	} else if (!b && moving_barge) {
 		moving_barge->done();    // No longer 'barging'.
+		// Smooth scroll: prevent jerkiness on offboarding, especially the flying carpet.
+		scrolltx_lp = scrolltx_l = scrolltx;
+		scrollty_lp = scrollty_l = scrollty;
 	}
 	moving_barge = b;
 }
@@ -1224,14 +1227,26 @@ inline void Get_shape_location(Tile_coord t, int scrolltx, int scrollty, int& x,
  */
 
 void Game_window::get_shape_location(const Game_object* obj, int& x, int& y) {
-	Get_shape_location(obj->get_tile(), scrolltx, scrollty, x, y);
-	// Smooth scroll the avatar as well, if possible
-	const Actor* actor = obj->as_actor();
-	if (obj == get_camera_actor()) {
-		x += avposx_ld;
-		y += avposy_ld;
-	} else if (actor && actor->is_in_party() && lerping_enabled) {
-		// Apply the same lerping offset to party members
+	const Tile_coord t = obj->get_tile();
+	Get_shape_location(t, scrolltx, scrollty, x, y);
+	bool apply_avpos = false;
+	// Smooth scroll barges but only if the Avatar is on board,
+	// otherwise the barge could be jerking during automatic boarding.
+	if (moving_barge && moving_barge->contains(get_main_actor())) {
+		if (moving_barge->is_grouped_member(obj)) {
+			apply_avpos = true;
+		}
+	} else {
+		// Smooth scroll the avatar
+		const Actor* actor = obj->as_actor();
+		if (obj == get_camera_actor()) {
+			apply_avpos = true;
+		} else if (actor && actor->is_in_party() && lerping_enabled) {
+			// Apply the same lerping offset to party members
+			apply_avpos = true;
+		}
+	}
+	if (apply_avpos) {
 		x += avposx_ld;
 		y += avposy_ld;
 	}

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -649,7 +649,7 @@ void Game_window::set_moving_barge(Barge_object* b) {
 		// Smooth scroll: prevent jerkiness on offboarding, especially the flying carpet.
 		scrolltx_lp = scrolltx_l = scrolltx;
 		scrollty_lp = scrollty_l = scrollty;
-		landing_barge = moving_barge;
+		landing_barge            = moving_barge;
 	}
 	moving_barge = b;
 }
@@ -948,8 +948,8 @@ void Game_window::clear_world(bool restoremapedit) {
 	bodies.resize(0);
 	moving_barge       = nullptr;    // Get out of barge mode.
 	landing_barge      = nullptr;
-	special_light      = 0;          // Clear out light spells.
-	ambient_light      = false;      // And ambient lighting.
+	special_light      = 0;        // Clear out light spells.
+	ambient_light      = false;    // And ambient lighting.
 	infravision_active = false;
 	effects->remove_all_effects(false);
 	Schedule_change::clear();

--- a/gamewin.h
+++ b/gamewin.h
@@ -124,9 +124,9 @@ class Game_window {
 	int           theft_warnings;        // # times warned in current chunk.
 	short         theft_cx, theft_cy;    // Chunk where warnings occurred.
 	// Gameplay objects:
-	Barge_object*             moving_barge;    // ->cart/ship that's moving, or 0.
+	Barge_object* moving_barge;    // ->cart/ship that's moving, or 0.
 	// Track barge landing to keep party and barge moving in sync.
-	Barge_object*             landing_barge = nullptr;
+	Barge_object* landing_barge = nullptr;
 	// Don't recenter barge during lift off and landing.
 	bool                      suppress_barge_recenter = false;
 	Main_actor*               main_actor;      // Main sprite to move around.

--- a/gamewin.h
+++ b/gamewin.h
@@ -127,6 +127,8 @@ class Game_window {
 	Barge_object*             moving_barge;    // ->cart/ship that's moving, or 0.
 	// Track barge landing to keep party and barge moving in sync.
 	Barge_object*             landing_barge = nullptr;
+	// Don't recenter barge during lift off and landing.
+	bool                      suppress_barge_recenter = false;
 	Main_actor*               main_actor;      // Main sprite to move around.
 	Actor*                    camera_actor;    // What to center view around.
 	std::vector<Actor_shared> npcs;            // Array of NPC's + the Avatar.
@@ -471,6 +473,8 @@ public:
 	}
 
 	void set_moving_barge(Barge_object* b);
+	// Change lift of a barge without recentering the view.
+	void barge_lift_move(Game_object* obj, const Tile_coord& t);
 	bool is_moving() const;    // Is Avatar (or barge) moving?
 
 	inline Main_actor* get_main_actor() const {

--- a/gamewin.h
+++ b/gamewin.h
@@ -125,6 +125,8 @@ class Game_window {
 	short         theft_cx, theft_cy;    // Chunk where warnings occurred.
 	// Gameplay objects:
 	Barge_object*             moving_barge;    // ->cart/ship that's moving, or 0.
+	// Track barge landing to keep party and barge moving in sync.
+	Barge_object*             landing_barge = nullptr;
 	Main_actor*               main_actor;      // Main sprite to move around.
 	Actor*                    camera_actor;    // What to center view around.
 	std::vector<Actor_shared> npcs;            // Array of NPC's + the Avatar.

--- a/objs/barge.h
+++ b/objs/barge.h
@@ -74,6 +74,23 @@ public:
 		return frame_time > 0;
 	}
 
+	int get_frame_time() const {    // Time between steps, 0 if stopped.
+		return frame_time;
+	}
+
+	// Is obj part of this barge's gathered group (i.e. barge itself, its seats, cargo, etc.)?
+	bool is_grouped_member(const Game_object* obj) const {
+		if (obj == this) {
+			return true;
+		}
+		for (const auto& o : objects) {
+			if (o.get() == obj) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	int get_xtiles() const {    // Dims. in tiles.
 		return xtiles;
 	}

--- a/objs/chunks.cc
+++ b/objs/chunks.cc
@@ -30,6 +30,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "actors.h"
 #include "animate.h"
+#include "barge.h"
 #include "chunkter.h"
 #include "citerate.h"
 #include "databuf.h"
@@ -812,6 +813,41 @@ void Map_chunk::add_dependencies(
 						}
 						if (!would_cycle) {
 							cmp = new_asleep ? -1 : 1;
+						}
+					}
+				}
+			}
+		}
+		// Magic carpet dependencies compare.
+		Barge_object* const mbarge = gwin->get_moving_barge();
+		if (mbarge != nullptr && mbarge->get_lift() > 0) {
+			const bool new_member = mbarge->is_grouped_member(newobj);
+			const bool obj_member = mbarge->is_grouped_member(obj);
+			if (new_member != obj_member) {    // Exactly one rides the carpet.
+				const int deck = mbarge->get_lift();
+				const int pad = 2 * c_tilesize;
+				TileRect  a   = newinfo.area;
+				TileRect  r   = gwin->get_shape_rect(obj);
+				if (new_member) {
+					a.x -= pad;
+					a.y -= pad;
+					a.w += 2 * pad;
+					a.h += 2 * pad;
+				} else {
+					r.x -= pad;
+					r.y -= pad;
+					r.w += 2 * pad;
+					r.h += 2 * pad;
+				}
+				if (a.intersects(r)) {
+					if (new_member) {
+						const int objtop = obj->get_lift() + obj->get_info().get_3d_height() - 2;
+						if (objtop <= deck) {
+							cmp = 1;
+						}
+					} else {    // obj rides the carpet.
+						if (newinfo.ztop <= deck) {
+							cmp = -1;
 						}
 					}
 				}

--- a/objs/chunks.cc
+++ b/objs/chunks.cc
@@ -825,9 +825,9 @@ void Map_chunk::add_dependencies(
 			const bool obj_member = mbarge->is_grouped_member(obj);
 			if (new_member != obj_member) {    // Exactly one rides the carpet.
 				const int deck = mbarge->get_lift();
-				const int pad = 2 * c_tilesize;
-				TileRect  a   = newinfo.area;
-				TileRect  r   = gwin->get_shape_rect(obj);
+				const int pad  = 2 * c_tilesize;
+				TileRect  a    = newinfo.area;
+				TileRect  r    = gwin->get_shape_rect(obj);
 				if (new_member) {
 					a.x -= pad;
 					a.y -= pad;

--- a/usecode/ucsched.cc
+++ b/usecode/ucsched.cc
@@ -458,7 +458,7 @@ int Usecode_script::exec(
 			if (t.tz < 10) {
 				t.tz++;
 			}
-			optr->move(t);
+			gwin->barge_lift_move(optr.get(), t);
 			break;
 		}
 		case descend: {
@@ -466,7 +466,7 @@ int Usecode_script::exec(
 			if (t.tz > 0) {
 				t.tz--;
 			}
-			optr->move(t);
+			gwin->barge_lift_move(optr.get(), t);
 			break;
 		}
 		case frame:    // Set frame.


### PR DESCRIPTION
As I did eventually appreciate the smooth scrolling I thought of some more fixes for it:
- Stop walking sooner, to limit the ice skating look
- Allow smooth scrolling for when traveling on barges (and fix the carpet and sitting party going out of sync on smooth scrolling)

This made two more carpet changes necessary:
- magic carpet was not sorted over everything, so trees and ship sail masts were sometimes going through the carpet
- on lift off and landing the view recentered on the barge and made it look choppy

Things I cannot fix:
- Smooth scrolling at >= 75% and slow walking produces the terrible ice skating look. I tried adding an extra walk frame but that made it look worse in a different way.
- when moving barges vertically, horizontally and diagonally it looks good, but when you move horizontally and vertically with a slight offset so it's not a straight line, there is an extra little jerkiness as it adapts to the slight change on each (or some) tiles. This is a general barge traveling issue.