### PR TITLE
Auto-launch configured default mod

### DIFF
--- a/exult.cc
+++ b/exult.cc
@@ -550,7 +550,9 @@ int exult_main(const char* runpath) {
 		}
 		config->remove("config/gameplay/allow_double_right_move", false);
 	}
-
+	if (!config->key_exists("config/gameplay/default_mod")) {
+		config->set("config/gameplay/default_mod", "", true);
+	}
 	// Setup virtual directories
 	string data_path;
 	config->value("config/disk/data_path", data_path, EXULT_DATADIR);
@@ -918,7 +920,17 @@ static void Init() {
 					// Prints error messages:
 					newgame = basegame->get_mod(arg_modname);
 				} else {
-					newgame = basegame;
+					string default_mod;
+					config->value("config/gameplay/default_mod", default_mod, "");
+					if (!default_mod.empty()) {
+						ModInfo* mod = basegame->find_mod(default_mod);
+						if (mod && mod->is_mod_compatible()) {
+							newgame = mod;
+						}
+					}
+					if (!newgame) {
+						newgame = basegame;
+					}
 				}
 				arg_modname = "default";
 			} else {
@@ -976,6 +988,21 @@ static void Init() {
 			exit(error);
 		}
 #endif
+		// If no game was selected, try the configured default mod before the
+		// Exult menu.
+		if (!newgame) {
+			string default_mod;
+			config->value("config/gameplay/default_mod", default_mod, "");
+			if (!default_mod.empty()) {
+				for (auto& game : gamemanager->get_game_list()) {
+					ModInfo* mod = game.find_mod(default_mod);
+					if (mod && mod->is_mod_compatible()) {
+						newgame = mod;
+						break;
+					}
+				}
+			}
+		}
 		if (!newgame) {
 			ExultMenu exult_menu(gwin);
 			newgame = exult_menu.run();


### PR DESCRIPTION
- Add custom config/gameplay/default_mod key with an empty value when missing.

- If no game is selected by command line, use config/gameplay/default_mod to auto-launch the first configured game that contains a compatible mod with that exact name.

- If a game is selected by command line without --mod, launch that game's configured default mod when present and compatible; otherwise launch the selected base game.

