### PR TITLE
Add 15 and 20 FPS gameplay choices

### DIFF
--- a/gumps/GameEngineOptions_gump.cc
+++ b/gumps/GameEngineOptions_gump.cc
@@ -144,7 +144,7 @@ namespace {
 		}
 	};
 
-	std::array framerates{2, 4, 5, 6, 8, 10, -1};
+	std::array framerates{2, 4, 5, 6, 8, 10, 15, 20, -1};
 	// -1 is placeholder for custom framerate
 	constexpr const size_t num_default_rates = framerates.size() - 1;
 


### PR DESCRIPTION
Expose 15 FPS and 20 FPS in the Gameplay Options frame-rate selector. These custom higher game-speed values can now be selected and preserved through the normal options screen instead of requiring manual exult.cfg editing.

