### PR TITLE
Add get_shape_flag intrinsic with contact effect flags

### DIFF
--- a/actors.cc
+++ b/actors.cc
@@ -1547,7 +1547,8 @@ void Actor::get_tile_info(
 	} else {
 		const Shape_info& finfo = flat.get_info();
 		water                   = finfo.is_water();
-		poison                  = finfo.is_poisonous();
+		// For flats, the raw contact-effect bit means terrain poison.
+		poison = finfo.has_contact_effect();
 		// Check for swamp/swamp boots.
 		if (poison && actor) {
 			if ((actor->gear_powers & (Frame_flags::swamp_safe | Frame_flags::poison_safe)) != 0) {

--- a/gamemap.cc
+++ b/gamemap.cc
@@ -1137,7 +1137,8 @@ Ireg_game_object_shared Game_map::create_ireg_object(
 ) {
 	Ireg_game_object_shared newobj;
 	// (These are all animated.)
-	if (info.is_field() && info.get_field_type() >= 0) {
+	// Contact-effect shapes with field type become runtime field objects.
+	if (info.has_contact_effect() && info.get_field_type() >= 0) {
 		newobj = std::make_shared<Field_object>(shnum, frnum, tilex, tiley, lift, Egg_object::fire_field + info.get_field_type());
 	} else if (info.is_animated() || info.has_sfx()) {
 		newobj = std::make_shared<Animated_ireg_object>(shnum, frnum, tilex, tiley, lift);

--- a/mapedit/shapeedit.cc
+++ b/mapedit/shapeedit.cc
@@ -2617,9 +2617,9 @@ void ExultStudio::init_shape_notebook(
 	set_toggle("shinfo_animated_check", info.is_animated());
 	set_toggle("shinfo_solid_check", info.is_solid());
 	set_toggle("shinfo_water_check", info.is_water());
-	// ++++Set poison for flats, field for non-flats.
-	set_toggle("shinfo_poison_check", info.is_poisonous());
-	set_toggle("shinfo_field_check", info.is_field());
+	// Shared contact-effect bit, shown as poison for flats and field for objects.
+	set_toggle("shinfo_poison_check", info.has_contact_effect());
+	set_toggle("shinfo_field_check", info.has_contact_effect());
 	set_toggle("shinfo_door_check", info.is_door());
 	set_toggle("shinfo_barge_check", info.is_barge_part());
 	set_toggle("shinfo_transp_check", info.is_transparent());
@@ -3519,8 +3519,8 @@ void ExultStudio::save_shape_notebook(
 	info.set_animated(get_toggle("shinfo_animated_check"));
 	info.set_solid(get_toggle("shinfo_solid_check"));
 	info.set_water(get_toggle("shinfo_water_check"));
-	// ++++Set poison for flats, field for non-flats.
-	info.set_field(get_toggle("shinfo_field_check") || get_toggle("shinfo_poison_check"));
+	// Shared contact-effect bit, shown as poison for flats and field for objects.
+	info.set_contact_effect(get_toggle("shinfo_field_check") || get_toggle("shinfo_poison_check"));
 	info.set_door(get_toggle("shinfo_door_check"));
 	info.set_barge_part(get_toggle("shinfo_barge_check"));
 	info.set_transparent(get_toggle("shinfo_transp_check"));

--- a/shapes/shapeinf.h
+++ b/shapes/shapeinf.h
@@ -254,7 +254,8 @@ public:
 		fire_field = 0,
 		sleep_field,
 		poison_field,
-		caltrops
+		caltrops_field,
+		campfire_field
 	};
 	friend class Shapes_vga_file;    // Class that reads in data.
 
@@ -803,16 +804,24 @@ public:
 		set_tfa(0, 4, tf);
 	}
 
-	bool is_poisonous() const {    // Swamps.  Applies to tiles.
+	bool has_contact_effect() const {
 		return (tfa[1] & (1 << 4)) != 0;
 	}
 
-	bool is_field() const {    // Applies to Game_objects??
-		return (tfa[1] & (1 << 4)) != 0;
-	}
-
-	void set_field(bool tf) {
+	void set_contact_effect(bool tf) {
 		set_tfa(1, 4, tf);
+	}
+
+	bool is_poisonous() const {    // Legacy tile-facing alias for contact effects.
+		return has_contact_effect();
+	}
+
+	bool is_field() const {    // Legacy object-facing alias for contact effects.
+		return has_contact_effect();
+	}
+
+	void set_field(bool tf) {    // Legacy object-facing setter for contact effects.
+		set_contact_effect(tf);
 	}
 
 	bool is_door() const {

--- a/usecode/bgintrinsics.h
+++ b/usecode/bgintrinsics.h
@@ -251,7 +251,7 @@ USECODE_INTRINSIC_PTR(get_random),                               // 0x00
 		USECODE_INTRINSIC_PTR(set_slider_value),          // 0xe1 (Exult)
 		USECODE_INTRINSIC_PTR(get_slider_value),          // 0xe2 (Exult)
 		USECODE_INTRINSIC_PTR(set_gump_text_font),        // 0xe3 (Exult)
-		USECODE_INTRINSIC_PTR(UNKNOWN),                   // 0xe4
+		USECODE_INTRINSIC_PTR(get_shape_flag),            // 0xe4 (Exult)
 		USECODE_INTRINSIC_PTR(UNKNOWN),                   // 0xe5
 		USECODE_INTRINSIC_PTR(UNKNOWN),                   // 0xe6
 		USECODE_INTRINSIC_PTR(UNKNOWN),                   // 0xe7

--- a/usecode/intrinsics.cc
+++ b/usecode/intrinsics.cc
@@ -2694,6 +2694,164 @@ USECODE_INTRINSIC(is_water) {
 	return Usecode_value(0);
 }
 
+namespace {
+
+	enum Shape_query_flag_id {
+		shape_flag_sfx = 0,
+		shape_flag_strange,
+		shape_flag_contact_effect,
+		shape_flag_water,
+		shape_flag_fire_field,
+		shape_flag_sleep_field,
+		shape_flag_poison_field,
+		shape_flag_caltrops_field,
+		shape_flag_campfire_field,
+		shape_flag_typed_field,
+		shape_flag_animated,
+		shape_flag_solid,
+		shape_flag_transparent,
+		shape_flag_translucent,
+		shape_flag_occludes,
+		shape_flag_light_source,
+		shape_flag_x_obstacle,
+		shape_flag_y_obstacle,
+		shape_flag_door,
+		shape_flag_barge_part,
+		shape_flag_container_locked,
+		shape_flag_extradimensional_storage,
+		shape_flag_quantity_frames,
+		shape_flag_usecode_events,
+		shape_flag_explosive,
+		shape_flag_on_fire,
+		shape_flag_lightweight,
+		shape_flag_body,
+		shape_flag_jawbone,
+		shape_flag_mirror,
+		shape_flag_spell,
+		shape_flag_count
+	};
+
+	bool eval_shape_flag(const Shape_info& info, int flag_id) {
+		switch (flag_id) {
+		case shape_flag_sfx:
+			return info.has_sfx();
+		case shape_flag_strange:
+			return info.has_strange_movement();
+		case shape_flag_contact_effect:
+			return info.has_contact_effect();
+		case shape_flag_water:
+			return info.is_water();
+		case shape_flag_fire_field:
+			return info.get_field_type() == Shape_info::fire_field;
+		case shape_flag_sleep_field:
+			return info.get_field_type() == Shape_info::sleep_field;
+		case shape_flag_poison_field:
+			return info.get_field_type() == Shape_info::poison_field;
+		case shape_flag_caltrops_field:
+			return info.get_field_type() == Shape_info::caltrops_field;
+		case shape_flag_campfire_field:
+			return info.get_field_type() == Shape_info::campfire_field;
+		case shape_flag_typed_field:
+			return info.get_field_type() != Shape_info::no_field;
+		case shape_flag_animated:
+			return info.is_animated();
+		case shape_flag_solid:
+			return info.is_solid();
+		case shape_flag_transparent:
+			return info.is_transparent();
+		case shape_flag_translucent:
+			return info.has_translucency();
+		case shape_flag_occludes:
+			return info.occludes();
+		case shape_flag_light_source:
+			return info.is_light_source();
+		case shape_flag_x_obstacle:
+			return info.is_xobstacle();
+		case shape_flag_y_obstacle:
+			return info.is_yobstacle();
+		case shape_flag_door:
+			return info.is_door();
+		case shape_flag_barge_part:
+			return info.is_barge_part();
+		case shape_flag_container_locked:
+			return info.is_container_locked();
+		case shape_flag_extradimensional_storage:
+			return info.has_extradimensional_storage();
+		case shape_flag_quantity_frames:
+			return info.has_quantity_frames();
+		case shape_flag_usecode_events:
+			return info.has_usecode_events();
+		case shape_flag_explosive:
+			return info.is_explosive();
+		case shape_flag_on_fire:
+			return info.is_on_fire();
+		case shape_flag_lightweight:
+			return info.is_lightweight();
+		case shape_flag_body:
+			return info.is_body_shape();
+		case shape_flag_jawbone:
+			return info.is_jawbone();
+		case shape_flag_mirror:
+			return info.is_mirror();
+		case shape_flag_spell:
+			return info.is_spell();
+		default:
+			return false;
+		}
+	}
+
+	const Shape_info* get_shape_info_for_shape(int shapenum) {
+		Shape_manager* sman = Shape_manager::get_instance();
+		if (!sman || shapenum < 0 || shapenum >= sman->get_shapes().get_num_shapes()) {
+			return nullptr;
+		}
+		return &ShapeID::get_info(shapenum);
+	}
+
+	bool eval_flat_shape_flag(Game_window* gwin, int xpos, int ypos, int flag_id) {
+		const int x   = (xpos - gwin->get_scrolltx()) * c_tilesize;
+		const int y   = (ypos - gwin->get_scrollty()) * c_tilesize;
+		ShapeID   sid = gwin->get_flat(x, y);
+		return !sid.is_invalid() && eval_shape_flag(sid.get_info(), flag_id);
+	}
+
+}    // namespace
+
+USECODE_INTRINSIC(get_shape_flag) {
+	if (num_parms < 2) {
+		return Usecode_value(0);
+	}
+	const int flag_id = parms[1].get_int_value();
+	if (flag_id < 0 || flag_id >= shape_flag_count) {
+		return Usecode_value(0);
+	}
+
+	const Usecode_value& target = parms[0];
+	const size_t         size   = target.get_array_size();
+	if (size) {
+		if (size == 4) {
+			if (Game_object* obj = get_item(target.get_elem(0))) {
+				return Usecode_value(eval_shape_flag(obj->get_info(), flag_id));
+			}
+			return Usecode_value(
+					eval_flat_shape_flag(gwin, target.get_elem(1).get_int_value(), target.get_elem(2).get_int_value(), flag_id));
+		}
+		if (size == 2 || size == 3) {
+			return Usecode_value(
+					eval_flat_shape_flag(gwin, target.get_elem(0).get_int_value(), target.get_elem(1).get_int_value(), flag_id));
+		}
+		return Usecode_value(0);
+	}
+
+	if (target.is_ptr() || target.get_int_value() < 0) {
+		Game_object* obj = get_item(target);
+		return Usecode_value(obj ? eval_shape_flag(obj->get_info(), flag_id) : 0);
+	}
+
+	const Shape_info* info = get_shape_info_for_shape(target.get_int_value());
+	return Usecode_value(info ? eval_shape_flag(*info, flag_id) : 0);
+}
+
 USECODE_INTRINSIC(run_endgame) {
 	ignore_unused_variable_warning(num_parms);
 	Audio::get_ptr()->stop_sound_effects();

--- a/usecode/sibetaintrinsics.h
+++ b/usecode/sibetaintrinsics.h
@@ -254,7 +254,7 @@ USECODE_INTRINSIC_PTR(get_random),                               // 0x00
 		USECODE_INTRINSIC_PTR(set_slider_value),          // 0xe1 (Exult)
 		USECODE_INTRINSIC_PTR(get_slider_value),          // 0xe2 (Exult)
 		USECODE_INTRINSIC_PTR(set_gump_text_font),        // 0xe3 (Exult)
-		USECODE_INTRINSIC_PTR(UNKNOWN),                   // 0xe4
+		USECODE_INTRINSIC_PTR(get_shape_flag),            // 0xe4 (Exult)
 		USECODE_INTRINSIC_PTR(UNKNOWN),                   // 0xe5
 		USECODE_INTRINSIC_PTR(UNKNOWN),                   // 0xe6
 		USECODE_INTRINSIC_PTR(UNKNOWN),                   // 0xe7

--- a/usecode/siintrinsics.h
+++ b/usecode/siintrinsics.h
@@ -258,7 +258,7 @@ USECODE_INTRINSIC_PTR(get_random),                               // 0x00
 		USECODE_INTRINSIC_PTR(set_slider_value),          // 0xe2 (Exult)
 		USECODE_INTRINSIC_PTR(get_slider_value),          // 0xe3 (Exult)
 		USECODE_INTRINSIC_PTR(set_gump_text_font),        // 0xe4 (Exult)
-		USECODE_INTRINSIC_PTR(UNKNOWN),                   // 0xe5
+		USECODE_INTRINSIC_PTR(get_shape_flag),            // 0xe5 (Exult)
 		USECODE_INTRINSIC_PTR(UNKNOWN),                   // 0xe6
 		USECODE_INTRINSIC_PTR(UNKNOWN),                   // 0xe7
 		USECODE_INTRINSIC_PTR(UNKNOWN),                   // 0xe8

--- a/usecode/ucinternal.h
+++ b/usecode/ucinternal.h
@@ -309,6 +309,7 @@ class Usecode_internal : public Usecode_machine {
 	USECODE_INTRINSIC_DECL(start_speech);
 	USECODE_INTRINSIC_DECL(start_blocking_speech);
 	USECODE_INTRINSIC_DECL(is_water);
+	USECODE_INTRINSIC_DECL(get_shape_flag);
 	USECODE_INTRINSIC_DECL(run_endgame);
 	USECODE_INTRINSIC_DECL(fire_projectile);
 	USECODE_INTRINSIC_DECL(nap_time);


### PR DESCRIPTION
https://github.com/exult/exult/issues/968

In addition to the discussion above:

New Exult usecode intrinsic, `UI_get_shape_flag`, for querying shape metadata from usecode.

Changes

- Adds `UI_get_shape_flag(mixed target, int flag_id)`
- Supports scalar shape ids, object refs, tile coordinates, and `[obj, x, y, z]` targets
- Binds the intrinsic for BG, SI, and SI beta
- Adds `Shape_info::has_contact_effect()` / `set_contact_effect()` for the shared contact-effect TFA bit
- Keeps `is_poisonous()`, `is_field()`, and `set_field()` as legacy wrappers
- Updates existing Exult and Exult Studio call sites to use the contact-effect naming
- Adds field-type query flags for fire, sleep, poison, caltrops, campfire, and typed fields
- Adds `campfire_field` to `Shape_info::Field_types`

Notes

The old field/poisonous storage bit is exposed as `contact_effect`, since the same TFA bit is used for terrain poison/contact behavior and typed field objects. Specific field behavior is queried separately through the field-type flags.

The older `is_poisonous()`, `is_field()`, and `set_field()` accessors have been kept as legacy wrappers around the new contact effect accessors. Call sites were updated, but keeping the wrappers avoids breaking any missed call sites or external code that may still use the old names for the time being.

The new flag list:
```
0  sfx
1  strange_movement

2  contact_effect

3  water

4  fire_field
5  sleep_field
6  poison_field
7  caltrops_field
8  campfire_field
9  typed_field

10 animated
11 solid
12 transparent
13 translucent
14 occludes
15 light_source

16 x_obstacle
17 y_obstacle
18 door
19 barge_part

20 container_locked
21 extradimensional_storage
22 quantity_frames
23 usecode_events
24 explosive
25 on_fire
26 lightweight

27 body
28 jawbone
29 mirror
30 spell
```

These have been grouped by the following categories:
```
Audio / Movement
0  sfx
1  strange_movement

Raw Contact Effect
2  contact_effect

Terrain
3  water

Field Types
4  fire_field
5  sleep_field
6  poison_field
7  caltrops_field
8  campfire_field
9  typed_field

Rendering / Physical Shape
10 animated
11 solid
12 transparent
13 translucent
14 occludes
15 light_source

Map / Object Interaction
16 x_obstacle
17 y_obstacle
18 door
19 barge_part

Shape Flags / Special Behavior
20 container_locked
21 extradimensional_storage
22 quantity_frames
23 usecode_events
24 explosive
25 on_fire
26 lightweight

Special Shape Classes
27 body
28 jawbone
29 mirror
30 spell
```


Testing

- Built `Exult.exe`, `exult_studio.exe`, and `ucc.exe` with MinGW64
- Tested the intrinsic locally against the below

Poison Field
```
Shape target: object= shape=900 frame=6
Shape flags:  | sfx | contact_effect | poison_field | typed_field | animated
```
Fire Field
```
Shape target: object= shape=895 frame=8
Shape flags:  | sfx | contact_effect | fire_field | typed_field | animated | translucent | light_source | on_fire
```
Force Field
```
Shape target: object= shape=768 frame=15
Shape flags:  | sfx | animated | solid | translucent
```
Sleep Field
```
Shape target: object= shape=902 frame=8
Shape flags:  | sfx | contact_effect | sleep_field | typed_field | animated | x_obstacle
```
Water Tile
```
Shape target: tile=(2167,2742,0)
Shape flags:  | water | solid
```
Firedoom Staff
```
Shape target: object= shape=553 frame=0
Shape flags: sfx | solid | light_source | x_obstacle | y_obstacle
```
Serpent Jawbone
```
Shape target: object= shape=555 frame=0
Shape flags: solid | y_obstacle | jawbone
```
