### PR TITLE
Render selected VGA fonts in fixed colors

### DIFF
--- a/gamemgr/bggame.cc
+++ b/gamemgr/bggame.cc
@@ -245,6 +245,10 @@ BG_Game::BG_Game() : shapes(ENDSHAPE_FLX, -1, PATCH_ENDSHAPE) {
 	fontManager.add_font("NORMAL_FONT", font_source, font_patch, 0, -1);
 	fontManager.add_font("SMALL_BLACK_FONT", font_source, font_patch, 2, 0);
 	fontManager.add_font("TINY_BLACK_FONT", font_source, font_patch, 4, 0);
+	Palette font_palette;
+	font_palette.load(PALETTES_FLX, PATCH_PALETTES, 0);
+	fontManager.get_font("TINY_BLACK_FONT")
+			->set_monochrome_color(font_palette.find_color(0, 0, 0));
 
 	if (font_config == "original" || font_config == "serif") {
 		fontManager.add_font("MENU_FONT", font_source, font_patch, 16, 1);

--- a/gamemgr/sigame.cc
+++ b/gamemgr/sigame.cc
@@ -218,6 +218,10 @@ SI_Game::SI_Game() {
 
 	fontManager.add_font("SMALL_BLACK_FONT", font_source, font_patch, 2, 0);
 	fontManager.add_font("TINY_BLACK_FONT", font_source, font_patch, 4, 0);
+	Palette font_palette;
+	font_palette.load(PALETTES_FLX, PATCH_PALETTES, 0);
+	fontManager.get_font("TINY_BLACK_FONT")
+			->set_monochrome_color(font_palette.find_color(0, 0, 0));
 
 	if (font_config == "original" || font_config == "serif") {
 		fontManager.add_font("MENU_FONT", font_source, font_patch, 17, 1);

--- a/shapes/font.cc
+++ b/shapes/font.cc
@@ -273,11 +273,7 @@ int Font::paint_text(
 
 				continue;
 			}
-			if (trans) {
-				shape->paint_rle_remapped(x, yoff, trans);
-			} else {
-				shape->paint_rle(x, yoff);
-			}
+			paint_shape(shape, x, yoff, trans);
 			x += shape->get_width() + hor_lead;
 		}
 	}
@@ -312,11 +308,7 @@ int Font::paint_text(
 
 				continue;
 			}
-			if (trans) {
-				shape->paint_rle_remapped(x, yoff, trans);
-			} else {
-				shape->paint_rle(x, yoff);
-			}
+			paint_shape(shape, x, yoff, trans);
 			x += shape->get_width() + hor_lead;
 		}
 	}
@@ -492,11 +484,7 @@ int Font::paint_text_fixedwidth(
 			continue;
 		}
 		x += w = (width - shape->get_width()) / 2;
-		if (trans) {
-			shape->paint_rle_remapped(x, yoff, trans);
-		} else {
-			shape->paint_rle(x, yoff);
-		}
+		paint_shape(shape, x, yoff, trans);
 		x += width - w;
 	}
 	return x - xoff;
@@ -532,11 +520,7 @@ int Font::paint_text_fixedwidth(
 			continue;
 		}
 		x += w = (width - shape->get_width()) / 2;
-		if (trans) {
-			shape->paint_rle_remapped(x, yoff, trans);
-		} else {
-			shape->paint_rle(x, yoff);
-		}
+		paint_shape(shape, x, yoff, trans);
 		x += width - w;
 	}
 	return x - xoff;
