### PR TITLE
Combat Speed Menu option

### DIFF
--- a/data/exultmsg.txt
+++ b/data/exultmsg.txt
@@ -296,6 +296,7 @@
 0x632:Cheats:
 0x633:Feeding:
 0x634:Enhancements:
+0x635:Combat Speed:
 
 #InputOptions_gump.cc
 0x640:Single

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -594,7 +594,15 @@ void Game_window::init_files(bool cycle) {
 	if (fps <= 0) {
 		fps = 5;
 	}
-	std_delay = 1000 / fps;    // Convert to msecs. between frames.
+	configured_std_delay = 1000 / fps;    // Convert to msecs. between frames.
+	std_delay            = configured_std_delay;
+
+	int combat_fps;
+	config->value("config/gameplay/combat/fps", combat_fps, 10);
+	if (combat_fps <= 0) {
+		combat_fps = 10;
+	}
+	configured_combat_std_delay = 1000 / combat_fps;
 }
 
 /*
@@ -742,6 +750,9 @@ long Game_window::check_time_stopped() {
 
 void Game_window::toggle_combat() {
 	combat = !combat;
+	// Combat mode is player-controlled.  Run it at the configured combat
+	// pacing, then restore the normal speed in peaceful mode.
+	std_delay = combat ? configured_combat_std_delay : configured_std_delay;
 	// Change party member's schedules.
 	int       newsched = combat ? Schedule::combat : Schedule::follow_avatar;
 	const int cnt      = party_man->get_count();
@@ -773,6 +784,9 @@ void Game_window::toggle_combat() {
 		for (int i = 0; i < cnt; i++) {
 			// Did Usecode set to flee?
 			Actor* act = all[i];
+			// Only clear script-forced flee.  Player-selected flee is the
+			// passive combat behavior and should remain sticky across
+			// combat toggles and save/load.
 			if (act->get_attack_mode() == Actor::flee && !act->did_user_set_attack()) {
 				act->set_attack_mode(Actor::nearest);
 			}
@@ -1539,6 +1553,8 @@ void Game_window::read_gwin() {
 	if (!gin.good()) {
 		combat = false;
 	}
+	// Restore the active frame delay to match the loaded combat state.
+	std_delay = combat ? configured_combat_std_delay : configured_std_delay;
 
 	infravision_active = gin.read1() == 1;
 	if (!gin.good()) {

--- a/gamewin.h
+++ b/gamewin.h
@@ -119,6 +119,8 @@ class Game_window {
 	unsigned int  in_dungeon;            // true if inside a dungeon.
 	int           num_npcs1;             // Number of type1 NPC's.
 	int           std_delay;             // Standard delay between frames.
+	int           configured_std_delay;  // User speed restored after combat.
+	int           configured_combat_std_delay;  // Combat speed from config.
 	long          time_stopped;          // For 'stop time' spell.
 	unsigned long special_light;         // Game minute when light spell ends.
 	int           theft_warnings;        // # times warned in current chunk.
@@ -547,7 +549,17 @@ public:
 	}
 
 	void set_std_delay(int msecs) {
-		std_delay = msecs;
+		configured_std_delay = msecs;
+		if (!combat) {
+			std_delay = msecs;
+		}
+	}
+
+	void set_combat_std_delay(int msecs) {
+		configured_combat_std_delay = msecs;
+		if (combat) {
+			std_delay = msecs;
+		}
 	}
 
 	Actor* get_npc(long npc_num) const;

--- a/gumps/GameEngineOptions_gump.cc
+++ b/gumps/GameEngineOptions_gump.cc
@@ -115,6 +115,10 @@ namespace {
 			return get_text_msg(0x62D - msg_file_start);
 		}
 
+		static auto CombatSpeed_() {
+			return get_text_msg(0x635 - msg_file_start);
+		}
+
 		static auto CombatShowHits_() {
 			return get_text_msg(0x62E - msg_file_start);
 		}
@@ -205,6 +209,10 @@ void GameEngineOptions_gump::build_buttons() {
 			this, &GameEngineOptions_gump::toggle_frames, frametext, frames, get_button_pos_for_label(Strings::Speed_()),
 			yForRow(++y_index), small_size);
 
+	buttons[id_combat_frames] = std::make_unique<GameEngineTextToggle>(
+			this, &GameEngineOptions_gump::toggle_combat_frames, combat_frametext, combat_frames,
+			get_button_pos_for_label(Strings::CombatSpeed_()), yForRow(++y_index), small_size);
+
 	buttons[id_show_hits] = std::make_unique<GameEngineTextToggle>(
 			this, &GameEngineOptions_gump::toggle_show_hits, yesNo, show_hits, get_button_pos_for_label(Strings::CombatShowHits_()),
 			yForRow(++y_index), small_size);
@@ -278,8 +286,10 @@ void GameEngineOptions_gump::load_settings() {
 	enhancements          = gwin->get_allow_enhancements();
 	gumps_pause           = !gumpman->gumps_dont_pause_game();
 	frames                = -1;
+	combat_frames         = -1;
 	size_t num_framerates = num_default_rates;
 	frametext.clear();
+	combat_frametext.clear();
 	// setting the framerate number to show by actually loading from config
 	int fps;
 	config->value("config/video/fps", fps, 5);
@@ -287,12 +297,22 @@ void GameEngineOptions_gump::load_settings() {
 	if (fps <= 0) {
 		fps = 5;    // default should be 5 frames
 	}
+	int combat_fps;
+	config->value("config/gameplay/combat/fps", combat_fps, 10);
+	if (combat_fps <= 0) {
+		combat_fps = 10;
+	}
 	// Now we want to populate the framerates vector and match our current text
 	// to the proper index
 	for (size_t i = 0; i < num_framerates; i++) {
-		frametext.emplace_back(framestring(framerates[i]));
+		const string rate = framestring(framerates[i]);
+		frametext.emplace_back(rate);
+		combat_frametext.emplace_back(rate);
 		if (framerates[i] == fps) {
 			frames = i;
+		}
+		if (framerates[i] == combat_fps) {
+			combat_frames = i;
 		}
 	}
 	feeding = int(cheat.GetFoodUse(true));
@@ -335,6 +355,9 @@ void GameEngineOptions_gump::save_settings() {
 	const int fps = framerates[frames];
 	gwin->set_std_delay(1000 / fps);
 	config->set("config/video/fps", fps, false);
+	const int combat_fps = framerates[combat_frames];
+	gwin->set_combat_std_delay(1000 / combat_fps);
+	config->set("config/gameplay/combat/fps", combat_fps, false);
 	cheat.set_enabled(cheats != 0);
 	cheat.SetFoodUse(Cheat::FoodUse(feeding), false);
 	gumpman->set_gumps_dont_pause_game(!gumps_pause);
@@ -355,6 +378,7 @@ void GameEngineOptions_gump::paint() {
 	font->paint_text(iwin->get_ib8(), Strings::Gumpspausegame_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::Alternativedraganddrop_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::Speed_(), x + label_margin, y + yForRow(++y_index) + 1);
+	font->paint_text(iwin->get_ib8(), Strings::CombatSpeed_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::CombatShowHits_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::CombatpausedwithSpace_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::CombatCharmedDifficulty_(), x + label_margin, y + yForRow(++y_index) + 1);

--- a/gumps/GameEngineOptions_gump.h
+++ b/gumps/GameEngineOptions_gump.h
@@ -33,7 +33,9 @@ private:
 	int                      gumps_pause;
 	bool                     alternate_drop;
 	int                      frames;
+	int                      combat_frames;
 	std::vector<std::string> frametext;
+	std::vector<std::string> combat_frametext;
 	int                      difficulty;
 	int                      show_hits;
 	int                      mode;
@@ -52,6 +54,7 @@ private:
 		id_gumps_pause,
 		id_alternate_drop,
 		id_frames,
+		id_combat_frames,
 		id_show_hits,
 		id_mode,
 		id_charmDiff,
@@ -95,6 +98,10 @@ public:
 
 	void toggle_frames(int state) {
 		frames = state;
+	}
+
+	void toggle_combat_frames(int state) {
+		combat_frames = state;
 	}
 
 	void toggle_difficulty(int state) {


### PR DESCRIPTION
Add a Combat Speed selector to Game Engine Options alongside the existing gameplay Speed choice, defaulting to 10 FPS. Track the user's configured gameplay delay separately from the configured combat delay; when combat is toggled on, the active frame delay switches to the configured combat rate, and reverts to the configured gameplay speed when combat ends. Also restore the correct delay when loading a save game.

Implemented against the current Strings::/get_button_pos_for_label()/yForRow() layout system rather than the old fixed colx[]/rowy[] arrays, adding a new "Combat Speed:" string (0x635) to data/exultmsg.txt.

Incidentally fixes a compile-breaking bug already present in the "Smooth actor movement between tile steps" commit, which referenced configured_std_delay/configured_combat_std_delay in gamewin.cc without ever declaring them in gamewin.h.

