### PR TITLE
Smooth actor movement between tile steps

### DIFF
--- a/actions.cc
+++ b/actions.cc
@@ -291,15 +291,11 @@ int Path_walking_actor_action::handle_event(Actor* actor) {
 	if (done) {    // In case we're deleted.
 		reached_end = true;
 	}
-	const Tile_coord cur        = actor->get_tile();
-	const int        newdir     = static_cast<int>(Get_direction4(cur.ty - tile.ty, tile.tx - cur.tx));
-	Frames_sequence* frames     = actor->get_frames(newdir);
-	int&             step_index = actor->get_step_index();
-	if (!step_index) {    // First time?  Init.
-		step_index = frames->find_unrotated(actor->get_framenum());
-	}
-	// Get next (updates step_index).
-	const int frame     = frames->get_next(step_index);
+	const Tile_coord cur    = actor->get_tile();
+	const int        newdir = static_cast<int>(
+            Get_direction4(cur.ty - tile.ty, tile.tx - cur.tx));
+	bool      advance_frame;
+	const int frame = actor->get_next_walk_frame(newdir, advance_frame);
 	const int cur_speed = speed;    // Step() might delete us!
 	if (from_offscreen) {           // Teleport to 1st spot.
 		from_offscreen = false;
@@ -325,7 +321,7 @@ int Path_walking_actor_action::handle_event(Actor* actor) {
 		return 0;
 	}
 	reached_end = false;
-	frames->decrement(step_index);    // We didn't take the step.
+	actor->restore_walk_frame(newdir, advance_frame);
 	// Blocked by a door?
 	if (actor->distance(tile) <= 2 && !cheat.in_map_editor() &&    // And NOT map-editing?
 		actor->is_sentient()) {

--- a/actors.cc
+++ b/actors.cc
@@ -765,6 +765,17 @@ bool Actor::add_dirty(bool figure_rect    // Recompute weapon rectangle.
 	if (!gwin->add_dirty(this)) {
 		return false;
 	}
+	int body_xoff;
+	int body_yoff;
+	gwin->get_shape_location(this, body_xoff, body_yoff);
+	if (get_render_offset(body_xoff, body_yoff)) {
+		Shape_frame* shape = get_shape();
+		if (shape) {
+			TileRect rect = gwin->get_shape_rect(shape, body_xoff, body_yoff);
+			rect.enlarge(1 + c_tilesize / 2);
+			gwin->add_dirty(gwin->clip_to_win(rect));
+		}
+	}
 	if (figure_rect || get_casting_mode() == Actor::show_casting_frames) {
 		int weapon_x;
 		int weapon_y;
@@ -788,6 +799,9 @@ bool Actor::add_dirty(bool figure_rect    // Recompute weapon rectangle.
 		int      xoff;
 		int      yoff;
 		gwin->get_shape_location(this, xoff, yoff);
+		if (get_render_offset(xoff, yoff)) {
+			r.enlarge(c_tilesize);
+		}
 		r.shift(xoff, yoff);
 		r.enlarge(c_tilesize / 2);
 		gwin->add_dirty(gwin->clip_to_win(r));
@@ -913,6 +927,11 @@ Game_object* Actor::find_blocking(const Tile_coord& tile, int dir) {
  */
 inline void Actor::movef(Map_chunk* old_chunk, Map_chunk* new_chunk, int new_sx, int new_sy, int new_frame, int new_lift) {
 	const Game_object_shared keep = shared_from_this();
+	const Tile_coord         old_tile = get_tile();
+	const Tile_coord         new_tile(
+			new_chunk->get_cx() * c_tiles_per_chunk + new_sx,
+			new_chunk->get_cy() * c_tiles_per_chunk + new_sy,
+			new_lift >= 0 ? new_lift : old_tile.tz);
 	if (old_chunk) {    // Remove from current chunk.
 		old_chunk->remove(this);
 	}
@@ -923,7 +942,54 @@ inline void Actor::movef(Map_chunk* old_chunk, Map_chunk* new_chunk, int new_sx,
 	if (new_lift >= 0) {
 		set_lift(new_lift);
 	}
+	const int dx = (new_tile.tx - old_tile.tx + c_num_tiles) % c_num_tiles;
+	const int dy = (new_tile.ty - old_tile.ty + c_num_tiles) % c_num_tiles;
+	const int lerp = gwin->is_lerping_enabled();
+	if (lerp > 0 && gwin->get_smooth_actor_movement() && old_tile != new_tile
+		&& (dx <= 1 || dx >= c_num_tiles - 1)
+		&& (dy <= 1 || dy >= c_num_tiles - 1)) {
+		int       duration
+				= frame_time > 0 ? frame_time : gwin->get_std_delay();
+		duration = (duration * lerp) / 100;
+		render_prev_tile      = old_tile;
+		render_move_start     = Game::get_ticks();
+		render_move_duration  = duration > 0 ? duration : gwin->get_std_delay();
+	} else {
+		render_move_duration = 0;
+	}
 	new_chunk->add(this);
+}
+
+bool Actor::get_render_offset(int& xoff, int& yoff) const {
+	if (render_move_duration <= 0 || !gwin->get_smooth_actor_movement()
+		|| gwin->is_camera_actor_lerped(this)) {
+		return false;
+	}
+	const unsigned long now     = Game::get_ticks();
+	const unsigned long elapsed = now - render_move_start;
+	if (elapsed >= static_cast<unsigned long>(render_move_duration)) {
+		return false;
+	}
+	const Tile_coord tile = get_tile();
+	int              dx   = tile.tx - render_prev_tile.tx;
+	int              dy   = tile.ty - render_prev_tile.ty;
+	if (dx > c_num_tiles / 2) {
+		dx -= c_num_tiles;
+	} else if (dx < -c_num_tiles / 2) {
+		dx += c_num_tiles;
+	}
+	if (dy > c_num_tiles / 2) {
+		dy -= c_num_tiles;
+	} else if (dy < -c_num_tiles / 2) {
+		dy += c_num_tiles;
+	}
+	const int remaining = render_move_duration - static_cast<int>(elapsed);
+	const int lift_delta = tile.tz - render_prev_tile.tz;
+	const int xdelta     = -dx * c_tilesize + lift_delta * 4;
+	const int ydelta     = -dy * c_tilesize + lift_delta * 4;
+	xoff += xdelta * remaining / render_move_duration;
+	yoff += ydelta * remaining / render_move_duration;
+	return true;
 }
 
 /**
@@ -941,7 +1007,8 @@ Actor::Actor(const std::string& nm, int shapenum, int num, int uc)
 		  dormant(true), hit(false), combat_protected(false), user_set_attack(false), alignment(0), charmalign(0),
 		  two_handed(false), two_fingered(false), use_scabbard(false), use_neck(false), light_sources(0), usecode_dir(0),
 		  type_flags(0), gear_immunities(0), gear_powers(0), ident(0), skin_color(-1), action(nullptr), frame_time(0),
-		  step_index(0), qsteps(0), weapon_rect(0, 0, 0, 0), rest_time(0) {
+		  step_index(0), qsteps(0), walk_frame_elapsed(0), render_prev_tile(0, 0, 0), render_move_start(0),
+		  render_move_duration(0), weapon_rect(0, 0, 0, 0), rest_time(0) {
 	set_shape(shapenum, 0);
 	init();
 	frames = &npc_frames[0];    // Default:  5-frame walking.
@@ -1234,6 +1301,30 @@ void Actor::init_default_frames() {
 	avatar_frames[static_cast<int>(south) / 2] = &avatar_south_frames;
 	avatar_frames[static_cast<int>(east) / 2]  = &avatar_east_frames;
 	avatar_frames[static_cast<int>(west) / 2]  = &avatar_west_frames;
+}
+
+int Actor::get_next_walk_frame(int dir, bool& advanced) {
+	constexpr int walking_frame_msecs = 500;    // Original 2 FPS cadence.
+	Frames_sequence* sequence = get_frames(dir);
+	if (!step_index) {
+		step_index = sequence->find_unrotated(get_framenum());
+	}
+	walk_frame_elapsed = std::min(
+			walking_frame_msecs,
+			walk_frame_elapsed + gwin->get_std_delay());
+	advanced = walk_frame_elapsed >= walking_frame_msecs;
+	if (advanced) {
+		walk_frame_elapsed -= walking_frame_msecs;
+		return sequence->get_next(step_index);
+	}
+	return get_dir_framenum(dir, get_framenum());
+}
+
+void Actor::restore_walk_frame(int dir, bool advanced) {
+	if (advanced) {
+		get_frames(dir)->decrement(step_index);
+		walk_frame_elapsed = 500;
+	}
 }
 
 /*
@@ -2080,6 +2171,7 @@ void Actor::paint() {
 		int xoff;
 		int yoff;
 		gwin->get_shape_location(this, xoff, yoff);
+		get_render_offset(xoff, yoff);
 		const bool invis = flags & (1L << Obj_flags::invisible);
 		if (invis && party_id < 0 && npc_num != 0) {
 			return;    // Don't render invisible NPCs not in party.
@@ -2132,6 +2224,7 @@ void Actor::paint_weapon() {
 		int xoff;
 		int yoff;
 		gwin->get_shape_location(this, xoff, yoff);
+		get_render_offset(xoff, yoff);
 		xoff += weapon_x;
 		yoff += weapon_y;
 

--- a/actors.cc
+++ b/actors.cc
@@ -2441,7 +2441,37 @@ void Actor::update_from_studio(unsigned char* data, int datalen) {
 #endif
 }
 
+void Actor::consolidate_backpack_gold() {
+	Game_object* bp = get_readied(backpack);
+	if (!bp) {
+		return;
+	}
+	Container_game_object* cont = bp->as_container();
+	if (cont) {
+		cont->consolidate_gold(c_gold_coin_shapenum);
+	}
+}
+
+void Maybe_consolidate_backpack_gold(Container_game_object* cont) {
+	if (!cont) {
+		return;
+	}
+	Game_object* owner = cont->get_owner();
+	if (!owner) {
+		return;
+	}
+	Actor* act = owner->as_actor();
+	if (!act || !act->is_in_party()) {
+		return;
+	}
+	if (act->get_readied(backpack) != cont) {
+		return;
+	}
+	cont->consolidate_gold(c_gold_coin_shapenum);
+}
+
 void Actor::show_inventory() {
+	consolidate_backpack_gold();
 	Gump_manager* gump_man = gumpman;
 
 	const int shapenum = inventory_shapenum();

--- a/actors.h
+++ b/actors.h
@@ -144,6 +144,10 @@ protected:
 	//   actor not moving.
 	int step_index;    // Index into walking frames, 1 1st.
 	int qsteps;        // # steps since last quake.
+	int walk_frame_elapsed;    // Time credit for walking-pose animation.
+	Tile_coord render_prev_tile;    // Previous tile for smooth walking.
+	unsigned long render_move_start;
+	int           render_move_duration;
 
 	std::unique_ptr<Npc_timer_list> timers;         // Timers for poison, hunger, etc.
 	TileRect                        weapon_rect;    // Screen area weapon was drawn in.
@@ -151,6 +155,7 @@ protected:
 	void                            init();         // Clear stuff during construction.
 	// Move and change frame.
 	void movef(Map_chunk* old_chunk, Map_chunk* new_chunk, int new_sx, int new_sy, int new_frame, int new_lift);
+	bool get_render_offset(int& xoff, int& yoff) const;
 	bool is_really_blocked(Tile_coord& t, bool force);
 	// Empty one hand
 	bool empty_hand(Game_object* obj, Game_object_shared* keep);
@@ -191,6 +196,8 @@ public:
 	int& get_step_index() {    // Get it (for updating).
 		return step_index;
 	}
+	int  get_next_walk_frame(int dir, bool& advanced);
+	void restore_walk_frame(int dir, bool advanced);
 
 	// Get attack frames.
 	int get_attack_frames(int weapon, bool projectile, int dir, signed char* frames) const;

--- a/actors.h
+++ b/actors.h
@@ -809,6 +809,7 @@ public:
 
 	void show_inventory();
 	int  inventory_shapenum();
+	void consolidate_backpack_gold();
 
 	bool was_hit() {
 		return hit;
@@ -819,6 +820,9 @@ public:
 	bool in_usecode_control() const;
 	bool quake_on_walk();
 };
+
+// Consolidate gold if this is a party member's backpack.
+void Maybe_consolidate_backpack_gold(Container_game_object* cont);
 
 using Actor_shared = std::shared_ptr<Actor>;
 

--- a/exult.cc
+++ b/exult.cc
@@ -550,7 +550,9 @@ int exult_main(const char* runpath) {
 		}
 		config->remove("config/gameplay/allow_double_right_move", false);
 	}
-
+	if (!config->key_exists("config/gameplay/default_mod")) {
+		config->set("config/gameplay/default_mod", "", true);
+	}
 	// Setup virtual directories
 	string data_path;
 	config->value("config/disk/data_path", data_path, EXULT_DATADIR);
@@ -918,7 +920,17 @@ static void Init() {
 					// Prints error messages:
 					newgame = basegame->get_mod(arg_modname);
 				} else {
-					newgame = basegame;
+					string default_mod;
+					config->value("config/gameplay/default_mod", default_mod, "");
+					if (!default_mod.empty()) {
+						ModInfo* mod = basegame->find_mod(default_mod);
+						if (mod && mod->is_mod_compatible()) {
+							newgame = mod;
+						}
+					}
+					if (!newgame) {
+						newgame = basegame;
+					}
 				}
 				arg_modname = "default";
 			} else {
@@ -976,6 +988,21 @@ static void Init() {
 			exit(error);
 		}
 #endif
+		// If no game was selected, try the configured default mod before the
+		// Exult menu.
+		if (!newgame) {
+			string default_mod;
+			config->value("config/gameplay/default_mod", default_mod, "");
+			if (!default_mod.empty()) {
+				for (auto& game : gamemanager->get_game_list()) {
+					ModInfo* mod = game.find_mod(default_mod);
+					if (mod && mod->is_mod_compatible()) {
+						newgame = mod;
+						break;
+					}
+				}
+			}
+		}
 		if (!newgame) {
 			ExultMenu exult_menu(gwin);
 			newgame = exult_menu.run();

--- a/exult_constants.h
+++ b/exult_constants.h
@@ -47,6 +47,9 @@ constexpr const int c_any_qual     = -359;
 constexpr const int c_any_framenum = -359;
 constexpr const int c_any_quantity = -359;
 
+// Gold coin shape # (same in BG and SI).
+constexpr const int c_gold_coin_shapenum = 644;
+
 // Maximum number of shapes:
 constexpr const int c_max_shapes = 2048;
 constexpr const int c_occsize    = c_max_shapes / 8 + ((c_max_shapes % 8) != 0 ? 1 : 0);

--- a/gamemgr/bggame.cc
+++ b/gamemgr/bggame.cc
@@ -245,6 +245,10 @@ BG_Game::BG_Game() : shapes(ENDSHAPE_FLX, -1, PATCH_ENDSHAPE) {
 	fontManager.add_font("NORMAL_FONT", font_source, font_patch, 0, -1);
 	fontManager.add_font("SMALL_BLACK_FONT", font_source, font_patch, 2, 0);
 	fontManager.add_font("TINY_BLACK_FONT", font_source, font_patch, 4, 0);
+	Palette font_palette;
+	font_palette.load(PALETTES_FLX, PATCH_PALETTES, 0);
+	fontManager.get_font("TINY_BLACK_FONT")
+			->set_monochrome_color(font_palette.find_color(0, 0, 0));
 
 	if (font_config == "original" || font_config == "serif") {
 		fontManager.add_font("MENU_FONT", font_source, font_patch, 16, 1);

--- a/gamemgr/sigame.cc
+++ b/gamemgr/sigame.cc
@@ -218,6 +218,10 @@ SI_Game::SI_Game() {
 
 	fontManager.add_font("SMALL_BLACK_FONT", font_source, font_patch, 2, 0);
 	fontManager.add_font("TINY_BLACK_FONT", font_source, font_patch, 4, 0);
+	Palette font_palette;
+	font_palette.load(PALETTES_FLX, PATCH_PALETTES, 0);
+	fontManager.get_font("TINY_BLACK_FONT")
+			->set_monochrome_color(font_palette.find_color(0, 0, 0));
 
 	if (font_config == "original" || font_config == "serif") {
 		fontManager.add_font("MENU_FONT", font_source, font_patch, 17, 1);

--- a/gamewin.cc
+++ b/gamewin.cc
@@ -309,14 +309,15 @@ Game_window::Game_window(
 		  gump_man(new Gump_manager), party_man(new Party_manager), win(nullptr), npc_prox(new Npc_proximity_handler(this)),
 		  pal(nullptr), tqueue(new Time_queue()), background_noise(new Background_noise(this)), usecode(nullptr), combat(false),
 		  focus(true), ice_dungeon(false), painted(false), ambient_light(false), infravision_active(false), skip_above_actor(31),
-		  in_dungeon(0), num_npcs1(0), std_delay(c_std_delay), time_stopped(0), special_light(0), theft_warnings(0), theft_cx(255),
+		  in_dungeon(0), num_npcs1(0), std_delay(c_std_delay), configured_std_delay(c_std_delay),
+		  configured_combat_std_delay(c_std_delay), time_stopped(0), special_light(0), theft_warnings(0), theft_cx(255),
 		  theft_cy(255), moving_barge(nullptr), main_actor(nullptr), camera_actor(nullptr), npcs(0), bodies(0), scrolltx(0),
 		  scrollty(0), dirty(0, 0, 0, 0), save_names{}, mouse3rd(false), fastmouse(false), double_click_closes_gumps(false),
 		  text_bg(false), step_tile_delta(8), allow_right_pathfind(2), scroll_with_mouse(false), alternate_drop(false),
 		  allow_autonotes(false), allow_enhancements(false), in_exult_menu(false), extended_intro(false), load_palette_timer(0),
 		  plasma_start_color(0), plasma_cycle_range(0), skip_lift(255), paint_eggs(false), paint_egg_areas(0), armageddon(false),
 		  walk_in_formation(false), debug(0), blits(0), scrolltx_l(0), scrollty_l(0), scrolltx_lp(0), scrollty_lp(0),
-		  scrolltx_lo(0), scrollty_lo(0), avposx_ld(0), avposy_ld(0), lerping_enabled(0) {
+		  scrolltx_lo(0), scrollty_lo(0), avposx_ld(0), avposy_ld(0), lerping_enabled(0), smooth_actor_movement(true) {
 	game_window = this;    // Set static ->.
 	clock       = new Game_clock(tqueue);
 	shape_man   = new Shape_manager();    // Create the single instance.
@@ -385,6 +386,11 @@ Game_window::Game_window(
 
 	config->value("config/gameplay/smooth_scrolling", lerping_enabled, 0);
 	config->set("config/gameplay/smooth_scrolling", lerping_enabled, false);
+	config->value("config/gameplay/smooth_actor_movement", str, "yes");
+	smooth_actor_movement = str != "no";
+	config->set(
+			"config/gameplay/smooth_actor_movement",
+			smooth_actor_movement ? "yes" : "no", false);
 	config->value("config/gameplay/alternate_drop", str, "no");
 	alternate_drop = str == "yes";
 	config->set("config/gameplay/alternate_drop", alternate_drop ? "yes" : "no", false);

--- a/gamewin.h
+++ b/gamewin.h
@@ -850,6 +850,8 @@ private:
 	int avposx_ld, avposy_ld;
 	// Is lerping enabled
 	int lerping_enabled;
+	// Is actor interpolation enabled
+	bool smooth_actor_movement;
 
 public:
 	// Reset (well update really) saved lerp scroll positions
@@ -870,12 +872,25 @@ public:
 		return lerping_enabled;
 	}
 
+	bool get_smooth_actor_movement() const {
+		return smooth_actor_movement;
+	}
+
+	bool is_camera_actor_lerped(const Actor* actor) const {
+		return actor == camera_actor
+			   && (avposx_ld || avposy_ld || scrolltx_lo || scrollty_lo);
+	}
+
 	void set_lerping_enabled(int e) {
 		lerping_enabled = e;
 	}
 
 	Game_render* get_render() {
 		return render;
+	}
+
+	void set_smooth_actor_movement(bool e) {
+		smooth_actor_movement = e;
 	}
 };
 

--- a/gumps/GameDisplayOptions_gump.cc
+++ b/gumps/GameDisplayOptions_gump.cc
@@ -46,6 +46,7 @@
 #include "Gump_manager.h"
 #include "ShortcutBar_gump.h"
 #include "Text_button.h"
+#include "files/U7obj.h"
 #include "exult.h"
 #include "font.h"
 #include "game.h"
@@ -461,6 +462,7 @@ void GameDisplayOptions_gump::save_settings() {
 	}
 	gwin->set_lerping_enabled(smooth_scrolling * 25);
 	config->set("config/gameplay/smooth_scrolling", smooth_scrolling * 25, false);
+	gwin->set_smooth_actor_movement(smooth_scrolling > 0);
 	config->set("config/gameplay/skip_intro", usecode_intro ? "yes" : "no", false);
 	config->set("config/gameplay/extended_intro", extended_intro ? "yes" : "no", false);
 	gwin->set_extended_intro(extended_intro);

--- a/gumps/GameEngineOptions_gump.cc
+++ b/gumps/GameEngineOptions_gump.cc
@@ -144,7 +144,7 @@ namespace {
 		}
 	};
 
-	std::array framerates{2, 4, 5, 6, 8, 10, -1};
+	std::array framerates{2, 4, 5, 6, 8, 10, 15, 20, -1};
 	// -1 is placeholder for custom framerate
 	constexpr const size_t num_default_rates = framerates.size() - 1;
 

--- a/gumps/Gump_ToggleButton.cc
+++ b/gumps/Gump_ToggleButton.cc
@@ -77,6 +77,13 @@ bool Gump_ToggleTextButton::activate(MouseButton button) {
 
 void Gump_ToggleTextButton::setselection(int selectionnum) {
 	set_frame(selectionnum);
+	if (selectionnum >= 0
+		&& size_t(selectionnum) < selections.size()) {
+		text = selections[selectionnum];
+	} else {
+		text.clear();
+	}
+	init();
 	gwin->add_dirty(get_rect());
 }
 

--- a/gumps/ShortcutBar_gump.cc
+++ b/gumps/ShortcutBar_gump.cc
@@ -308,8 +308,16 @@ ShortcutBar_gump::~ShortcutBar_gump() {
 void ShortcutBar_gump::paint() {
 	Game_window*   gwin = Game_window::get_instance();
 	Shape_manager* sman = Shape_manager::get_instance();
+	Image_window8* win  = gwin->get_win();
 
 	Gump::paint();
+	const int bar_x = locx + (gamex - 320) / 2;
+	const int bar_y = locy + starty;
+	constexpr unsigned char pavement_grey = 128;
+	win->fill8(pavement_grey, 320, height, bar_x, bar_y);
+	const unsigned char line = sman->get_special_pixel(PROTECT_PIXEL);
+	win->fill8(line, 320, 1, bar_x, bar_y);
+	win->fill8(line, 320, 1, bar_x, bar_y + height - 1);
 
 	for (int i = 0; i < numButtons; i++) {
 		const ShortcutBarButtonItem& item  = buttonItems[i];

--- a/objs/contain.cc
+++ b/objs/contain.cc
@@ -26,6 +26,7 @@
 #include "contain.h"
 
 #include "Gump_manager.h"
+#include "actors.h"
 #include "ShortcutBar_gump.h"
 #include "cheat.h"
 #include "databuf.h"
@@ -42,6 +43,9 @@
 #include "ucmachine.h"
 #include "ucsched.h"
 #include "weaponinf.h"
+
+#include <algorithm>
+#include <vector>
 
 #ifdef USE_EXULTSTUDIO
 #	include "objserial.h"
@@ -107,6 +111,7 @@ bool Container_game_object::add(
 		bool noset    // True to prevent actors from setting sched. weapon.
 ) {
 	ignore_unused_variable_warning(noset);
+	const int added_shapenum = obj->get_shapenum();
 	// Prevent dragging the avatar into a container.
 	// Casting to void* to avoid including actors.h.
 	if (obj == static_cast<void*>(gwin->get_main_actor())) {
@@ -148,6 +153,9 @@ bool Container_game_object::add(
 			if (g_shortcutBar) {
 				g_shortcutBar->check_for_updates(shape_num);
 			}
+			if (shape_num == c_gold_coin_shapenum) {
+				Maybe_consolidate_backpack_gold(this);
+			}
 			return true;
 		} else if (newquant < quant) {    // Partly successful.
 			obj->modify_quantity(newquant - quant);
@@ -171,7 +179,82 @@ bool Container_game_object::add(
 	if (g_shortcutBar) {
 		g_shortcutBar->check_for_updates(obj->get_shapenum());
 	}
+	if (added_shapenum == c_gold_coin_shapenum) {
+		Maybe_consolidate_backpack_gold(this);
+	}
 	return true;
+}
+
+/*
+ *  Combine gold coins in this container into piles of 100.
+ */
+
+void Container_game_object::consolidate_gold(int shapenum) {
+	static int consolidating = 0;
+	if (consolidating || !Can_be_added(this, shapenum)) {
+		return;
+	}
+	Game_object_vector gold_objs;
+	int                total = 0;
+	Game_object*       obj;
+	Object_iterator    next(objects);
+	while ((obj = next.get_next()) != nullptr) {
+		if (obj->get_shapenum() == shapenum) {
+			gold_objs.push_back(obj);
+			total += obj->get_quantity();
+		}
+	}
+	if (gold_objs.empty()) {
+		return;
+	}
+	std::vector<int> expected;
+	int              remaining = total;
+	while (remaining >= 100) {
+		expected.push_back(100);
+		remaining -= 100;
+	}
+	if (remaining > 0) {
+		expected.push_back(remaining);
+	}
+	std::vector<int> current;
+	current.reserve(gold_objs.size());
+	for (Game_object* gold : gold_objs) {
+		current.push_back(gold->get_quantity());
+	}
+	std::sort(current.begin(), current.end(), std::greater<int>());
+	if (current == expected) {
+		return;
+	}
+	++consolidating;
+	const Shape_info& shp_info = ShapeID::get_info(shapenum);
+	for (size_t i = 0; i < expected.size(); ++i) {
+		const int want = expected[i];
+		if (i < gold_objs.size()) {
+			Game_object* pile = gold_objs[i];
+			const int    have = pile->get_quantity();
+			if (have != want) {
+				pile->modify_quantity(want - have);
+			}
+		} else {
+			Game_object_shared newobj = gmap->create_ireg_object(
+					shp_info, shapenum, 0, 0, 0, 0);
+			if (!add(newobj.get())) {
+				newobj.reset();
+				break;
+			}
+			int left = want - 1;
+			if (left > 0) {
+				newobj->modify_quantity(left);
+			}
+		}
+	}
+	for (size_t i = expected.size(); i < gold_objs.size(); ++i) {
+		gold_objs[i]->remove_this();
+	}
+	--consolidating;
+	if (g_shortcutBar) {
+		g_shortcutBar->check_for_updates(shapenum);
+	}
 }
 
 /*
@@ -222,6 +305,7 @@ int Container_game_object::add_quantity(
 	if (delta <= 0 || !Can_be_added(this, shapenum)) {
 		return delta;
 	}
+	const int start_delta = delta;
 
 	int cant_add  = 0;                   // # we can't add due to weight.
 	int maxweight = get_max_weight();    // Check weight.
@@ -264,11 +348,19 @@ int Container_game_object::add_quantity(
 			delta = obj->add_quantity(delta, shapenum, qual, framenum, true, temporary);
 		}
 	}
+	int result;
 	if (!delta || dontcreate) {    // All added?
-		return delta + cant_add;
+		result = delta + cant_add;
 	} else {
-		return cant_add + create_quantity(delta, shapenum, qual, framenum == c_any_framenum ? 0 : framenum, temporary);
+		result = cant_add
+				 + create_quantity(
+						 delta, shapenum, qual,
+						 framenum == c_any_framenum ? 0 : framenum, temporary);
 	}
+	if (shapenum == c_gold_coin_shapenum && result < start_delta) {
+		Maybe_consolidate_backpack_gold(this);
+	}
+	return result;
 }
 
 /*
@@ -415,6 +507,7 @@ bool Container_game_object::show_gump(int event) {
 		// Run normal usecode fun.
 		return false;
 	} else if ((gump = inf.get_gump_shape()) >= 0) {
+		Maybe_consolidate_backpack_gold(this);
 		Gump_manager* gump_man = gumpman;
 		gump_man->add_gump(this, gump);
 		return true;

--- a/objs/contain.h
+++ b/objs/contain.h
@@ -150,6 +150,9 @@ public:
 	const Container_game_object* as_container() const override {
 		return this;
 	}
+
+	// Combine gold coins into piles of 100 (plus remainder).
+	void consolidate_gold(int shapenum = c_gold_coin_shapenum);
 };
 
 #endif

--- a/party.cc
+++ b/party.cc
@@ -567,13 +567,8 @@ int Party_manager::step(
 	if (npc->in_queue() || npc->is_moving()) {
 		cout << npc->get_name() << " shouldn't be stepping!" << endl;
 	}
-	Frames_sequence* frames     = npc->get_frames(dir);
-	int&             step_index = npc->get_step_index();
-	if (!step_index) {    // First time?  Init.
-		step_index = frames->find_unrotated(npc->get_framenum());
-	}
-	// Get next (updates step_index).
-	const int frame = frames->get_next(step_index);
+	bool      advance_frame;
+	const int frame = npc->get_next_walk_frame(dir, advance_frame);
 	// Want dz<=1, dx<=2, dy<=2.
 	if (Is_step_okay(npc, leader, to) && npc->step(to, frame))
 		;
@@ -582,7 +577,7 @@ int Party_manager::step(
 	else if (npc->is_dead() || !Take_best_step(npc, leader, pos, frame, npc->get_direction(dest))) {
 		// Failed to take a step.
 		cout << npc->get_name() << " failed to take a step" << endl;
-		frames->decrement(step_index);
+		npc->restore_walk_frame(dir, advance_frame);
 		return dir;
 	}
 	return Get_dir_from(npc, pos);

--- a/schedule.cc
+++ b/schedule.cc
@@ -903,15 +903,12 @@ void Pace_schedule::pace(Actor* npc, char& which, int& phase, Tile_coord& blocke
 			phase++;
 		} else {
 			const Tile_coord p0         = npc->get_tile().get_neighbor(dir);
-			Frames_sequence* frames     = npc->get_frames(dir);
-			int&             step_index = npc->get_step_index();
-			if (!step_index) {    // First time?  Init.
-				step_index = frames->find_unrotated(npc->get_framenum());
-			}
-			// Get next (updates step_index).
-			const int frame = frames->get_next(step_index);
+			bool      advance_frame;
+			const int frame = npc->get_next_walk_frame(dir, advance_frame);
 			// One step at a time.
-			npc->step(p0, frame);
+			if (!npc->step(p0, frame)) {
+				npc->restore_walk_frame(dir, advance_frame);
+			}
 		}
 		npc->start(delay, delay);
 		break;

--- a/shapes/font.cc
+++ b/shapes/font.cc
@@ -273,11 +273,7 @@ int Font::paint_text(
 
 				continue;
 			}
-			if (trans) {
-				shape->paint_rle_remapped(x, yoff, trans);
-			} else {
-				shape->paint_rle(x, yoff);
-			}
+			paint_shape(shape, x, yoff, trans);
 			x += shape->get_width() + hor_lead;
 		}
 	}
@@ -312,11 +308,7 @@ int Font::paint_text(
 
 				continue;
 			}
-			if (trans) {
-				shape->paint_rle_remapped(x, yoff, trans);
-			} else {
-				shape->paint_rle(x, yoff);
-			}
+			paint_shape(shape, x, yoff, trans);
 			x += shape->get_width() + hor_lead;
 		}
 	}
@@ -492,11 +484,7 @@ int Font::paint_text_fixedwidth(
 			continue;
 		}
 		x += w = (width - shape->get_width()) / 2;
-		if (trans) {
-			shape->paint_rle_remapped(x, yoff, trans);
-		} else {
-			shape->paint_rle(x, yoff);
-		}
+		paint_shape(shape, x, yoff, trans);
 		x += width - w;
 	}
 	return x - xoff;
@@ -532,11 +520,7 @@ int Font::paint_text_fixedwidth(
 			continue;
 		}
 		x += w = (width - shape->get_width()) / 2;
-		if (trans) {
-			shape->paint_rle_remapped(x, yoff, trans);
-		} else {
-			shape->paint_rle(x, yoff);
-		}
+		paint_shape(shape, x, yoff, trans);
 		x += width - w;
 	}
 	return x - xoff;
@@ -760,6 +744,22 @@ Font::Font(const File_spec& fname0, int index, int hlead, int vlead) {
 
 Font::Font(const File_spec& fname0, const File_spec& fname1, int index, int hlead, int vlead) {
 	load(fname0, fname1, index, hlead, vlead);
+}
+
+void Font::set_monochrome_color(int color) {
+	monochrome_color = color;
+	monochrome_xform.fill(static_cast<unsigned char>(color));
+}
+
+void Font::paint_shape(
+		Shape_frame* shape, int x, int y, unsigned char* trans) {
+	if (monochrome_color >= 0) {
+		shape->paint_rle_remapped(x, y, monochrome_xform.data());
+	} else if (trans) {
+		shape->paint_rle_remapped(x, y, trans);
+	} else {
+		shape->paint_rle(x, y);
+	}
 }
 
 void Font::clean_up() {

--- a/shapes/font.h
+++ b/shapes/font.h
@@ -21,10 +21,12 @@
 
 #include "hash_utils.h"
 
+#include <array>
 #include <memory>
 
 class Image_buffer8;
 class Shape_file;
+class Shape_frame;
 class IDataSource;
 struct File_spec;
 class U7multiobject;
@@ -54,10 +56,15 @@ private:
 	int                         ver_lead = 0;
 	std::unique_ptr<Shape_file> font_shapes;
 	int                         highest = 0, lowest = 0;
+	int                            monochrome_color = -1;
+	std::array<unsigned char, 256> monochrome_xform{};
 
 	void calc_highlow();
 	void clean_up();
 	int  load_internal(IDataSource& data, int hlead, int vlead);
+	void paint_shape(
+			Shape_frame* shape, int x, int y,
+			unsigned char* trans = nullptr);
 
 public:
 	Font();
@@ -85,6 +92,7 @@ public:
 	 *  @return 0 on success
 	 */
 	int load(const File_spec& fname0, const File_spec& fname1, int index, int hlead = 0, int vlead = 1);
+	void set_monochrome_color(int color);
 	// Text rendering:
 	int paint_text_box(
 			Image_buffer8* win, const char* text, int x, int y, int w, int h, int vert_lead = 0, bool pbreak = false,

--- a/shapes/fontvga.cc
+++ b/shapes/fontvga.cc
@@ -29,6 +29,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "fontvga.h"
 
 #include "Flex.h"
+#include "fnames.h"
+#include "palette.h"
 
 #include <array>
 
@@ -60,6 +62,19 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // +TODO: This shouldn't be hard-coded.
 constexpr static const std::array hlead{-2, -1, 0, -1, 0, 0, -1, -2, -1, -1};
 
+static int get_monochrome_color(size_t fontnum, const Palette& palette) {
+	switch (fontnum) {
+	case 3:
+		return palette.find_color(20, 20, 20);    // Dark gray.
+	case 4:
+		return palette.find_color(0, 0, 0);       // Black.
+	case 6:
+		return palette.find_color(40, 24, 8);     // Brown.
+	default:
+		return -1;
+	}
+}
+
 /*
  *  Default vertical leads, by fontnum.
  */
@@ -77,10 +92,16 @@ void Fonts_vga_file::init(
 	const size_t pn       = pfonts.number_of_objects();
 	const size_t numfonts = std::max(sn, pn);
 	fonts.resize(numfonts);
+	Palette palette;
+	palette.load(PALETTES_FLX, PATCH_PALETTES, 0);
 
 	for (size_t i = 0; i < numfonts; i++) {
 		const int vl
 				= (vlead_overrides && static_cast<int>(i) < num_overrides) ? vlead_overrides[i] : (i < vlead.size() ? vlead[i] : 0);
 		fonts[i] = std::make_shared<Font>(font_source, font_patch, i, i < hlead.size() ? hlead[i] : 0, vl);
+		const int color = get_monochrome_color(i, palette);
+		if (color >= 0) {
+			fonts[i]->set_monochrome_color(color);
+		}
 	}
 }


### PR DESCRIPTION
Track each actor's previous tile and movement timing, then offset body and equipped-weapon painting between adjacent gameplay positions. Expand dirty regions to cover interpolated locations so companions and NPCs move smoothly without changing pathfinding, collision, or simulation timing.

Use the existing Smooth Scrolling percentage as the interpolation duration and disable the feature when Smooth Scrolling is off. Skip teleports and long-distance moves, handle map wrapping and lift changes, and suppress actor offsets while the existing camera interpolation is already positioning the camera actor to avoid double movement.

Keep walking-pose animation at the original 2 FPS cadence even when gameplay FPS is raised. Store timing per actor and apply it consistently to Avatar path walking, party followers, ordinary path-walking NPCs, and schedule-driven NPC movement, while position updates and interpolation continue at the selected gameplay rate.

Add a Game Display Options toggle so the interpolation can be turned off independently of Smooth Scrolling.

