### PR TITLE
QoL: show properties of Armor, Weapons, Ammo, Potions

### DIFF
--- a/actors.cc
+++ b/actors.cc
@@ -2441,7 +2441,37 @@ void Actor::update_from_studio(unsigned char* data, int datalen) {
 #endif
 }
 
+void Actor::consolidate_backpack_gold() {
+	Game_object* bp = get_readied(backpack);
+	if (!bp) {
+		return;
+	}
+	Container_game_object* cont = bp->as_container();
+	if (cont) {
+		cont->consolidate_gold(c_gold_coin_shapenum);
+	}
+}
+
+void Maybe_consolidate_backpack_gold(Container_game_object* cont) {
+	if (!cont) {
+		return;
+	}
+	Game_object* owner = cont->get_owner();
+	if (!owner) {
+		return;
+	}
+	Actor* act = owner->as_actor();
+	if (!act || !act->is_in_party()) {
+		return;
+	}
+	if (act->get_readied(backpack) != cont) {
+		return;
+	}
+	cont->consolidate_gold(c_gold_coin_shapenum);
+}
+
 void Actor::show_inventory() {
+	consolidate_backpack_gold();
 	Gump_manager* gump_man = gumpman;
 
 	const int shapenum = inventory_shapenum();

--- a/actors.h
+++ b/actors.h
@@ -809,6 +809,7 @@ public:
 
 	void show_inventory();
 	int  inventory_shapenum();
+	void consolidate_backpack_gold();
 
 	bool was_hit() {
 		return hit;
@@ -819,6 +820,9 @@ public:
 	bool in_usecode_control() const;
 	bool quake_on_walk();
 };
+
+// Consolidate gold if this is a party member's backpack.
+void Maybe_consolidate_backpack_gold(Container_game_object* cont);
 
 using Actor_shared = std::shared_ptr<Actor>;
 

--- a/data/exultmsg.txt
+++ b/data/exultmsg.txt
@@ -296,6 +296,7 @@
 0x632:Cheats:
 0x633:Feeding:
 0x634:Enhancements:
+0x635:Combat Speed:
 
 #InputOptions_gump.cc
 0x640:Single

--- a/data/exultmsg.txt
+++ b/data/exultmsg.txt
@@ -322,6 +322,8 @@
 0x654:Pickup
 0x655:Move to
 0x656:Do nothing
+0x657:Properties
+0x636:Show Item Properties:
 
 #Notebook_gump.cc
 0x658:Day

--- a/exult.cc
+++ b/exult.cc
@@ -550,7 +550,9 @@ int exult_main(const char* runpath) {
 		}
 		config->remove("config/gameplay/allow_double_right_move", false);
 	}
-
+	if (!config->key_exists("config/gameplay/default_mod")) {
+		config->set("config/gameplay/default_mod", "", true);
+	}
 	// Setup virtual directories
 	string data_path;
 	config->value("config/disk/data_path", data_path, EXULT_DATADIR);