@@ -760,6 +744,22 @@ Font::Font(const File_spec& fname0, int index, int hlead, int vlead) {
 
 Font::Font(const File_spec& fname0, const File_spec& fname1, int index, int hlead, int vlead) {
 	load(fname0, fname1, index, hlead, vlead);
+}
+
+void Font::set_monochrome_color(int color) {
+	monochrome_color = color;
+	monochrome_xform.fill(static_cast<unsigned char>(color));
+}
+
+void Font::paint_shape(
+		Shape_frame* shape, int x, int y, unsigned char* trans) {
+	if (monochrome_color >= 0) {
+		shape->paint_rle_remapped(x, y, monochrome_xform.data());
+	} else if (trans) {
+		shape->paint_rle_remapped(x, y, trans);
+	} else {
+		shape->paint_rle(x, y);
+	}
 }
 
 void Font::clean_up() {

--- a/shapes/font.h
+++ b/shapes/font.h
@@ -21,10 +21,12 @@
 
 #include "hash_utils.h"
 
+#include <array>
 #include <memory>
 
 class Image_buffer8;
 class Shape_file;
+class Shape_frame;
 class IDataSource;
 struct File_spec;
 class U7multiobject;
@@ -54,10 +56,15 @@ private:
 	int                         ver_lead = 0;
 	std::unique_ptr<Shape_file> font_shapes;
 	int                         highest = 0, lowest = 0;
+	int                            monochrome_color = -1;
+	std::array<unsigned char, 256> monochrome_xform{};
 
 	void calc_highlow();
 	void clean_up();
 	int  load_internal(IDataSource& data, int hlead, int vlead);
+	void paint_shape(
+			Shape_frame* shape, int x, int y,
+			unsigned char* trans = nullptr);
 
 public:
 	Font();
@@ -85,6 +92,7 @@ public:
 	 *  @return 0 on success
 	 */
 	int load(const File_spec& fname0, const File_spec& fname1, int index, int hlead = 0, int vlead = 1);
+	void set_monochrome_color(int color);
 	// Text rendering:
 	int paint_text_box(
 			Image_buffer8* win, const char* text, int x, int y, int w, int h, int vert_lead = 0, bool pbreak = false,

--- a/shapes/fontvga.cc
+++ b/shapes/fontvga.cc
@@ -29,6 +29,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "fontvga.h"
 
 #include "Flex.h"
+#include "fnames.h"
+#include "palette.h"
 
 #include <array>
 
@@ -60,6 +62,19 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // +TODO: This shouldn't be hard-coded.
 constexpr static const std::array hlead{-2, -1, 0, -1, 0, 0, -1, -2, -1, -1};
 
+static int get_monochrome_color(size_t fontnum, const Palette& palette) {
+	switch (fontnum) {
+	case 3:
+		return palette.find_color(20, 20, 20);    // Dark gray.
+	case 4:
+		return palette.find_color(0, 0, 0);       // Black.
+	case 6:
+		return palette.find_color(40, 24, 8);     // Brown.
+	default:
+		return -1;
+	}
+}
+
 /*
  *  Default vertical leads, by fontnum.
  */
@@ -77,10 +92,16 @@ void Fonts_vga_file::init(
 	const size_t pn       = pfonts.number_of_objects();
 	const size_t numfonts = std::max(sn, pn);
 	fonts.resize(numfonts);
+	Palette palette;
+	palette.load(PALETTES_FLX, PATCH_PALETTES, 0);
 
 	for (size_t i = 0; i < numfonts; i++) {
 		const int vl
 				= (vlead_overrides && static_cast<int>(i) < num_overrides) ? vlead_overrides[i] : (i < vlead.size() ? vlead[i] : 0);
 		fonts[i] = std::make_shared<Font>(font_source, font_patch, i, i < hlead.size() ? hlead[i] : 0, vl);
+		const int color = get_monochrome_color(i, palette);
+		if (color >= 0) {
+			fonts[i]->set_monochrome_color(color);
+		}
 	}
 }


### PR DESCRIPTION
Add optional monochrome remapping to the Font renderer and apply it to fonts 3, 4, and 6 using dark gray, black, and brown palette matches. Also force the tiny black UI font to black in both Black Gate and Serpent Isle so anti-colored source pixels cannot reduce text readability.