@@ -918,7 +920,17 @@ static void Init() {
 					// Prints error messages:
 					newgame = basegame->get_mod(arg_modname);
 				} else {
-					newgame = basegame;
+					string default_mod;
+					config->value("config/gameplay/default_mod", default_mod, "");
+					if (!default_mod.empty()) {
+						ModInfo* mod = basegame->find_mod(default_mod);
+						if (mod && mod->is_mod_compatible()) {
+							newgame = mod;
+						}
+					}
+					if (!newgame) {
+						newgame = basegame;
+					}
 				}
 				arg_modname = "default";
 			} else {
@@ -976,6 +988,21 @@ static void Init() {
 			exit(error);
 		}
 #endif
+		// If no game was selected, try the configured default mod before the
+		// Exult menu.
+		if (!newgame) {
+			string default_mod;
+			config->value("config/gameplay/default_mod", default_mod, "");
+			if (!default_mod.empty()) {
+				for (auto& game : gamemanager->get_game_list()) {
+					ModInfo* mod = game.find_mod(default_mod);
+					if (mod && mod->is_mod_compatible()) {
+						newgame = mod;
+						break;
+					}
+				}
+			}
+		}
 		if (!newgame) {
 			ExultMenu exult_menu(gwin);
 			newgame = exult_menu.run();

--- a/exult_constants.h
+++ b/exult_constants.h
@@ -47,6 +47,9 @@ constexpr const int c_any_qual     = -359;
 constexpr const int c_any_framenum = -359;
 constexpr const int c_any_quantity = -359;
 
+// Gold coin shape # (same in BG and SI).
+constexpr const int c_gold_coin_shapenum = 644;
+
 // Maximum number of shapes:
 constexpr const int c_max_shapes = 2048;
 constexpr const int c_occsize    = c_max_shapes / 8 + ((c_max_shapes % 8) != 0 ? 1 : 0);

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -594,7 +594,15 @@ void Game_window::init_files(bool cycle) {
 	if (fps <= 0) {
 		fps = 5;
 	}
-	std_delay = 1000 / fps;    // Convert to msecs. between frames.
+	configured_std_delay = 1000 / fps;    // Convert to msecs. between frames.
+	std_delay            = configured_std_delay;
+
+	int combat_fps;
+	config->value("config/gameplay/combat/fps", combat_fps, 10);
+	if (combat_fps <= 0) {
+		combat_fps = 10;
+	}
+	configured_combat_std_delay = 1000 / combat_fps;
 }
 
 /*
@@ -742,6 +750,9 @@ long Game_window::check_time_stopped() {
 
 void Game_window::toggle_combat() {
 	combat = !combat;
+	// Combat mode is player-controlled.  Run it at the configured combat
+	// pacing, then restore the normal speed in peaceful mode.
+	std_delay = combat ? configured_combat_std_delay : configured_std_delay;
 	// Change party member's schedules.
 	int       newsched = combat ? Schedule::combat : Schedule::follow_avatar;
 	const int cnt      = party_man->get_count();
@@ -773,6 +784,9 @@ void Game_window::toggle_combat() {
 		for (int i = 0; i < cnt; i++) {
 			// Did Usecode set to flee?
 			Actor* act = all[i];
+			// Only clear script-forced flee.  Player-selected flee is the
+			// passive combat behavior and should remain sticky across
+			// combat toggles and save/load.
 			if (act->get_attack_mode() == Actor::flee && !act->did_user_set_attack()) {
 				act->set_attack_mode(Actor::nearest);
 			}
@@ -1539,6 +1553,8 @@ void Game_window::read_gwin() {
 	if (!gin.good()) {
 		combat = false;
 	}
+	// Restore the active frame delay to match the loaded combat state.
+	std_delay = combat ? configured_combat_std_delay : configured_std_delay;
 
 	infravision_active = gin.read1() == 1;
 	if (!gin.good()) {

--- a/gamewin.h
+++ b/gamewin.h
@@ -119,6 +119,8 @@ class Game_window {
 	unsigned int  in_dungeon;            // true if inside a dungeon.
 	int           num_npcs1;             // Number of type1 NPC's.
 	int           std_delay;             // Standard delay between frames.
+	int           configured_std_delay;  // User speed restored after combat.
+	int           configured_combat_std_delay;  // Combat speed from config.
 	long          time_stopped;          // For 'stop time' spell.
 	unsigned long special_light;         // Game minute when light spell ends.
 	int           theft_warnings;        // # times warned in current chunk.
@@ -547,7 +549,17 @@ public:
 	}
 
 	void set_std_delay(int msecs) {
-		std_delay = msecs;
+		configured_std_delay = msecs;
+		if (!combat) {
+			std_delay = msecs;
+		}
+	}
+
+	void set_combat_std_delay(int msecs) {
+		configured_combat_std_delay = msecs;
+		if (combat) {
+			std_delay = msecs;
+		}
 	}
 
 	Actor* get_npc(long npc_num) const;

--- a/gumps/GameEngineOptions_gump.cc
+++ b/gumps/GameEngineOptions_gump.cc
@@ -144,7 +144,7 @@ namespace {
 		}
 	};
 
-	std::array framerates{2, 4, 5, 6, 8, 10, -1};
+	std::array framerates{2, 4, 5, 6, 8, 10, 15, 20, -1};
 	// -1 is placeholder for custom framerate
 	constexpr const size_t num_default_rates = framerates.size() - 1;
 

--- a/gumps/GameEngineOptions_gump.cc
+++ b/gumps/GameEngineOptions_gump.cc
@@ -115,6 +115,10 @@ namespace {
 			return get_text_msg(0x62D - msg_file_start);
 		}
 
+		static auto CombatSpeed_() {
+			return get_text_msg(0x635 - msg_file_start);
+		}
+
 		static auto CombatShowHits_() {
 			return get_text_msg(0x62E - msg_file_start);
 		}
@@ -205,6 +209,10 @@ void GameEngineOptions_gump::build_buttons() {
 			this, &GameEngineOptions_gump::toggle_frames, frametext, frames, get_button_pos_for_label(Strings::Speed_()),
 			yForRow(++y_index), small_size);
 
+	buttons[id_combat_frames] = std::make_unique<GameEngineTextToggle>(
+			this, &GameEngineOptions_gump::toggle_combat_frames, combat_frametext, combat_frames,
+			get_button_pos_for_label(Strings::CombatSpeed_()), yForRow(++y_index), small_size);
+
 	buttons[id_show_hits] = std::make_unique<GameEngineTextToggle>(
 			this, &GameEngineOptions_gump::toggle_show_hits, yesNo, show_hits, get_button_pos_for_label(Strings::CombatShowHits_()),
 			yForRow(++y_index), small_size);
@@ -278,8 +286,10 @@ void GameEngineOptions_gump::load_settings() {
 	enhancements          = gwin->get_allow_enhancements();
 	gumps_pause           = !gumpman->gumps_dont_pause_game();
 	frames                = -1;
+	combat_frames         = -1;
 	size_t num_framerates = num_default_rates;
 	frametext.clear();
+	combat_frametext.clear();
 	// setting the framerate number to show by actually loading from config
 	int fps;
 	config->value("config/video/fps", fps, 5);
@@ -287,12 +297,22 @@ void GameEngineOptions_gump::load_settings() {
 	if (fps <= 0) {
 		fps = 5;    // default should be 5 frames
 	}
+	int combat_fps;
+	config->value("config/gameplay/combat/fps", combat_fps, 10);
+	if (combat_fps <= 0) {
+		combat_fps = 10;
+	}
 	// Now we want to populate the framerates vector and match our current text
 	// to the proper index
 	for (size_t i = 0; i < num_framerates; i++) {
-		frametext.emplace_back(framestring(framerates[i]));
+		const string rate = framestring(framerates[i]);
+		frametext.emplace_back(rate);
+		combat_frametext.emplace_back(rate);
 		if (framerates[i] == fps) {
 			frames = i;
+		}
+		if (framerates[i] == combat_fps) {
+			combat_frames = i;
 		}
 	}
 	feeding = int(cheat.GetFoodUse(true));
@@ -335,6 +355,9 @@ void GameEngineOptions_gump::save_settings() {
 	const int fps = framerates[frames];
 	gwin->set_std_delay(1000 / fps);
 	config->set("config/video/fps", fps, false);
+	const int combat_fps = framerates[combat_frames];
+	gwin->set_combat_std_delay(1000 / combat_fps);
+	config->set("config/gameplay/combat/fps", combat_fps, false);
 	cheat.set_enabled(cheats != 0);
 	cheat.SetFoodUse(Cheat::FoodUse(feeding), false);
 	gumpman->set_gumps_dont_pause_game(!gumps_pause);
@@ -355,6 +378,7 @@ void GameEngineOptions_gump::paint() {
 	font->paint_text(iwin->get_ib8(), Strings::Gumpspausegame_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::Alternativedraganddrop_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::Speed_(), x + label_margin, y + yForRow(++y_index) + 1);
+	font->paint_text(iwin->get_ib8(), Strings::CombatSpeed_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::CombatShowHits_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::CombatpausedwithSpace_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::CombatCharmedDifficulty_(), x + label_margin, y + yForRow(++y_index) + 1);

--- a/gumps/GameEngineOptions_gump.cc
+++ b/gumps/GameEngineOptions_gump.cc
@@ -146,6 +146,10 @@ namespace {
 		static auto Enhancements_() {
 			return get_text_msg(0x634 - msg_file_start);
 		}
+
+		static auto ShowItemProperties_() {
+			return get_text_msg(0x636 - msg_file_start);
+		}
 	};
 
 	std::array framerates{2, 4, 5, 6, 8, 10, 15, 20, -1};
@@ -237,6 +241,10 @@ void GameEngineOptions_gump::build_buttons() {
 			this, &GameEngineOptions_gump::toggle_enhancements, yesNo, enhancements,
 			get_button_pos_for_label(Strings::Enhancements_()), yForRow(++y_index), small_size);
 
+	buttons[id_show_item_properties] = std::make_unique<GameEngineTextToggle>(
+			this, &GameEngineOptions_gump::toggle_show_item_properties, yesNo, show_item_properties,
+			get_button_pos_for_label(Strings::ShowItemProperties_()), yForRow(++y_index), small_size);
+
 	buttons[id_cheats] = std::make_unique<GameEngineTextToggle>(
 			this, &GameEngineOptions_gump::toggle_cheats, yesNo, cheats, get_button_pos_for_label(Strings::Cheats_()),
 			yForRow(++y_index), small_size);
@@ -266,7 +274,7 @@ void GameEngineOptions_gump::update_cheat_buttons() {
 }
 
 void GameEngineOptions_gump::load_settings() {
-	const string yn;
+	string yn;
 	cheats     = cheat();
 	difficulty = Combat::difficulty;
 	if (difficulty < -3) {
@@ -285,6 +293,8 @@ void GameEngineOptions_gump::load_settings() {
 	allow_autonotes       = gwin->get_allow_autonotes();
 	enhancements          = gwin->get_allow_enhancements();
 	gumps_pause           = !gumpman->gumps_dont_pause_game();
+	config->value("config/gameplay/show_item_properties", yn, "yes");
+	show_item_properties = yn == "yes";
 	frames                = -1;
 	combat_frames         = -1;
 	size_t num_framerates = num_default_rates;
@@ -319,17 +329,17 @@ void GameEngineOptions_gump::load_settings() {
 }
 
 GameEngineOptions_gump::GameEngineOptions_gump() : Modal_gump(nullptr, -1) {
-	SetProceduralBackground(TileRect(0, 0, 100, yForRow(13)), -1);
+	SetProceduralBackground(TileRect(0, 0, 100, yForRow(14)), -1);
 
 	// Ok
 	buttons[id_ok]
-			= std::make_unique<GameEngineOptions_button>(this, &GameEngineOptions_gump::close, Strings::OK(), 25, yForRow(12), 50);
+			= std::make_unique<GameEngineOptions_button>(this, &GameEngineOptions_gump::close, Strings::OK(), 25, yForRow(13), 50);
 	// Help
 	buttons[id_help]
-			= std::make_unique<GameEngineOptions_button>(this, &GameEngineOptions_gump::help, Strings::HELP(), 50, yForRow(12), 50);
+			= std::make_unique<GameEngineOptions_button>(this, &GameEngineOptions_gump::help, Strings::HELP(), 50, yForRow(13), 50);
 	// Cancel
 	buttons[id_cancel] = std::make_unique<GameEngineOptions_button>(
-			this, &GameEngineOptions_gump::cancel, Strings::CANCEL(), 75, yForRow(12), 50);
+			this, &GameEngineOptions_gump::cancel, Strings::CANCEL(), 75, yForRow(13), 50);
 
 	load_settings();
 	build_buttons();
@@ -352,6 +362,7 @@ void GameEngineOptions_gump::save_settings() {
 	config->set("config/gameplay/allow_autonotes", allow_autonotes ? "yes" : "no", false);
 	gwin->set_allow_enhancements(enhancements);
 	config->set("config/gameplay/enhancements", enhancements ? "yes" : "no", false);
+	config->set("config/gameplay/show_item_properties", show_item_properties ? "yes" : "no", false);
 	const int fps = framerates[frames];
 	gwin->set_std_delay(1000 / fps);
 	config->set("config/video/fps", fps, false);
@@ -384,6 +395,7 @@ void GameEngineOptions_gump::paint() {
 	font->paint_text(iwin->get_ib8(), Strings::CombatCharmedDifficulty_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::CombatDifficulty_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::Enhancements_(), x + label_margin, y + yForRow(++y_index) + 1);
+	font->paint_text(iwin->get_ib8(), Strings::ShowItemProperties_(), x + label_margin, y + yForRow(++y_index) + 1);
 	font->paint_text(iwin->get_ib8(), Strings::Cheats_(), x + label_margin, y + yForRow(++y_index) + 1);
 	if (buttons[id_feeding]) {
 		font->paint_text(iwin->get_ib8(), Strings::Feeding_(), x + label_margin, y + yForRow(++y_index) + 1);

--- a/gumps/GameEngineOptions_gump.h
+++ b/gumps/GameEngineOptions_gump.h
@@ -33,7 +33,9 @@ private:
 	int                      gumps_pause;
 	bool                     alternate_drop;
 	int                      frames;
+	int                      combat_frames;
 	std::vector<std::string> frametext;
+	std::vector<std::string> combat_frametext;
 	int                      difficulty;
 	int                      show_hits;
 	int                      mode;
@@ -52,6 +54,7 @@ private:
 		id_gumps_pause,
 		id_alternate_drop,
 		id_frames,
+		id_combat_frames,
 		id_show_hits,
 		id_mode,
 		id_charmDiff,
@@ -95,6 +98,10 @@ public:
 
 	void toggle_frames(int state) {
 		frames = state;
+	}
+
+	void toggle_combat_frames(int state) {
+		combat_frames = state;
 	}
 
 	void toggle_difficulty(int state) {

--- a/gumps/GameEngineOptions_gump.h
+++ b/gumps/GameEngineOptions_gump.h
@@ -43,6 +43,7 @@ private:
 	int                      cheats;
 	int                      feeding;
 	int                      enhancements;
+	int                      show_item_properties;
 
 	enum button_ids {
 		id_first = 0,
@@ -62,6 +63,7 @@ private:
 		id_cheats,
 		id_feeding,
 		id_enhancements,
+		id_show_item_properties,
 		id_count
 	};
 
@@ -131,6 +133,10 @@ public:
 
 	void toggle_enhancements(int state) {
 		enhancements = state;
+	}
+
+	void toggle_show_item_properties(int state) {
+		show_item_properties = state;
 	}
 
 	Gump_button* on_button(int mx, int my) override;

--- a/gumps/ItemMenu_gump.cc
+++ b/gumps/ItemMenu_gump.cc
@@ -22,8 +22,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "ItemMenu_gump.h"
 
+#include "Configuration.h"
 #include "Gump_button.h"
 #include "Gump_manager.h"
+#include "Scroll_gump.h"
 #include "Text_button.h"
 #include "actors.h"
 #include "cheat.h"
@@ -31,7 +33,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "exult_flx.h"
 #include "gamewin.h"
 #include "items.h"
+#include "ready.h"
 #include "shapeinf.h"
+#include "shapeinf/ammoinf.h"
+#include "shapeinf/armorinf.h"
+#include "shapeinf/weaponinf.h"
+
+#include <sstream>
+#include <string>
 
 using Itemmenu_button = CallbackTextButton<Itemmenu_gump>;
 using Itemmenu_object = CallbackTextButton<Itemmenu_gump, Game_object*>;
@@ -66,7 +75,330 @@ public:
 	static auto Donothing() {
 		return get_text_msg(0x656 - msg_file_start);
 	}
+
+	static auto Properties() {
+		return get_text_msg(0x657 - msg_file_start);
+	}
 };
+
+namespace {
+
+	constexpr int potion_shape = 0x154;
+
+	bool has_potion_properties(Game_object* object) {
+		return object && object->get_shapenum() == potion_shape && (object->get_framenum() & 31) <= 9;
+	}
+
+	bool show_item_properties() {
+		std::string enabled;
+		config->value("config/gameplay/show_item_properties", enabled, "yes");
+		return enabled == "yes";
+	}
+
+	const char* get_damage_type_name(int type) {
+		switch (type) {
+		case Weapon_data::normal_damage:
+			return "normal";
+		case Weapon_data::fire_damage:
+			return "fire";
+		case Weapon_data::magic_damage:
+			return "magic";
+		case Weapon_data::lightning_damage:
+			return "lightning/poison/freezing";
+		case Weapon_data::ethereal_damage:
+			return "ethereal";
+		case Weapon_data::sonic_damage:
+			return "sonic";
+		default:
+			return "unknown";
+		}
+	}
+
+	const char* get_weapon_kind_name(int uses) {
+		switch (uses) {
+		case Weapon_info::melee:
+			return "melee";
+		case Weapon_info::poor_thrown:
+			return "poor thrown";
+		case Weapon_info::good_thrown:
+			return "good thrown";
+		case Weapon_info::ranged:
+			return "ranged";
+		default:
+			return "unknown";
+		}
+	}
+
+	const char* get_ready_type_name(int ready) {
+		switch (ready) {
+		case head:
+			return "head";
+		case backpack:
+			return "backpack";
+		case belt:
+			return "belt";
+		case lhand:
+			return "lhand";
+		case lfinger:
+			return "lfinger";
+		case legs:
+			return "legs";
+		case feet:
+			return "feet";
+		case rfinger:
+			return "rfinger";
+		case rhand:
+			return "rhand";
+		case torso:
+			return "torso";
+		case amulet:
+			return "amulet";
+		case quiver:
+			return "quiver";
+		case back_2h:
+			return "back_2h";
+		case back_shield:
+			return "back_shield";
+		case earrings:
+			return "earrings";
+		case cloak:
+			return "cloak";
+		case gloves:
+			return "gloves";
+		case ucont:
+			return "ucont";
+		case both_hands:
+			return "both_hands";
+		case lrgloves:
+			return "lrgloves";
+		case neck:
+			return "neck";
+		case scabbard:
+			return "scabbard";
+		case triple_bolts:
+			return "triple_bolts";
+		default:
+			return "unknown";
+		}
+	}
+
+	void append_power(std::ostringstream& out, bool& first, unsigned char powers, int bit, const char* name) {
+		if ((powers & bit) == 0) {
+			return;
+		}
+		if (!first) {
+			out << ", ";
+		}
+		out << name;
+		first = false;
+	}
+
+	std::string get_power_names(unsigned char powers) {
+		if (powers == 0) {
+			return "none";
+		}
+		std::ostringstream out;
+		bool               first = true;
+		append_power(out, first, powers, Weapon_data::sleep, "sleep");
+		append_power(out, first, powers, Weapon_data::charm, "charm");
+		append_power(out, first, powers, Weapon_data::curse, "curse");
+		append_power(out, first, powers, Weapon_data::poison, "poison");
+		append_power(out, first, powers, Weapon_data::paralyze, "paralyze");
+		append_power(out, first, powers, Weapon_data::magebane, "magebane");
+		append_power(out, first, powers, Weapon_data::unknown, "unknown");
+		append_power(out, first, powers, Weapon_data::no_damage, "no damage");
+		return out.str();
+	}
+
+	const char* get_potion_name(int frame) {
+		switch (frame) {
+		case 0:
+			return "Blue Potion";
+		case 1:
+			return "Yellow Potion";
+		case 2:
+			return "Red Potion";
+		case 3:
+			return "Green Potion";
+		case 4:
+			return "Orange Potion";
+		case 5:
+			return "Purple Potion";
+		case 6:
+			return "White Potion";
+		case 7:
+			return "Black Potion";
+		case 8:
+			return "Essence of Mandrake";
+		case 9:
+			return "Warmth potion";
+		default:
+			return "Unknown potion";
+		}
+	}
+
+	const char* get_potion_effect(int frame) {
+		switch (frame) {
+		case 0:
+			return "Makes the target fall asleep.";
+		case 1:
+			return "Restores 3-12 HP.";
+		case 2:
+			return "Cures poison, paralysis, sleep, charm, and curse.";
+		case 3:
+			return "Poisons the target.";
+		case 4:
+			return "Wakes a sleeping target.";
+		case 5:
+			return "Gives protection.";
+		case 6:
+			return "Creates light.";
+		case 7:
+			return "Makes the target invisible.";
+		case 8:
+			return "";
+		case 9:
+			return "Sets the target's temperature to normal.";
+		default:
+			return "Unknown.";
+		}
+	}
+
+	std::string get_potion_description(Game_object* object) {
+		const int   frame  = object->get_framenum() & 31;
+		const char* effect = get_potion_effect(frame);
+		std::string description = get_potion_name(frame);
+		if (*effect != '\0') {
+			description += " - ";
+			description += effect;
+		}
+		return description;
+	}
+
+	const char* get_potion_duration(int frame) {
+		switch (frame) {
+		case 0:
+			return "Until awakened, rest, or another clearing effect";
+		case 1:
+		case 2:
+		case 4:
+		case 8:
+		case 9:
+			return "Instant";
+		case 3:
+			return "Until cured, rest, or another clearing effect";
+		case 5:
+		case 7:
+			return "Until rest or another clearing effect";
+		case 6:
+			return "About 10 game minutes";
+		default:
+			return "Unknown";
+		}
+	}
+
+	void display_potion_properties(Game_object* object) {
+		const int          frame = object->get_framenum() & 31;
+		std::ostringstream text;
+		text << get_potion_description(object) << "~";
+		text << "Duration: " << get_potion_duration(frame) << "~";
+
+		Game_window* gwin = Game_window::get_instance();
+		Scroll_gump  scroll;
+		scroll.add_text(text.str().c_str());
+		scroll.paint();
+		do {
+			int x;
+			int y;
+			Get_click(x, y, Mouse::hand, nullptr, false, &scroll);
+		} while (scroll.show_next_page());
+		gwin->paint();
+	}
+
+	void display_weapon_properties(Game_object* object) {
+		const Weapon_info* weapon = object->get_info().get_weapon_info();
+		if (!weapon) {
+			return;
+		}
+		const Shape_info&   info = object->get_info();
+		std::ostringstream  text;
+		text << "Name: " << object->get_name() << "~";
+		text << "Damage: " << weapon->get_damage() << "~";
+		text << "Range: " << weapon->get_range() << "~";
+		text << "Speed: " << weapon->get_missile_speed() << "~";
+		text << "XP: " << weapon->get_base_xp_value() << "~";
+		text << "Damage Type: " << get_damage_type_name(weapon->get_damage_type()) << "~";
+		text << "Powers: " << get_power_names(weapon->get_powers()) << "~";
+		text << "Kind of Weapon: " << get_weapon_kind_name(weapon->get_uses()) << "~";
+		text << "Weight: " << info.get_weight() << "~";
+		text << "Volume: " << info.get_volume() << "~";
+		text << "ReadyType: " << get_ready_type_name(info.get_ready_type()) << "~";
+
+		Game_window* gwin = Game_window::get_instance();
+		Scroll_gump  scroll;
+		scroll.add_text(text.str().c_str());
+		scroll.paint();
+		do {
+			int x;
+			int y;
+			Get_click(x, y, Mouse::hand, nullptr, false, &scroll);
+		} while (scroll.show_next_page());
+		gwin->paint();
+	}
+
+	void display_armor_properties(Game_object* object) {
+		const Armor_info* armor = object->get_info().get_armor_info();
+		if (!armor) {
+			return;
+		}
+		const Shape_info&  info = object->get_info();
+		std::ostringstream text;
+		text << "Name: " << object->get_name() << "~";
+		text << "Prot: " << static_cast<int>(armor->get_prot()) << "~";
+		text << "XP: " << armor->get_base_xp_value() << "~";
+		text << "Weight: " << info.get_weight() << "~";
+		text << "Volume: " << info.get_volume() << "~";
+		text << "ReadyType: " << get_ready_type_name(info.get_ready_type()) << "~";
+
+		Game_window* gwin = Game_window::get_instance();
+		Scroll_gump  scroll;
+		scroll.add_text(text.str().c_str());
+		scroll.paint();
+		do {
+			int x;
+			int y;
+			Get_click(x, y, Mouse::hand, nullptr, false, &scroll);
+		} while (scroll.show_next_page());
+		gwin->paint();
+	}
+
+	void display_ammo_properties(Game_object* object) {
+		const Ammo_info* ammo = object->get_info().get_ammo_info();
+		if (!ammo) {
+			return;
+		}
+		const Shape_info&  info = object->get_info();
+		std::ostringstream text;
+		text << "Name: " << object->get_name() << "~";
+		text << "Damage: " << ammo->get_damage() << "~";
+		text << "DamageType: " << get_damage_type_name(ammo->get_damage_type()) << "~";
+		text << "Powers: " << get_power_names(ammo->get_powers()) << "~";
+		text << "IsSpell: " << (info.is_spell() ? "true" : "false") << "~";
+		text << "ReadyType: " << get_ready_type_name(info.get_ready_type()) << "~";
+
+		Game_window* gwin = Game_window::get_instance();
+		Scroll_gump  scroll;
+		scroll.add_text(text.str().c_str());
+		scroll.paint();
+		do {
+			int x;
+			int y;
+			Get_click(x, y, Mouse::hand, nullptr, false, &scroll);
+		} while (scroll.show_next_page());
+		gwin->paint();
+	}
+
+}    // namespace
 
 void Itemmenu_gump::select_object(Game_object* obj) {
 	objectSelected = obj;
@@ -103,9 +435,21 @@ Itemmenu_gump::Itemmenu_gump(Game_object_map_xy* mobjxy, int cx, int cy)
 	// set_object_area(TileRect(0, 0, 0, 0), -1, -1);//++++++ ???
 	int       btop = 0;
 	const int maxh = Game_window::get_instance()->get_height() - 2 * button_spacing_y;
+	Game_object* ammoPropertiesObject   = nullptr;
+	Game_object* armorPropertiesObject  = nullptr;
+	Game_object* potionPropertiesObject = nullptr;
+	Game_object* weaponPropertiesObject = nullptr;
+	int          ammoPropertiesCount    = 0;
+	int          armorPropertiesCount   = 0;
+	int          potionPropertiesCount  = 0;
+	int          weaponPropertiesCount  = 0;
+	const bool   showProperties         = show_item_properties();
 	for (auto it = mobjxy->begin(); it != mobjxy->end() && btop < maxh; it++) {
 		Game_object* o    = it->first;
 		std::string  name = o->get_name();
+		if (showProperties && has_potion_properties(o)) {
+			name = get_potion_description(o);
+		}
 		// Skip objects with no name.
 		if (name.empty()) {
 			continue;
@@ -113,6 +457,38 @@ Itemmenu_gump::Itemmenu_gump(Game_object_map_xy* mobjxy, int cx, int cy)
 		objects[o] = it->second;
 		buttons.push_back(
 				std::make_unique<Itemmenu_object>(this, &Itemmenu_gump::select_object, ObjectParams{o}, name, 10, btop, 59, 20));
+		btop += button_spacing_y;
+		if (showProperties) {
+			if (o->get_info().has_weapon_info()) {
+				weaponPropertiesObject = o;
+				++weaponPropertiesCount;
+			}
+			if (o->get_info().has_armor_info()) {
+				armorPropertiesObject = o;
+				++armorPropertiesCount;
+			}
+			if (o->get_info().has_ammo_info()) {
+				ammoPropertiesObject = o;
+				++ammoPropertiesCount;
+			}
+			if (has_potion_properties(o)) {
+				potionPropertiesObject = o;
+				++potionPropertiesCount;
+			}
+		}
+	}
+	if (objects.size() == 1
+		&& (weaponPropertiesCount == 1 || armorPropertiesCount == 1 || ammoPropertiesCount == 1
+			|| potionPropertiesCount == 1)) {
+		Game_object* propertiesObject
+				= weaponPropertiesCount == 1
+						  ? weaponPropertiesObject
+						  : (armorPropertiesCount == 1
+									 ? armorPropertiesObject
+									 : (ammoPropertiesCount == 1 ? ammoPropertiesObject : potionPropertiesObject));
+		buttons.push_back(std::make_unique<Itemmenu_object>(
+				this, &Itemmenu_gump::select_weapon_properties, ObjectParams{propertiesObject}, Strings::Properties(),
+				10, btop, 59, 20));
 		btop += button_spacing_y;
 	}
 	buttons.push_back(std::make_unique<Itemmenu_button>(this, &Itemmenu_gump::cancel_menu, Strings::Cancel(), 10, btop, 59, 20));
@@ -156,6 +532,13 @@ Itemmenu_gump::Itemmenu_gump(Game_object* obj, int ox, int oy, int cx, int cy)
 		buttons.push_back(std::make_unique<Itemmenu_button>(this, &Itemmenu_gump::set_pickup, Strings::Pickup(), 10, btop, 59, 20));
 		btop += button_spacing_y;
 		buttons.push_back(std::make_unique<Itemmenu_button>(this, &Itemmenu_gump::set_move, Strings::Moveto(), 10, btop, 59, 20));
+		btop += button_spacing_y;
+	}
+	if (show_item_properties()
+		&& (info.has_weapon_info() || info.has_armor_info() || info.has_ammo_info()
+			|| has_potion_properties(objectSelected))) {
+		buttons.push_back(
+				std::make_unique<Itemmenu_button>(this, &Itemmenu_gump::set_weapon_properties, Strings::Properties(), 10, btop, 59, 20));
 		btop += button_spacing_y;
 	}
 	buttons.push_back(std::make_unique<Itemmenu_button>(this, &Itemmenu_gump::cancel_menu, Strings::Donothing(), 10, btop, 59, 20));
@@ -241,6 +624,17 @@ void Itemmenu_gump::postCloseActions() {
 	}
 	case use_item:
 		objectSelected->activate();
+		break;
+	case show_weapon_properties:
+		if (objectSelected->get_info().has_weapon_info()) {
+			display_weapon_properties(objectSelected);
+		} else if (objectSelected->get_info().has_armor_info()) {
+			display_armor_properties(objectSelected);
+		} else if (objectSelected->get_info().has_ammo_info()) {
+			display_ammo_properties(objectSelected);
+		} else if (has_potion_properties(objectSelected)) {
+			display_potion_properties(objectSelected);
+		}
 		break;
 	case pickup_item: {
 		Main_actor*      ava    = gwin->get_main_actor();

--- a/gumps/ItemMenu_gump.h
+++ b/gumps/ItemMenu_gump.h
@@ -35,7 +35,8 @@ class Itemmenu_gump : public Modal_gump {
 		use_item,
 		pickup_item,
 		move_item,
-		show_inventory
+		show_inventory,
+		show_weapon_properties
 	};
 
 public:
@@ -56,6 +57,12 @@ public:
 
 	void select_object(Game_object* obj);
 
+	void select_weapon_properties(Game_object* obj) {
+		objectSelected = obj;
+		objectAction   = show_weapon_properties;
+		close();
+	}
+
 	void set_use() {
 		objectAction = use_item;
 		close();
@@ -73,6 +80,11 @@ public:
 
 	void set_inventory() {
 		objectAction = show_inventory;
+		close();
+	}
+
+	void set_weapon_properties() {
+		objectAction = show_weapon_properties;
 		close();
 	}
 

--- a/gumps/ShortcutBar_gump.cc
+++ b/gumps/ShortcutBar_gump.cc
@@ -308,8 +308,16 @@ ShortcutBar_gump::~ShortcutBar_gump() {
 void ShortcutBar_gump::paint() {
 	Game_window*   gwin = Game_window::get_instance();
 	Shape_manager* sman = Shape_manager::get_instance();
+	Image_window8* win  = gwin->get_win();
 
 	Gump::paint();
+	const int bar_x = locx + (gamex - 320) / 2;
+	const int bar_y = locy + starty;
+	constexpr unsigned char pavement_grey = 128;
+	win->fill8(pavement_grey, 320, height, bar_x, bar_y);
+	const unsigned char line = sman->get_special_pixel(PROTECT_PIXEL);
+	win->fill8(line, 320, 1, bar_x, bar_y);
+	win->fill8(line, 320, 1, bar_x, bar_y + height - 1);
 
 	for (int i = 0; i < numButtons; i++) {
 		const ShortcutBarButtonItem& item  = buttonItems[i];

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -961,12 +961,13 @@ gint Shape_chooser::check_editing_files() {
 
 static int Find_closest_color(
 		const unsigned char* pal,    // 3*255 bytes.
-		int r, int g, int b          // Color to match.
+		int r, int g, int b,         // Color to match.
+		int last                    // First palette index to exclude.
 ) {
 	int  best_index    = -1;
 	long best_distance = 0xfffffff;
 	// Be sure to search rotating colors too.
-	for (int i = 0; i < 0xff; i++) {
+	for (int i = 0; i < last; i++) {
 		// Get deltas.
 		const long dr = r - pal[3 * i];
 		const long dg = g - pal[3 * i + 1];
@@ -991,7 +992,8 @@ static void Convert_indexed_image(
 		int            count,         // # pixels.
 		unsigned char* oldpal,        // Palette pixels currently uses.
 		int            oldpalsize,    // Size of old palette.
-		unsigned char* newpal         // Palette (255 bytes) to convert to.
+		unsigned char* newpal,        // Palette (255 bytes) to convert to.
+		int            last           // First destination index to exclude.
 ) {
 	if (memcmp(oldpal, newpal, oldpalsize) == 0) {
 		return;    // Old palette matches new.
@@ -1006,7 +1008,7 @@ static void Convert_indexed_image(
 	for (i = 0; i < count; i++) {
 		const unsigned char pix = *pixels;
 		if (map[pix] == -1) {    // New one?
-			map[pix] = Find_closest_color(newpal, oldpal[3 * pix], oldpal[3 * pix + 1], oldpal[3 * pix + 2]);
+			map[pix] = Find_closest_color(newpal, oldpal[3 * pix], oldpal[3 * pix + 1], oldpal[3 * pix + 2], last);
 		}
 		Write1(pixels, map[pix]);
 	}
@@ -1044,7 +1046,13 @@ static void Import_png(
 		return;    // Just return if error, for now.
 	}
 	// Convert to game palette.
-	Convert_indexed_image(pixels, h * rowsize, oldpal, palsize, pal);
+	// Face portraits must not use palette entries 224-254: Exult cycles or
+	// interprets those entries as effects, making imported pixels flicker.
+	const int last_color = strcmp(finfo->get_basename(), "faces.vga") == 0
+								 ? 0xe0
+								 : 0xff;
+	Convert_indexed_image(
+			pixels, h * rowsize, oldpal, palsize, pal, last_color);
 	delete[] oldpal;
 	// Low shape in 'shapes.vga'?
 	const bool flat = IS_FLAT(shapenum) && finfo == studio->get_vgafile();

--- a/objs/contain.cc
+++ b/objs/contain.cc
@@ -26,6 +26,7 @@
 #include "contain.h"
 
 #include "Gump_manager.h"
+#include "actors.h"
 #include "ShortcutBar_gump.h"
 #include "cheat.h"
 #include "databuf.h"
@@ -42,6 +43,9 @@
 #include "ucmachine.h"
 #include "ucsched.h"
 #include "weaponinf.h"
+
+#include <algorithm>
+#include <vector>
 
 #ifdef USE_EXULTSTUDIO
 #	include "objserial.h"
@@ -107,6 +111,7 @@ bool Container_game_object::add(
 		bool noset    // True to prevent actors from setting sched. weapon.
 ) {
 	ignore_unused_variable_warning(noset);
+	const int added_shapenum = obj->get_shapenum();
 	// Prevent dragging the avatar into a container.
 	// Casting to void* to avoid including actors.h.
 	if (obj == static_cast<void*>(gwin->get_main_actor())) {
@@ -148,6 +153,9 @@ bool Container_game_object::add(
 			if (g_shortcutBar) {
 				g_shortcutBar->check_for_updates(shape_num);
 			}
+			if (shape_num == c_gold_coin_shapenum) {
+				Maybe_consolidate_backpack_gold(this);
+			}
 			return true;
 		} else if (newquant < quant) {    // Partly successful.
 			obj->modify_quantity(newquant - quant);
@@ -171,7 +179,82 @@ bool Container_game_object::add(
 	if (g_shortcutBar) {
 		g_shortcutBar->check_for_updates(obj->get_shapenum());
 	}
+	if (added_shapenum == c_gold_coin_shapenum) {
+		Maybe_consolidate_backpack_gold(this);
+	}
 	return true;
+}
+
+/*
+ *  Combine gold coins in this container into piles of 100.
+ */
+
+void Container_game_object::consolidate_gold(int shapenum) {
+	static int consolidating = 0;
+	if (consolidating || !Can_be_added(this, shapenum)) {
+		return;
+	}
+	Game_object_vector gold_objs;
+	int                total = 0;
+	Game_object*       obj;
+	Object_iterator    next(objects);
+	while ((obj = next.get_next()) != nullptr) {
+		if (obj->get_shapenum() == shapenum) {
+			gold_objs.push_back(obj);
+			total += obj->get_quantity();
+		}
+	}
+	if (gold_objs.empty()) {
+		return;
+	}
+	std::vector<int> expected;
+	int              remaining = total;
+	while (remaining >= 100) {
+		expected.push_back(100);
+		remaining -= 100;
+	}
+	if (remaining > 0) {
+		expected.push_back(remaining);
+	}
+	std::vector<int> current;
+	current.reserve(gold_objs.size());
+	for (Game_object* gold : gold_objs) {
+		current.push_back(gold->get_quantity());
+	}
+	std::sort(current.begin(), current.end(), std::greater<int>());
+	if (current == expected) {
+		return;
+	}
+	++consolidating;
+	const Shape_info& shp_info = ShapeID::get_info(shapenum);
+	for (size_t i = 0; i < expected.size(); ++i) {
+		const int want = expected[i];
+		if (i < gold_objs.size()) {
+			Game_object* pile = gold_objs[i];
+			const int    have = pile->get_quantity();
+			if (have != want) {
+				pile->modify_quantity(want - have);
+			}
+		} else {
+			Game_object_shared newobj = gmap->create_ireg_object(
+					shp_info, shapenum, 0, 0, 0, 0);
+			if (!add(newobj.get())) {
+				newobj.reset();
+				break;
+			}
+			int left = want - 1;
+			if (left > 0) {
+				newobj->modify_quantity(left);
+			}
+		}
+	}
+	for (size_t i = expected.size(); i < gold_objs.size(); ++i) {
+		gold_objs[i]->remove_this();
+	}
+	--consolidating;
+	if (g_shortcutBar) {
+		g_shortcutBar->check_for_updates(shapenum);
+	}
 }
 
 /*
@@ -222,6 +305,7 @@ int Container_game_object::add_quantity(
 	if (delta <= 0 || !Can_be_added(this, shapenum)) {
 		return delta;
 	}
+	const int start_delta = delta;
 
 	int cant_add  = 0;                   // # we can't add due to weight.
 	int maxweight = get_max_weight();    // Check weight.
@@ -264,11 +348,19 @@ int Container_game_object::add_quantity(
 			delta = obj->add_quantity(delta, shapenum, qual, framenum, true, temporary);
 		}
 	}
+	int result;
 	if (!delta || dontcreate) {    // All added?
-		return delta + cant_add;
+		result = delta + cant_add;
 	} else {
-		return cant_add + create_quantity(delta, shapenum, qual, framenum == c_any_framenum ? 0 : framenum, temporary);
+		result = cant_add
+				 + create_quantity(
+						 delta, shapenum, qual,
+						 framenum == c_any_framenum ? 0 : framenum, temporary);
 	}
+	if (shapenum == c_gold_coin_shapenum && result < start_delta) {
+		Maybe_consolidate_backpack_gold(this);
+	}
+	return result;
 }
 
 /*
@@ -415,6 +507,7 @@ bool Container_game_object::show_gump(int event) {
 		// Run normal usecode fun.
 		return false;
 	} else if ((gump = inf.get_gump_shape()) >= 0) {
+		Maybe_consolidate_backpack_gold(this);
 		Gump_manager* gump_man = gumpman;
 		gump_man->add_gump(this, gump);
 		return true;

--- a/objs/contain.h
+++ b/objs/contain.h
@@ -150,6 +150,9 @@ public:
 	const Container_game_object* as_container() const override {
 		return this;
 	}
+
+	// Combine gold coins into piles of 100 (plus remainder).
+	void consolidate_gold(int shapenum = c_gold_coin_shapenum);
 };
 
 #endif

--- a/palette.h
+++ b/palette.h
@@ -126,6 +126,10 @@ public:
 		return pal1[3 * nr + 2];
 	}
 
+	const unsigned char* get_color_data() const {
+		return pal1;
+	}
+
 	void set_palette(const unsigned char palnew[768]);
 
 	int get_palette_index() const {

--- a/shapeid.cc
+++ b/shapeid.cc
@@ -465,9 +465,14 @@ Shape_manager::~Shape_manager() {
  */
 int Shape_manager::paint_text_box(
 		int fontnum, const char* text, int x, int y, int w, int h, int vert_lead, bool pbreak, bool center, int shading,
-		Cursor_info* cursor) {
+		Cursor_info* cursor, bool opaque_background) {
 	if (shading >= 0) {
-		gwin->get_win()->fill_translucent8(0, w, h, x, y, xforms[shading]);
+		if (opaque_background) {
+			const unsigned char black = get_special_pixel(BLACK_PIXEL);
+			gwin->get_win()->fill8(xforms[shading][black], w, h, x, y);
+		} else {
+			gwin->get_win()->fill_translucent8(0, w, h, x, y, xforms[shading]);
+		}
 	}
 	return fonts->paint_text_box(gwin->get_win()->get_ib8(), fontnum, text, x, y, w, h, vert_lead, pbreak, center, cursor);
 }

--- a/shapeid.h
+++ b/shapeid.h
@@ -187,7 +187,7 @@ public:
 	// Paint text using "fonts.vga".
 	int paint_text_box(
 			int fontnum, const char* text, int x, int y, int w, int h, int vert_lead = 0, bool pbreak = false, bool center = false,
-			int shading = -1, Cursor_info* cursor = nullptr);
+			int shading = -1, Cursor_info* cursor = nullptr, bool opaque_background = false);
 	int paint_text(int fontnum, const char* text, int xoff, int yoff);
 	int paint_text(int fontnum, const char* text, int textlen, int xoff, int yoff);
 	int paint_text(std::shared_ptr<Font> font, const char* text, int xoff, int yoff);

--- a/usecode/conversation.cc
+++ b/usecode/conversation.cc
@@ -29,12 +29,14 @@
 #include "data/exult_bg_flx.h"
 #include "effects.h"
 #include "exult.h"
+#include "fnames.h"
 #include "font_map.h"
 #include "game.h"
 #include "gamewin.h"
 #include "gump_utils.h"
 #include "miscinf.h"
 #include "mouse.h"
+#include "palette.h"
 #include "touchui.h"
 #include "tqueue.h"
 #include "useval.h"
@@ -46,6 +48,47 @@ using std::string;
 // TODO: show_avatar_choices shouldn't first convert to char**, probably
 
 bool Conversation::noface = false;
+
+static bool Is_dark_time_palette(int pal) {
+	return pal == PALETTE_DUSK || pal == PALETTE_NIGHT;
+}
+
+// Halfway between the active dark-time palette and day (see Palette_transition).
+static constexpr int Conversation_palette_blend_steps = 2;
+static constexpr int Conversation_palette_blend_pos   = 1;
+
+static void Blend_palettes(
+		const Palette& from, const Palette& to, unsigned char out[768]) {
+	const unsigned char* src = from.get_color_data();
+	const unsigned char* dst = to.get_color_data();
+	for (int c = 0; c < 768; ++c) {
+		out[c] = static_cast<unsigned char>(
+				((dst[c] - src[c]) * Conversation_palette_blend_pos)
+						/ Conversation_palette_blend_steps
+				+ src[c]);
+	}
+}
+
+static Palette& Get_day_reference_palette() {
+	static Palette day;
+	static bool    loaded = false;
+	if (!loaded) {
+		day.load(PALETTES_FLX, PATCH_PALETTES, PALETTE_DAY);
+		loaded = true;
+	}
+	return day;
+}
+
+static void Build_stable_face_remap(unsigned char stable_colors[256]) {
+	for (int i = 0; i < 256; ++i) {
+		stable_colors[i] = static_cast<unsigned char>(i);
+	}
+	Palette& day = Get_day_reference_palette();
+	for (int i = 0xe0; i < 0xff; ++i) {
+		stable_colors[i] = static_cast<unsigned char>(day.find_color(
+				day.get_red(i), day.get_green(i), day.get_blue(i), 0xe0));
+	}
+}
 
 /*
  *  Store information about an NPC's face and text on the screen during
@@ -69,6 +112,7 @@ public:
 };
 
 Conversation::~Conversation() {
+	restore_ui_palette();
 	delete[] conv_choices;
 }
 
@@ -133,7 +177,35 @@ void Conversation::remove_answer(Usecode_value& val) {
  *  Initialize face list.
  */
 
+void Conversation::ensure_day_palette() {
+	if (saved_ui_palette >= 0) {
+		return;
+	}
+	Palette* pal = gwin->get_pal();
+	const int active_palette = pal->get_palette_index();
+	if (!Is_dark_time_palette(active_palette)) {
+		return;
+	}
+	saved_ui_palette    = active_palette;
+	saved_ui_brightness = pal->get_brightness();
+	// Load the current time palette so night includes expand_night_shadow_contrast.
+	Palette current;
+	current.load(PALETTES_FLX, PATCH_PALETTES, active_palette);
+	unsigned char blended[768];
+	Blend_palettes(current, Get_day_reference_palette(), blended);
+	pal->set(blended, saved_ui_brightness, false);
+}
+
+void Conversation::restore_ui_palette() {
+	if (saved_ui_palette < 0) {
+		return;
+	}
+	gwin->get_pal()->set(saved_ui_palette, saved_ui_brightness, true);
+	saved_ui_palette = -1;
+}
+
 void Conversation::init_faces() {
+	restore_ui_palette();
 	for (Npc_face_info*& finfo : face_info) {
 		delete finfo;
 		finfo = nullptr;
@@ -153,8 +225,15 @@ void Conversation::init_faces() {
 	last_face_shown = -1;
 }
 
-void Conversation::set_face_rect(Npc_face_info* info, Npc_face_info* prev, int screenw, int screenh) {
-	const int text_height = sman->get_text_line_height(0);
+void Conversation::set_face_rect(
+		Npc_face_info* info, int slot, int screenw, int screenh) {
+	const int text_left   = screenw / 3;
+	const int text_right  = (2 * screenw) / 3;
+	// Speaker slots use the middle, bottom, then top thirds of the screen.
+	static constexpr int vertical_third[] = {1, 2, 0};
+	const int third = vertical_third[std::clamp(slot, 0, 2)];
+	const int text_top    = (third * screenh) / 3;
+	const int text_bottom = ((third + 1) * screenh) / 3;
 	// Figure starting y-coord.
 	// Get character's portrait.
 	Shape_frame* face   = info->shape.get_shapenum() >= 0 ? info->shape.get_shape() : nullptr;
@@ -166,44 +245,28 @@ void Conversation::set_face_rect(Npc_face_info* info, Npc_face_info* prev, int s
 	}
 	int startx;
 	int extraw;
-	if (face_w >= 119) {
+	// Shape 296 is the Guardian (and the SI special face that shares it).
+	// Do not classify ordinary high-resolution portraits by dimensions.
+	if (info->face_num == 296) {
 		startx           = (screenw - face_w) / 2;
 		extraw           = 0;
 		info->large_face = true;
 	} else {
-		startx = 8;
 		extraw = 4;
+		startx = std::max(1, text_left - face_w - extraw - 4);
 	}
-	int starty;
-	int extrah;
-	if (face_h >= 142) {
-		starty = (screenh - face_h) / 2;
-		extrah = 0;
-	} else if (prev) {
-		starty = prev->text_rect.y + prev->last_text_height;
-		if (starty < prev->face_rect.y + prev->face_rect.h) {
-			starty = prev->face_rect.y + prev->face_rect.h;
-		}
-		starty += 2 * text_height;
-		if (starty + face_h > screenh - 1) {
-			starty = screenh - face_h - 1;
-		}
-		extrah = 4;
-	} else {
-		starty = 1;
-		extrah = 4;
+	const int extrah = info->large_face ? 0 : 4;
+	int starty = info->large_face ? (screenh - face_h) / 2 : text_top;
+	if (starty + face_h + extrah > text_bottom) {
+		starty = std::max(text_top, text_bottom - face_h - extrah);
 	}
-	info->face_rect      = gwin->clip_to_win(TileRect(startx, starty, face_w + extraw, face_h + extrah));
-	const TileRect& fbox = info->face_rect;
-	// This is where NPC text will go.
-	info->text_rect = gwin->clip_to_win(TileRect(fbox.x + fbox.w + 3, fbox.y + 3, screenw - fbox.x - fbox.w - 6, 4 * text_height));
-	// No room?  (Serpent?)
-	if (info->large_face) {
-		// Show in lower center.
-		const int x     = screenw / 5;
-		const int y     = 3 * (screenh / 4);
-		info->text_rect = TileRect(x, y, screenw - (2 * x), screenh - y - 4);
-	}
+	info->face_rect = gwin->clip_to_win(
+			TileRect(startx, starty, face_w + extraw, face_h + extrah));
+	// Keep NPC speech in the middle third of the logical game viewport. This
+	// remains stable across display resolutions and output scaling modes.
+	info->text_rect       = gwin->clip_to_win(TileRect(
+			text_left, text_top, text_right - text_left,
+			text_bottom - text_top));
 	info->last_text_height = info->text_rect.h;
 }
 
@@ -214,6 +277,9 @@ void Conversation::set_face_rect(Npc_face_info* info, Npc_face_info* prev, int s
 
 void Conversation::show_face(int shape, int frame, int slot) {
 	ShapeID face_sid(shape, frame, SF_FACES_VGA);
+	if (slot < -1 || static_cast<unsigned>(slot) >= face_info.size()) {
+		slot = -1;
+	}
 
 	// Make sure mode is set right.
 	Palette* pal = gwin->get_pal();    // Watch for weirdness (lightning).
@@ -242,11 +308,13 @@ void Conversation::show_face(int shape, int frame, int slot) {
 		if (noface) {
 			info->no_show_face = true;
 		}
-		if (slot == -1) {    // Want next one?
-			slot = num_faces;
+		if (slot == -1) {    // Use the first free speaker region.
+			for (slot = 0; static_cast<unsigned>(slot) < face_info.size(); ++slot) {
+				if (!face_info[slot]) {
+					break;
+				}
+			}
 		}
-		// Get last one shown.
-		Npc_face_info* prev = slot ? face_info[slot - 1] : nullptr;
 		last_face_shown     = slot;
 		if (!face_info[slot]) {
 			num_faces++;    // We're adding one (not replacing).
@@ -254,7 +322,7 @@ void Conversation::show_face(int shape, int frame, int slot) {
 			delete face_info[slot];
 		}
 		face_info[slot] = info;
-		set_face_rect(info, prev, screenw, screenh);
+		set_face_rect(info, slot, screenw, screenh);
 	}
 	gwin->get_win()->set_clip(0, 0, screenw, screenh);
 	paint_faces();    // Paint all faces.
@@ -300,8 +368,7 @@ void Conversation::change_face_frame(int frame, int slot) {
 	// Get screen dims.
 	const int      screenw = gwin->get_width();
 	const int      screenh = gwin->get_height();
-	Npc_face_info* prev    = slot ? face_info[slot - 1] : nullptr;
-	set_face_rect(info, prev, screenw, screenh);
+	set_face_rect(info, slot, screenw, screenh);
 
 	gwin->get_win()->set_clip(0, 0, screenw, screenh);
 	paint_faces();    // Paint all faces.
@@ -391,6 +458,7 @@ void Conversation::show_npc_message(const char* msg) {
 		eman->set_sprites_always(false);
 		gwin->get_tqueue()->resume(SDL_GetTicks());
 	}
+	ensure_day_palette();
 	Npc_face_info* info = face_info[last_face_shown];
 	const int      font = info->large_face ? 7 : 0;    // Use red for Guardian, snake.
 	info->cur_text      = "";
@@ -400,7 +468,9 @@ void Conversation::show_npc_message(const char* msg) {
 	gwin->paint();
 	int height;    // Break at punctuation.
 	/* NOTE:  The original centers text for Guardian, snake.    */
-	while ((height = sman->paint_text_box(font, msg, box.x, box.y, box.w, box.h, -1, true, info->large_face, gwin->get_text_bg()))
+	while ((height = sman->paint_text_box(
+					font, msg, box.x, box.y, box.w, box.h, -1, true,
+					info->large_face, gwin->get_text_bg(), nullptr, true))
 		   < 0) {
 		// More to do?
 		info->cur_text = string(msg, -height);
@@ -450,6 +520,7 @@ void Conversation::clear_text_pending() {
  */
 
 void Conversation::show_avatar_choices(int num_choices, char** choices) {
+	ensure_day_palette();
 	const bool  SI         = Game::get_game_type() == SERPENT_ISLE;
 	Main_actor* main_actor = gwin->get_main_actor();
 	// Get screen rectangle.
@@ -510,11 +581,13 @@ void Conversation::show_avatar_choices(int num_choices, char** choices) {
 				  5 * line_height);    // Try 5 lines.
 	tbox = tbox.intersect(sbox);
 	// Draw portrait.
-	sman->paint_shape(mbox.x + face->get_xleft(), mbox.y + face->get_yabove(), face);
+	unsigned char stable_colors[256];
+	Build_stable_face_remap(stable_colors);
+	sman->paint_shape(
+			mbox.x + face->get_xleft(), mbox.y + face->get_yabove(), face,
+			false, stable_colors);
 	delete[] conv_choices;    // Set up new list of choices.
-	conv_choices        = new TileRect[num_choices + 1];
-	const int text_bg   = gwin->get_text_bg();
-	const int bg_offset = (sman->get_text_height(0) - line_height) / 2;
+	conv_choices = new TileRect[num_choices + 1];
 	// First pass: determine positions and draw all backgrounds.
 	for (int i = 0; i < num_choices; i++) {
 		char text[256];
@@ -530,11 +603,9 @@ void Conversation::show_avatar_choices(int num_choices, char** choices) {
 		conv_choices[i] = TileRect(tbox.x + x, tbox.y + y, width, line_height);
 		conv_choices[i] = conv_choices[i].intersect(sbox);
 		avatar_face     = avatar_face.add(conv_choices[i]);
-		// Draw shading with line_height, shifted down to align with text.
-		if (text_bg >= 0) {
-			gwin->get_win()->fill_translucent8(
-					0, width + space_width, line_height, tbox.x + x, tbox.y + y + bg_offset, sman->get_xform(text_bg));
-		}
+		sman->paint_text_box(
+				0, text, tbox.x + x, tbox.y + y, width + space_width, line_height, 0,
+				false, false, gwin->get_text_bg(), nullptr, true);
 		x += width + space_width;
 	}
 	// Second pass: draw all text on top of backgrounds.
@@ -608,6 +679,7 @@ void Conversation::paint() {
 
 void Conversation::paint_faces(bool text    // Show text too.
 ) {
+	ensure_day_palette();
 	if (!num_faces) {
 		return;
 	}
@@ -642,15 +714,26 @@ void Conversation::paint_faces(bool text    // Show text too.
 					win->fill_translucent8(0, gw, gh, gx, gy, xform);
 				}
 			}
-			// Use translucency.
-			sman->paint_shape(fx, fy, face, true);
+			if (finfo->large_face) {
+				// Guardian and other special faces intentionally use xform colors.
+				sman->paint_shape(fx, fy, face, true);
+			} else {
+				// Palette entries 224-254 are animated or reserved for xforms.
+				// Remap using day palette colors so night palette and rotation
+				// do not alter portrait appearance.
+				unsigned char stable_colors[256];
+				Build_stable_face_remap(stable_colors);
+				sman->paint_shape(fx, fy, face, false, stable_colors);
+			}
 		}
 		if (text) {    // Show text too?
 			const TileRect& box = finfo->text_rect;
 			// Use red for Guardian, snake.
 			const int font = finfo->large_face ? 7 : 0;
 			sman->paint_text_box(
-					font, finfo->cur_text.c_str(), box.x, box.y, box.w, box.h, -1, true, finfo->large_face, gwin->get_text_bg());
+					font, finfo->cur_text.c_str(), box.x, box.y, box.w, box.h,
+					-1, true, finfo->large_face, gwin->get_text_bg(), nullptr,
+					true);
 		}
 	}
 }

--- a/usecode/conversation.h
+++ b/usecode/conversation.h
@@ -32,12 +32,13 @@ class Npc_face_info;
 class Usecode_value;
 class Game_window;
 
-class Conversation : public Game_singletons, public Paintable {
+class Conversation : public Game_singletons, public BackgroundPaintable {
 public:
 	~Conversation() override;
 
 private:
-	std::array<Npc_face_info*, 2> face_info{nullptr, nullptr};    // NPC's on-screen faces in convers.
+	std::array<Npc_face_info*, 3> face_info{
+			nullptr, nullptr, nullptr};    // NPC's on-screen faces in convers.
 	int                           num_faces       = 0;
 	int                           last_face_shown = 0;               // Index of last npc face shown.
 	TileRect                      avatar_face     = {0, 0, 0, 0};    // Area take by Avatar in conversation.
@@ -45,6 +46,8 @@ private:
 
 	std::vector<std::string>             answers;
 	std::deque<std::vector<std::string>> answer_stack;
+	int saved_ui_palette     = -1;
+	int saved_ui_brightness  = 100;
 
 public:
 	inline int get_num_answers() const {
@@ -94,7 +97,9 @@ public:
 	static bool noface;
 
 private:
-	void set_face_rect(Npc_face_info* info, Npc_face_info* prev, int screenw, int screenh);
+	void set_face_rect(Npc_face_info* info, int slot, int screenw, int screenh);
+	void ensure_day_palette();
+	void restore_ui_palette();
 	void show_avatar_choices(int num_choices, char** choices);
 	void add_answer(const char* str);
 	void remove_answer(const char* str);

--- a/usecode/ucinternal.cc
+++ b/usecode/ucinternal.cc
@@ -686,7 +686,7 @@ int Usecode_internal::get_face_shape(Usecode_value& arg1, Actor*& npc, int& fram
 void Usecode_internal::show_npc_face(
 		Usecode_value& arg1,    // Shape (NPC #).
 		Usecode_value& arg2,    // Frame.
-		int            slot     // 0, 1, or -1 to find free spot.
+		int            slot     // 0, 1, 2, or -1 to find free spot.
 ) {
 	show_pending_text();
 	Actor*    npc;


### PR DESCRIPTION
Add a Properties entry to item menus for weapons, armor, ammo, and potion
objects, showing damage, protection, weight, powers, ready type, and other
stats in a scroll gump. Add a Game Engine option to enable or disable
these item property entries, defaulting to on.

Reimplemented against the new Strings::/get_button_pos_for_label()/
yForRow() gump layout system rather than the old colx[]/rowy[] arrays,
since the original commit predated that upstream rework. Adds message
IDs 0x636 (Show Item Properties toggle label) and 0x657 (Properties
button label).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

