### PR TITLE
Layered scenes and screens

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -105,6 +105,7 @@ EXULTSOURCES =	\
 	playscene.h	\
 	readnpcs.cc	\
 	rect.h		\
+	scene_layer.h	\
 	schedule.cc	\
 	schedule.h	\
 	shapeid.cc	\

--- a/audio/soundtest.cc
+++ b/audio/soundtest.cc
@@ -89,13 +89,27 @@ void SoundTester::test_sound() {
 	bool      redraw  = true;
 	SDL_Event event;
 
-	const int centerx    = gwin->get_width() / 2;
-	const int centery    = gwin->get_height() / 2;
-	const int left       = centerx - 68;
-	const int first_line = centery - 53;
+	const int centerx = gwin->get_width() / 2;
+	const int centery = gwin->get_height() / 2;
+
+	// Create the scroll once and paint the dynamic text INTO that layer
+	// so the text sits ON the scroll instead of behind it in the game
+	// buffer. Text positions are relative to the layer.
+	Scroll_gump scroll;
+	scroll.set_from_help(true);
+	scroll.add_text(" ~");
+	const auto scroll_rect = scroll.get_rect();
+
+	const int left       = centerx - 68 - scroll_rect.x;
+	const int first_line = centery - 53 - scroll_rect.y;
 	const int height     = 6;
 	const int width      = 6;
 	int       sfx_id     = -1;
+
+	// Show only the text-gump layer so the mouse pointer, HUD and any other
+	// gumps stay hidden while the sound tester is up.
+	const uint32 saved_mask = gwin->get_ui_layer_kind_mask();
+	gwin->set_ui_layer_kind_mask(1u << static_cast<int>(Image_window::UiLayerTextGumps));
 
 	Mouse::mouse()->hide();
 
@@ -104,10 +118,15 @@ void SoundTester::test_sound() {
 	int line;
 	do {
 		if (redraw) {
-			Scroll_gump scroll;
-			scroll.set_from_help(true);
-			scroll.add_text(" ~");
 			scroll.paint();
+			// Font::paint_text_fixedwidth() ignores its buffer argument and draws
+			// into the current render target, so redirect drawing to the scroll's
+			// overlay layer for the duration of the text painting.
+			Image_buffer8* lbuf = gwin->get_layer_ibuf(scroll.get_render_layer());
+			Image_buffer8* prev = lbuf ? gwin->push_render_target(lbuf) : nullptr;
+			if (lbuf) {
+				lbuf->clear_clip();
+			}
 			// Update our repeat flag to match the player if it is playing out
 			// song
 			if (player && player->is_track_playing(song)) {
@@ -169,6 +188,10 @@ void SoundTester::test_sound() {
 				}
 			}
 
+			if (lbuf) {
+				gwin->pop_render_target(prev);
+				gwin->layer_set_dirty(scroll.get_render_layer());
+			}
 			gwin->show();
 			redraw = false;
 		}
@@ -295,6 +318,13 @@ void SoundTester::test_sound() {
 			redraw = redraw || SDL_GetTicks() > repainttime;
 		}
 	} while (looping);
+
+	// Hide the scroll and restore normal layer compositing before the game
+	// view is repainted below.
+	if (scroll.get_render_layer() >= 0) {
+		gwin->layer_set_visible(scroll.get_render_layer(), false);
+	}
+	gwin->set_ui_layer_kind_mask(saved_mask);
 
 	gwin->get_tqueue()->resume(SDL_GetTicks());
 

--- a/browser.cc
+++ b/browser.cc
@@ -138,8 +138,10 @@ void ShapeBrowser::browse_shapes() {
 	// Render the browser into a fixed-size full-screen scene layer that is
 	// scaled to fill the display using the main game video settings, the same
 	// way the cheat screen does. 360x225 gives a little more room than the
-	// classic 320x200.
-	Scene_layer    scene_obj(360, 225);
+	// classic 320x200; for touch UI use 320x200
+	const int      scene_w = (touchui != nullptr) ? 320 : 360;
+	const int      scene_h = (touchui != nullptr) ? 200 : 225;
+	Scene_layer    scene_obj(scene_w, scene_h);
 	Image_buffer8* ibuf = scene_obj.valid() ? scene_obj.buffer() : gwin->get_win()->get_ib8();
 
 	Palette             pal;

--- a/browser.cc
+++ b/browser.cc
@@ -45,6 +45,7 @@
 #include "items.h"
 #include "keys.h"
 #include "palette.h"
+#include "scene_layer.h"
 #include "shapeid.h"
 
 #include <iomanip>
@@ -133,7 +134,13 @@ static void handle_key(bool shift, int& value, int max, int amt = 1) {
 void ShapeBrowser::browse_shapes() {
 	Game_window*   gwin = Game_window::get_instance();
 	Shape_manager* sman = Shape_manager::get_instance();
-	Image_buffer8* ibuf = gwin->get_win()->get_ib8();
+
+	// Render the browser into a fixed-size full-screen scene layer that is
+	// scaled to fill the display using the main game video settings, the same
+	// way the cheat screen does. 360x225 gives a little more room than the
+	// classic 320x200.
+	Scene_layer    scene_obj(360, 225);
+	Image_buffer8* ibuf = scene_obj.valid() ? scene_obj.buffer() : gwin->get_win()->get_ib8();
 
 	Palette             pal;
 	const str_int_pair& pal_tuple_static = game->get_resource("palettes/0");
@@ -166,9 +173,9 @@ void ShapeBrowser::browse_shapes() {
 		}
 	}
 
-	const int   maxx    = gwin->get_width();
+	const int   maxx    = scene_obj.valid() ? scene_obj.width() : gwin->get_width();
 	const int   centerx = maxx / 2;
-	const int   maxy    = gwin->get_height();
+	const int   maxy    = scene_obj.valid() ? scene_obj.height() : gwin->get_height();
 	const int   centery = maxy / 2;
 	char        buf[255];
 	const char* fname;
@@ -272,9 +279,18 @@ void ShapeBrowser::browse_shapes() {
 		shapes->load(sources);
 	}
 
+	// Show only the full-screen scene layer. The mouse pointer and text gumps
+	// are overlaid only while the help scroll (K) is on screen (see below).
+	const uint32                      scene_mask = 1u << static_cast<int>(Image_window::UiLayerFullScreenScene);
+	Game_window::Scoped_ui_layer_mask scene_layers(gwin, scene_mask);
+
 	do {
 		if (redraw) {
-			gwin->clear_screen();
+			if (scene_obj.valid()) {
+				scene_obj.begin_frame();
+			} else {
+				gwin->clear_screen();
+			}
 			snprintf(buf, sizeof(buf), "palettes/%d", current_palette);
 			const str_int_pair& pal_tuple = game->get_resource(buf);
 			snprintf(buf, sizeof(buf), "palettes/patch/%d", current_palette);
@@ -288,7 +304,7 @@ void ShapeBrowser::browse_shapes() {
 				pal.load(pal_tuple.str, patch_tuple.str, pal_tuple.num);
 			}
 
-			pal.apply();
+			pal.apply(false);
 
 			font->paint_text_fixedwidth(ibuf, Strings::ShowKeys(), 2, maxy - 50, 8, fontcolor.colors);
 
@@ -326,8 +342,8 @@ void ShapeBrowser::browse_shapes() {
 					font->paint_text_fixedwidth(ibuf, buf, 2, 22, 8, fontcolor.colors);
 
 					// Coords for shape to be drawn (centre of the screen)
-					const int x = gwin->get_width() / 2;
-					const int y = gwin->get_height() / 2;
+					const int x = centerx;
+					const int y = centery;
 
 					// draw outline if not drawing bbox
 					if (current_file != 0 || !bounding_box) {
@@ -376,7 +392,11 @@ void ShapeBrowser::browse_shapes() {
 				font->draw_text(ibuf, centerx - 20, centery - 5, Strings::NoShape());
 			}
 
-			pal.apply();
+			pal.apply(false);
+			if (scene_obj.valid()) {
+				scene_obj.end_frame();
+			}
+			gwin->get_win()->show();
 			redraw = false;
 		}
 		Delay();
@@ -459,9 +479,23 @@ void ShapeBrowser::browse_shapes() {
 			case SDLK_RIGHT:
 				handle_key(false, current_frame, num_frames);
 				break;
-			case SDLK_K:
+			case SDLK_K: {
+				// Overlay the help scroll (a text gump) and the mouse pointer on
+				// top of the browser. The scene normally composites above text
+				// gumps, so lower it beneath them for the duration of the scroll.
+				const uint32 help_mask = (1u << static_cast<int>(Image_window::UiLayerFullScreenScene))
+										 | (1u << static_cast<int>(Image_window::UiLayerMousePointer))
+										 | (1u << static_cast<int>(Image_window::UiLayerTextGumps));
+				Game_window::Scoped_ui_layer_mask help_layers(gwin, help_mask);
+				if (scene_obj.valid()) {
+					scene_obj.lower_beneath_gumps();
+				}
 				keybinder->ShowBrowserKeys();
+				if (scene_obj.valid()) {
+					scene_obj.restore_z();
+				}
 				break;
+			}
 			default:
 				break;
 			}

--- a/cheat.cc
+++ b/cheat.cc
@@ -1247,7 +1247,7 @@ public:
 		}
 		int sx;
 		int sy;
-		gwin->get_win()->game_to_screen(gx, gy, gwin->get_fastmouse(), sx, sy);
+		gwin->get_win()->game_to_screen(gx, gy, false, sx, sy);
 		return gwin->screen_to_layer(layer, sx, sy, lx, ly);
 	}
 

--- a/cheat_screen.cc
+++ b/cheat_screen.cc
@@ -43,6 +43,7 @@
 #include "ignore_unused_variable_warning.h"
 #include "miscinf.h"
 #include "party.h"
+#include "scene_layer.h"
 #include "schedule.h"
 #include "touchui.h"
 #include "ucmachine.h"
@@ -83,6 +84,15 @@ int CheatScreen::Get_highest_map() {
 	return n;
 }
 
+void CheatScreen::screen_to_cheat(int ex, int ey, int& cx, int& cy) const {
+	if (scene != nullptr && scene->valid()) {
+		// Map through the scaled scene layer so input lines up with what is drawn.
+		gwin->get_win()->screen_to_layer(scene->get_handle(), ex, ey, cx, cy);
+	} else {
+		gwin->get_win()->screen_to_game(ex, ey, gwin->get_fastmouse(), cx, cy);
+	}
+}
+
 void CheatScreen::show_screen() {
 	cscreen                              = this;
 	ibuf                                 = gwin->get_win()->get_ib8();
@@ -117,12 +127,27 @@ void CheatScreen::show_screen() {
 		font = fontManager.get_font("MENU_FONT");
 	}
 	clock = gwin->get_clock();
-	maxx  = gwin->get_width();
+	// Render the cheat screen into a fixed-size full-screen scene layer that is
+	// scaled to fill the display using the main game video settings. 360x225
+	// normally; 320x200 with the touch UI so its on-screen controls line up.
+	const int   scene_w = (touchui != nullptr) ? 320 : 360;
+	const int   scene_h = (touchui != nullptr) ? 200 : 225;
+	Scene_layer scene_obj(scene_w, scene_h);
+	scene = &scene_obj;
+	if (scene_obj.valid()) {
+		ibuf = scene_obj.buffer();
+		maxx = scene_obj.width();
+		maxy = scene_obj.height();
+	} else {
+		// No layer available: fall back to painting straight to the window.
+		ibuf = gwin->get_win()->get_ib8();
+		maxx = gwin->get_width();
 #if defined(SDL_PLATFORM_IOS) || defined(ANDROID) || defined(CHEAT_SCREEN_TEST_MOBILE)
-	maxy = 200;
+		maxy = 200;
 #else
-	maxy = gwin->get_height();
+		maxy = gwin->get_height();
 #endif
+	}
 	centerx            = maxx / 2;
 	centery            = maxy / 2;
 	SDL_Window* window = gwin->get_win()->get_screen_window();
@@ -166,10 +191,20 @@ void CheatScreen::show_screen() {
 	buttons_down.clear();
 	// Run the Menu
 	{
-		const uint32                      mouse_only = 1u << static_cast<int>(Image_window::UiLayerMousePointer);
-		Game_window::Scoped_ui_layer_mask scene_layers(gwin, mouse_only);
+		const uint32 scene_mask = (1u << static_cast<int>(Image_window::UiLayerMousePointer))
+								  | (1u << static_cast<int>(Image_window::UiLayerFullScreenScene));
+		Game_window::Scoped_ui_layer_mask scene_layers(gwin, scene_mask);
 		RunMenu(RootMenu());
 	}
+	// Make sure drawing is no longer redirected to the scene buffer (in case a
+	// render loop broke out before its end_frame), then hide the scene layer
+	// before the game view is repainted below; scene_obj's destructor removes it
+	// entirely when show_screen returns. Point ibuf back at the game window so
+	// nothing keeps a dangling reference to the scene buffer.
+	scene_obj.restore_target();
+	scene_obj.set_visible(false);
+	scene = nullptr;
+	ibuf  = gwin->get_win()->get_ib8();
 
 	Mouse::mouse()->set_speed_cursor();
 	Mouse::mouse()->hide();
@@ -552,6 +587,11 @@ bool CheatScreen::InputHandlers::GameObject::OnInput(SDL_Keycode key_sym) {
 	// Enter Pick Mode
 	if (hotspots[0].IsKeycode(key_sym)) {
 		cscreen->WaitButtonsUp(true);
+		// Temporarily hide the scene layer so the game world is visible while
+		// the user picks an object; the next menu frame re-shows the scene.
+		if (cscreen->scene != nullptr) {
+			cscreen->scene->set_visible(false);
+		}
 		gwin->set_all_dirty();
 		gwin->paint();
 		gwin->show(true);
@@ -800,13 +840,18 @@ SDL_Keycode CheatScreen::GetKey(const std::vector<Hotspot*>& hotspots, SDL_Keyco
 					gwin->get_win()->screen_to_game(event.motion.x, event.motion.y, gwin->get_fastmouse(), gx, gy);
 
 					Mouse::mouse()->move(gx, gy);
+					// Track the pointer in cheat-screen (scene) coordinates for
+					// hotspot hover/hit-testing.
+					screen_to_cheat(event.motion.x, event.motion.y, cheat_mousex, cheat_mousey);
 					Mouse::mouse_update = true;
 				} break;
 					// return;
 
 				case SDL_EVENT_MOUSE_BUTTON_DOWN: {
 					SDL_ConvertEventToRenderCoordinates(renderer, &event);
-					gwin->get_win()->screen_to_game(event.button.x, event.button.y, gwin->get_fastmouse(), gx, gy);
+					screen_to_cheat(event.button.x, event.button.y, gx, gy);
+					cheat_mousex = gx;
+					cheat_mousey = gy;
 					CERR("SDL_EVENT_MOUSE_BUTTON_DOWN( " << gx << " , " << gy << " )");
 					buttons_down.insert(event.button.button);
 					if (event.button.button == 1) {
@@ -818,13 +863,12 @@ SDL_Keycode CheatScreen::GetKey(const std::vector<Hotspot*>& hotspots, SDL_Keyco
 								simulate_key = SDLK_RETURN;
 							}
 
-							CERR("window size( " << gwin->get_width() << " , " << gwin->get_height() << " )");
 							// Touch on the cheat screen will bring up the
 							// keyboard but not if the tap was within a 20 pixel
-							// border on the edge of the game screen)
+							// border on the edge of the cheat screen.
 							if (SDL_TextInputActive(window)) {
 								SDL_StopTextInput(window);
-							} else if (gx > 20 && gy > 20 && gx < (gwin->get_width() - 20) && gy < (gwin->get_height() - 20)) {
+							} else if (gx > 20 && gy > 20 && gx < (maxx - 20) && gy < (maxy - 20)) {
 								TouchUI::startTextInput(window);
 							}
 						}
@@ -933,7 +977,11 @@ void CheatScreen::RunMenu(std::shared_ptr<Menu> menu) {
 				for (;;) {
 					current->run();
 					hotspots.clear();
-					gwin->clear_screen();
+					if (scene && scene->valid()) {
+						scene->begin_frame();
+					} else {
+						gwin->clear_screen();
+					}
 					current->paint_display();
 					current->GatherHotspots(hotspots);
 
@@ -981,7 +1029,10 @@ void CheatScreen::RunMenu(std::shared_ptr<Menu> menu) {
 						}
 					}
 					for (const auto hs : hotspots) {
-						hs->Paint(highlighted, Mouse::mouse()->get_mousex(), Mouse::mouse()->get_mousey());
+						hs->Paint(highlighted, cheat_mousex, cheat_mousey);
+					}
+					if (scene && scene->valid()) {
+						scene->end_frame();
 					}
 					Mouse::mouse()->show();
 					gwin->get_win()->show();
@@ -1237,7 +1288,7 @@ std::shared_ptr<CheatScreen::Menu> CheatScreen::RootMenu() {
 #if !defined(SDL_PLATFORM_IOS) && !defined(ANDROID) && !defined(CHEAT_SCREEN_TEST_MOBILE)
 	// for small screens taking the liberty of leaving that out
 	command                  = std::make_shared<LeftRightIntegerCommand>(1, 20, clock->get_time_rate());
-	command->events.Activate = [this](MenuCommand* self, SDL_Keycode) noexcept -> std::shared_ptr<MenuCommand> {
+	command->events.Activate = [this](MenuCommand* self, SDL_Keycode) -> std::shared_ptr<MenuCommand> {
 		clock->set_time_rate(static_cast<LeftRightIntegerCommand*>(self)->currentval);
 		return {};
 	};
@@ -1519,7 +1570,7 @@ std::shared_ptr<CheatScreen::Menu> CheatScreen::GlobalFlagMenu(unsigned num) {
 		snprintf(buf, sizeof(buf), "%d ", num);
 		std::string_view flag_name;
 
-		if (num < global_flag_names.size() && !global_flag_names[num].empty()) {
+		if (num < static_cast<unsigned>(global_flag_names.size()) && !global_flag_names[num].empty()) {
 			flag_name = global_flag_names[num];
 		} else {
 			flag_name = Strings::AdvancedFlagsMenu::unnamed();
@@ -1589,7 +1640,7 @@ std::shared_ptr<CheatScreen::Menu> CheatScreen::GlobalFlagMenu(unsigned num) {
 	auto menu = std::make_shared<Menu>(std::move(items));
 	menu->setData<unsigned>(num);
 
-	menu->events.paint_display = [=](MenuCommand*) noexcept -> bool {
+	menu->events.paint_display = [=](MenuCommand*) -> bool {
 #if defined(SDL_PLATFORM_IOS) || defined(ANDROID) || defined(CHEAT_SCREEN_TEST_MOBILE)
 		font->paint_text_fixedwidth(ibuf, Strings::AdvancedFlagsMenu::GlobalFlags, 15, 0, 8, fontcolor.colors);
 		return true;
@@ -1663,7 +1714,7 @@ std::shared_ptr<CheatScreen::Menu> CheatScreen::TeleportMenu() {
 	command->inputs.push_back(std::make_shared<InputHandlers::KeyOnly>(Strings::TeleportMenu::Longitude, std::move(hotspots)));
 	command->inputs.push_back(std::make_shared<InputHandlers::Integer>(false, 0, 193, false, Strings::ENTER_LONGITUDE));
 
-	command->events.begin_phase = [=](MenuCommand* self) noexcept {
+	command->events.begin_phase = [=](MenuCommand* self) {
 		// Check phase 0 input and update maximum accepted for input[1]
 		if (self->phase == 1) {
 			auto latkeypress = static_cast<InputHandlers::KeyOnly*>(self->inputs[0].get());
@@ -1889,7 +1940,11 @@ void CheatScreen::WaitButtonsUp(bool silent) {
 			SDL_Keycode unicode;
 			keycode = GetKey(hotspotptrs, unicode);
 		}
-		gwin->clear_screen();
+		if (scene && scene->valid()) {
+			scene->begin_frame();
+		} else {
+			gwin->clear_screen();
+		}
 
 		// exit if escape is pressed
 		if (keycode == SDLK_ESCAPE) {
@@ -1950,7 +2005,7 @@ void CheatScreen::WaitButtonsUp(bool silent) {
 						continue;
 					}
 
-					button_name = Strings::MouseButton(button - 1);
+					button_name = Strings::MouseButton[button - 1];
 				} break;
 
 				default: {
@@ -2000,11 +2055,14 @@ void CheatScreen::WaitButtonsUp(bool silent) {
 		}
 
 		for (auto& hs : hotspots) {
-			hs.Paint(SDLK_UNKNOWN, Mouse::mouse()->get_mousex(), Mouse::mouse()->get_mousey());
-			Mouse::mouse()->show();
-			gwin->get_win()->show();
-			Mouse::mouse()->hide();    // Must immediately hide to prevent flickering
+			hs.Paint(SDLK_UNKNOWN, cheat_mousex, cheat_mousey);
 		}
+		if (scene && scene->valid()) {
+			scene->end_frame();
+		}
+		Mouse::mouse()->show();
+		gwin->get_win()->show();
+		Mouse::mouse()->hide();    // Must immediately hide to prevent flickering
 	}
 }
 

--- a/cheat_screen.h
+++ b/cheat_screen.h
@@ -57,6 +57,7 @@ class Font;
 class Game_clock;
 class Game_object;
 class Actor;
+class Scene_layer;
 
 // #define CHEAT_SCREEN_TEST_MOBILE 1
 
@@ -796,6 +797,11 @@ private:
 
 	void RunMenu(std::shared_ptr<Menu> menu);
 
+	// Map display/event coordinates to cheat-screen (scene layer) coordinates.
+	// The cheat screen is drawn into a scaled scene layer, so raw mouse events
+	// must be mapped through that layer rather than the game area.
+	void screen_to_cheat(int ex, int ey, int& cx, int& cy) const;
+
 	struct {
 		Uint32 last = 0;
 		// Accumulated swipe deltas. We treat these as a vector
@@ -803,7 +809,14 @@ private:
 		float dy = 0;
 	} swipe;
 
-	Image_buffer8*        ibuf  = nullptr;
+	Image_buffer8* ibuf = nullptr;
+	// The cheat screen renders into a full-screen scene layer (owned by a local
+	// in show_screen); this is a non-owning pointer valid only while the screen
+	// is shown. Null if no layer is available.
+	Scene_layer* scene = nullptr;
+	// Current mouse position in cheat-screen (scene) coordinates, used for
+	// hotspot hit-testing and hover.
+	int                   cheat_mousex = 0, cheat_mousey = 0;
 	std::shared_ptr<Font> font  = nullptr;
 	Game_clock*           clock = nullptr;
 	int                   maxx = 0, maxy = 0;

--- a/exultmenu.cc
+++ b/exultmenu.cc
@@ -42,6 +42,7 @@
 #include "menulist.h"
 #include "mouse.h"
 #include "palette.h"
+#include "scene_layer.h"
 #include "shapeid.h"
 #include "sigame.h"
 #include "span.h"
@@ -49,6 +50,7 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 
 #ifdef SDL_PLATFORM_IOS
 #	include "ios_utils.h"
@@ -376,6 +378,14 @@ BaseGameInfo* ExultMenu::show_mods_menu(ModManager* selgame) {
 	gpal->load(BUNDLE_CHECK(BUNDLE_EXULT_FLX, EXULT_FLX), EXULT_FLX_EXULT0_PAL);
 	gpal->apply();
 
+	// Render the mods menu into a 360x225 full-screen scene layer, like the main
+	// menu. Every exit fades out then returns/throws, so the scene stays active
+	// for the whole function and is torn down by its destructor.
+	int        dummy_topx = 0;
+	int        dummy_topy = 0;
+	Scene_view mods_scene(dummy_topx, dummy_topy, centerx, centery, ibuf, true, 360, 225);
+	calc_win();
+
 	int           first_mod   = 0;
 	const int     num_choices = selgame->get_mod_list().size() - 1;
 	const int     last_page   = num_choices - num_choices % pagesize;
@@ -387,10 +397,8 @@ BaseGameInfo* ExultMenu::show_mods_menu(ModManager* selgame) {
 		std::cerr << "Exult.flx file is corrupted. Please reinstall Exult." << std::endl;
 		throw quit_exception();
 	}
-	int logox;
-	int logoy;
-	logox = centerx - exultlogo->get_width() / 2;
-	logoy = centery - exultlogo->get_height() / 2;
+	const int logox = centerx - exultlogo->get_width() / 2;
+	const int logoy = centery - exultlogo->get_height() / 2;
 
 	do {
 		// Interferes with the menu.
@@ -496,24 +504,50 @@ BaseGameInfo* ExultMenu::run() {
 		std::cerr << "Exult.flx file is corrupted. Please reinstall Exult." << std::endl;
 		throw quit_exception();
 	}
-	int logox = centerx - exultlogo->get_width() / 2;
-	int logoy = centery - exultlogo->get_height() / 2;
-	sman->paint_shape(logox, logoy, exultlogo);
-	gpal->fade_in(c_fade_in_time);
-	wait_delay(2000);
+	{
+		// Show the initial logo splash in its own 320x200 scene layer so the
+		// full-screen logo fills the display (the menu below uses 360x225).
+		int        splash_topx = 0;
+		int        splash_topy = 0;
+		Scene_view logo_scene(splash_topx, splash_topy, centerx, centery, ibuf, false, 320, 200);
+		const int  logox = centerx - exultlogo->get_width() / 2;
+		const int  logoy = centery - exultlogo->get_height() / 2;
+		sman->paint_shape(logox, logoy, exultlogo);
+		gpal->fade_in(c_fade_in_time);
+		wait_delay(2000);
+	}
 
 	exultlogo = exult_flx.get_shape(EXULT_FLX_EXULT_LOGO_SHP, 1);
 
 	int       first_game  = 0;
 	const int num_choices = gamemanager->get_game_count() - 1;
-	const int last_page   = num_choices - num_choices % pagesize;
+	int       last_page   = num_choices - num_choices % pagesize;
 	// Erase the old logo.
 	gwin->clear_screen(true);
 
-	auto          menu     = create_main_menu(first_game);
-	BaseGameInfo* sel_game = nullptr;
+	// Render the menu into a 360x225 full-screen scene layer (like the shape
+	// browser and cheat screen). The scene is torn down before any sub-action
+	// (setup gump, credits/quotes scroller, mods menu, game load) and recreated
+	// on the next loop so those render normally.
+	int                       dummy_topx = 0;
+	int                       dummy_topy = 0;
+	int                       logox      = 0;
+	int                       logoy      = 0;
+	std::optional<Scene_view> menu_scene;
+	std::unique_ptr<MenuList> menu;
+	BaseGameInfo*             sel_game = nullptr;
 
 	do {
+		if (!menu_scene) {
+			menu_scene.emplace(dummy_topx, dummy_topy, centerx, centery, ibuf, true, 360, 225);
+			calc_win();
+			last_page = num_choices - num_choices % pagesize;
+			logox     = centerx - exultlogo->get_width() / 2;
+			logoy     = centery - exultlogo->get_height() / 2;
+			if (!menu) {
+				menu = create_main_menu(first_game);
+			}
+		}
 		// Interferes with the menu.
 		sman->paint_shape(logox, logoy, exultlogo);
 		font->draw_text(
@@ -523,6 +557,7 @@ BaseGameInfo* ExultMenu::run() {
 
 		switch (choice) {
 		case -4:    // Setup
+			menu_scene.reset();
 			gpal->fade_out(c_fade_out_time);
 			setup();
 			if (quitting_time == QUIT_TIME_YES) {
@@ -535,13 +570,12 @@ BaseGameInfo* ExultMenu::run() {
 				Audio::get_ptr()->start_music(EXULT_FLX_MEDITOWN_MID, true, MyMidiPlayer::Force_None, EXULT_FLX);
 			}
 
-			calc_win();
-			logox      = centerx - exultlogo->get_width() / 2;
-			logoy      = centery - exultlogo->get_height() / 2;
 			first_game = 0;
-			menu       = create_main_menu(first_game);
+			menu.reset();
 			break;
 		case -3: {    // Exult Credits
+			// Keep the 360x225 menu scene active so the scroller renders scaled
+			// like the menu instead of at the native game-area size.
 			gpal->fade_out(c_fade_out_time);
 			TextScroller credits(
 					BUNDLE_CHECK(BUNDLE_EXULT_FLX, EXULT_FLX), EXULT_FLX_CREDITS_TXT, fontManager.get_font("CREDITS_FONT"),
@@ -551,6 +585,8 @@ BaseGameInfo* ExultMenu::run() {
 			gpal->apply();
 		} break;
 		case -2: {    // Exult Quotes
+			// Keep the 360x225 menu scene active so the scroller renders scaled
+			// like the menu instead of at the native game-area size.
 			gpal->fade_out(c_fade_out_time);
 			TextScroller quotes(
 					BUNDLE_CHECK(BUNDLE_EXULT_FLX, EXULT_FLX), EXULT_FLX_QUOTES_TXT, fontManager.get_font("CREDITS_FONT"),
@@ -569,6 +605,7 @@ BaseGameInfo* ExultMenu::run() {
 #	endif
 			break;
 #else
+			menu_scene.reset();
 			gpal->fade_out(c_fade_out_time);
 			Audio::get_ptr()->stop_music();
 			throw quit_exception();
@@ -576,10 +613,12 @@ BaseGameInfo* ExultMenu::run() {
 		default:
 			if (choice >= 0 && choice < MAX_GAMES) {
 				// Load the game:
+				menu_scene.reset();
 				gpal->fade_out(c_fade_out_time);
 				sel_game = gamemanager->get_game(choice);
 			} else if (choice >= MAX_GAMES && choice < 2 * MAX_GAMES) {
 				// Show the mods for the game:
+				menu_scene.reset();
 				gpal->fade_out(c_fade_out_time / 2);
 				sel_game = show_mods_menu(gamemanager->get_game(choice - MAX_GAMES));
 				gwin->clear_screen(true);
@@ -591,6 +630,7 @@ BaseGameInfo* ExultMenu::run() {
 			break;
 		}
 	} while (sel_game == nullptr);
+	menu_scene.reset();
 	gwin->clear_screen(true);
 	Audio::get_ptr()->stop_music();
 	return sel_game;

--- a/exultmenu.cc
+++ b/exultmenu.cc
@@ -378,12 +378,15 @@ BaseGameInfo* ExultMenu::show_mods_menu(ModManager* selgame) {
 	gpal->load(BUNDLE_CHECK(BUNDLE_EXULT_FLX, EXULT_FLX), EXULT_FLX_EXULT0_PAL);
 	gpal->apply();
 
-	// Render the mods menu into a 360x225 full-screen scene layer, like the main
-	// menu. Every exit fades out then returns/throws, so the scene stays active
-	// for the whole function and is torn down by its destructor.
+	// Render the mods menu into a full-screen scene layer, like the main menu:
+	// 360x225, 320x200 for touch UI. Every exit fades out then eturns/throws,
+	// so the scene stays active for the whole function and is torn down by
+	// its destructor.
+	const int  scene_w    = (touchui != nullptr) ? 320 : 360;
+	const int  scene_h    = (touchui != nullptr) ? 200 : 225;
 	int        dummy_topx = 0;
 	int        dummy_topy = 0;
-	Scene_view mods_scene(dummy_topx, dummy_topy, centerx, centery, ibuf, true, 360, 225);
+	Scene_view mods_scene(dummy_topx, dummy_topy, centerx, centery, ibuf, true, scene_w, scene_h);
 	calc_win();
 
 	int           first_mod   = 0;
@@ -505,8 +508,7 @@ BaseGameInfo* ExultMenu::run() {
 		throw quit_exception();
 	}
 	{
-		// Show the initial logo splash in its own 320x200 scene layer so the
-		// full-screen logo fills the display (the menu below uses 360x225).
+		// Show the initial logo splash in its own 320x200 scene layer.
 		int        splash_topx = 0;
 		int        splash_topy = 0;
 		Scene_view logo_scene(splash_topx, splash_topy, centerx, centery, ibuf, false, 320, 200);
@@ -525,10 +527,12 @@ BaseGameInfo* ExultMenu::run() {
 	// Erase the old logo.
 	gwin->clear_screen(true);
 
-	// Render the menu into a 360x225 full-screen scene layer (like the shape
-	// browser and cheat screen). The scene is torn down before any sub-action
-	// (setup gump, credits/quotes scroller, mods menu, game load) and recreated
-	// on the next loop so those render normally.
+	// Render the menu into a full-screen scene layer (like the shape browser and
+	// cheat screen): 360x225, 320x200 for touch UI. The scene is torn down before
+	// any sub-action (setup gump, mods menu, game load) and recreated on the next
+	// loop so those render normally.
+	const int                 scene_w    = (touchui != nullptr) ? 320 : 360;
+	const int                 scene_h    = (touchui != nullptr) ? 200 : 225;
 	int                       dummy_topx = 0;
 	int                       dummy_topy = 0;
 	int                       logox      = 0;
@@ -539,7 +543,7 @@ BaseGameInfo* ExultMenu::run() {
 
 	do {
 		if (!menu_scene) {
-			menu_scene.emplace(dummy_topx, dummy_topy, centerx, centery, ibuf, true, 360, 225);
+			menu_scene.emplace(dummy_topx, dummy_topy, centerx, centery, ibuf, true, scene_w, scene_h);
 			calc_win();
 			last_page = num_choices - num_choices % pagesize;
 			logox     = centerx - exultlogo->get_width() / 2;

--- a/game.cc
+++ b/game.cc
@@ -119,7 +119,7 @@ Game* Game::create_game(BaseGameInfo* mygame) {
 	mygame->setup_game_paths();
 	gametitle    = mygame->get_cfgname();
 	modtitle     = mygame->get_mod_title();
-	menustring     = mygame->get_menu_string();
+	menustring   = mygame->get_menu_string();
 	game_type    = mygame->get_game_type();
 	language     = mygame->get_game_language();
 	expansion    = mygame->have_expansion();

--- a/game.cc
+++ b/game.cc
@@ -48,6 +48,7 @@
 #include "mouse.h"
 #include "palette.h"
 #include "playscene.h"
+#include "scene_layer.h"
 #include "shapeid.h"
 #include "shapes/miscinf.h"
 
@@ -56,6 +57,7 @@
 #include <array>
 #include <cstdlib>
 #include <cstring>
+#include <optional>
 #include <regex>
 #include <sstream>
 
@@ -568,7 +570,6 @@ bool Game::read_game_xml(const char* name1) {
 }
 
 bool Game::show_menu(bool skip) {
-	const int menuy = topy + 120;
 	// Brand-new game in development?
 	if (skip || (is_editing() && !U7exists(MAINSHP_FLX))) {
 		const bool first = !U7exists(IDENTITY);
@@ -579,6 +580,10 @@ bool Game::show_menu(bool skip) {
 	}
 	IExultDataSource mouse_data(MAINSHP_FLX, PATCH_MAINSHP, 19);
 	Mouse            menu_mouse(gwin, mouse_data);
+
+	std::optional<Scene_view> menu_scene;
+	menu_scene.emplace(topx, topy, centerx, centery, ibuf, true);
+	const int menuy = topy + 120;
 
 	top_menu();
 	MenuList* menu = nullptr;
@@ -623,6 +628,10 @@ bool Game::show_menu(bool skip) {
 	bool exitmenu = false;
 
 	do {
+		if (!menu_scene) {
+			menu_scene.emplace(topx, topy, centerx, centery, ibuf, true);
+			top_menu();
+		}
 		if (menu == nullptr) {
 			menu       = new MenuList();
 			int offset = 0;
@@ -693,6 +702,7 @@ bool Game::show_menu(bool skip) {
 #endif
 		case 0:    // Intro
 			pal->fade_out(c_fade_out_time);
+			menu_scene.reset();
 			if (scene_available("intro")) {
 				Audio::get_ptr()->stop_music();
 				play_scene("intro");
@@ -701,15 +711,13 @@ bool Game::show_menu(bool skip) {
 			} else {
 				play_intro();
 			}
-			gwin->clear_screen(true);
-			top_menu();
 			break;
 		case 2:    // Journey Onwards
+			// init_gamedat may raise an error gump, so drop the menu scene first.
+			menu_scene.reset();
 			created = gwin->init_gamedat(false);
 			if (!created) {
 				show_journey_failed();
-				gwin->clear_screen(true);
-				top_menu();
 				menu->set_selection(1);
 				break;
 			}
@@ -718,6 +726,9 @@ bool Game::show_menu(bool skip) {
 			play     = true;
 			break;
 		case 1:    // New Game
+			// new_game() runs its own scene and may raise an error gump from
+			// init_gamedat, so drop the menu scene while it runs.
+			menu_scene.reset();
 			if (new_game(menushapes)) {
 				exitmenu = true;
 			} else {
@@ -728,6 +739,7 @@ bool Game::show_menu(bool skip) {
 			break;
 		case 3:    // Credits
 			pal->fade_out(c_fade_out_time);
+			menu_scene.reset();
 			if (scene_available("credits")) {
 				Audio::get_ptr()->stop_music();
 				play_scene("credits");
@@ -737,20 +749,20 @@ bool Game::show_menu(bool skip) {
 			}
 			delete menu;
 			menu = nullptr;
-			top_menu();
 			break;
 		case 4:    // Quotes
 			pal->fade_out(c_fade_out_time);
+			menu_scene.reset();
 			if (scene_available("quotes")) {
 				Audio::get_ptr()->stop_music();
 				play_scene("quotes");
 			} else {
 				show_quotes();
 			}
-			top_menu();
 			break;
 		case 5:    // End Game
 			pal->fade_out(c_fade_out_time);
+			menu_scene.reset();
 			if (scene_available("endgame")) {
 				Audio::get_ptr()->stop_music();
 				play_scene("endgame");
@@ -759,7 +771,6 @@ bool Game::show_menu(bool skip) {
 			} else {
 				end_game(true, false);
 			}
-			top_menu();
 			break;
 		case 6:    // Return to Menu
 			play     = false;

--- a/gamemgr/bggame.cc
+++ b/gamemgr/bggame.cc
@@ -45,12 +45,14 @@
 #include "miscinf.h"
 #include "modmgr.h"
 #include "palette.h"
+#include "scene_layer.h"
 #include "shapeid.h"
 #include "touchui.h"
 #include "txtscroll.h"
 
 #include <array>
 #include <cstring>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -394,15 +396,14 @@ BG_Game::BG_Game() : shapes(ENDSHAPE_FLX, -1, PATCH_ENDSHAPE) {
 	} while (false)
 
 void BG_Game::play_intro() {
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, 0);
-	Audio*                            audio = Audio::get_ptr();
+	Audio* audio = Audio::get_ptr();
 	audio->stop_music();
 	MyMidiPlayer* midi = audio->get_midi();
 	if (midi) {
 		midi->set_timbre_lib(MyMidiPlayer::TIMBRE_LIB_INTRO);
 	}
 
-	gwin->clear_screen(true);
+	Scene_view scene(topx, topy, centerx, centery, ibuf);
 
 	// TODO: check/fix other resolutions
 
@@ -1494,8 +1495,7 @@ Shape_frame* BG_Game::get_menu_shape() {
 }
 
 void BG_Game::top_menu() {
-	const uint32                      menu_mouse_only = 1u << static_cast<int>(Image_window::UiLayerMousePointer);
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, menu_mouse_only);
+	// Painted into the full-screen menu scene owned by Game::show_menu().
 	Audio::get_ptr()->start_music(menu_midi, true, MyMidiPlayer::Force_None, INTROMUS);
 	sman->paint_shape(topx, topy, get_menu_shape());
 	pal->load(INTROPAL_DAT, PATCH_INTROPAL, 6);
@@ -1503,8 +1503,7 @@ void BG_Game::top_menu() {
 }
 
 void BG_Game::show_journey_failed() {
-	const uint32                      menu_mouse_only = 1u << static_cast<int>(Image_window::UiLayerMousePointer);
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, menu_mouse_only);
+	Scene_view scene(topx, topy, centerx, centery, ibuf, true);
 	pal->fade_out(50);
 	gwin->clear_screen(true);
 	sman->paint_shape(topx, topy, get_menu_shape());
@@ -1551,9 +1550,11 @@ std::vector<unsigned int> BG_Game::get_congratulations_messages() {
 
 void BG_Game::end_game(bool success, bool within_game) {
 	waitforspeech();
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, 0);
-	Audio*                            audio = Audio::get_ptr();
-	std::shared_ptr<Font>             font  = fontManager.get_font("MENU_FONT");
+
+	Scene_view scene(topx, topy, centerx, centery, ibuf);
+
+	Audio*                audio = Audio::get_ptr();
+	std::shared_ptr<Font> font  = fontManager.get_font("MENU_FONT");
 
 	if (!success) {
 		audio->stop_music();
@@ -1951,16 +1952,14 @@ void BG_Game::end_game(bool success, bool within_game) {
 }
 
 void BG_Game::show_quotes() {
-	const uint32                      menu_mouse_only = 1u << static_cast<int>(Image_window::UiLayerMousePointer);
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, menu_mouse_only);
+	Scene_view scene(topx, topy, centerx, centery, ibuf);
 	Audio::get_ptr()->start_music(quotes_midi, false, MyMidiPlayer::Force_None, INTROMUS);
 	TextScroller quotes(MAINSHP_FLX, 0x10, fontManager.get_font("MENU_FONT"), menushapes.extract_shape(0x14), true);
 	quotes.run(gwin);
 }
 
 void BG_Game::show_credits() {
-	const uint32                      menu_mouse_only = 1u << static_cast<int>(Image_window::UiLayerMousePointer);
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, menu_mouse_only);
+	Scene_view scene(topx, topy, centerx, centery, ibuf);
 	pal->load(INTROPAL_DAT, PATCH_INTROPAL, 6);
 	Audio::get_ptr()->start_music(credits_midi, false, MyMidiPlayer::Force_None, INTROMUS);
 	TextScroller credits(MAINSHP_FLX, 0x0E, fontManager.get_font("MENU_FONT"), menushapes.extract_shape(0x14), true);
@@ -1970,10 +1969,10 @@ void BG_Game::show_credits() {
 }
 
 bool BG_Game::new_game(Vga_file& shapes) {
-	const uint32                      menu_mouse_only = 1u << static_cast<int>(Image_window::UiLayerMousePointer);
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, menu_mouse_only);
-	const int                         menuy = topy + 110;
-	std::shared_ptr<Font>             font  = fontManager.get_font("MENU_FONT");
+	std::optional<Scene_view> scene;
+	scene.emplace(topx, topy, centerx, centery, ibuf, true);
+	const int             menuy = topy + 110;
+	std::shared_ptr<Font> font  = fontManager.get_font("MENU_FONT");
 
 	Vga_file faces_vga;
 	// Need to know if SI is installed
@@ -2104,7 +2103,7 @@ bool BG_Game::new_game(Vga_file& shapes) {
 				const SDL_Rect rectOnward = {topx + 10, topy + 180, 130, 16};
 				const SDL_Rect rectReturn = {centerx + 10, topy + 180, 130, 16};
 				SDL_Point      point;
-				gwin->get_win()->screen_to_game(event.button.x, event.button.y, gwin->get_fastmouse(), point.x, point.y);
+				scene->screen_to_scene(event.button.x, event.button.y, point.x, point.y);
 				if (SDL_GetRectEnclosingPoints(&point, 1, &rectName, nullptr)) {
 					if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
 						selected = 0;
@@ -2256,6 +2255,9 @@ bool BG_Game::new_game(Vga_file& shapes) {
 		set_avname(npc_name);
 		set_avsex(skindata->is_female);
 		pal->fade_out(c_fade_out_time);
+		// Leave the scene before init_gamedat so its error dialog (a gump) is not
+		// hidden by the scene layer mask.
+		scene.reset();
 		gwin->clear_screen(true);
 		// Immediately restore the palette after clearing the screen incase
 		// init_gamedat errors and displays a yesno_gump

--- a/gamemgr/sigame.cc
+++ b/gamemgr/sigame.cc
@@ -40,6 +40,7 @@
 #include "mappatch.h"
 #include "miscinf.h"
 #include "palette.h"
+#include "scene_layer.h"
 #include "shapeid.h"
 #include "span.h"
 #include "touchui.h"
@@ -47,6 +48,7 @@
 
 #include <array>
 #include <cctype>
+#include <optional>
 
 using std::cout;
 using std::endl;
@@ -273,8 +275,8 @@ static int get_frame() {
 }
 
 void SI_Game::play_intro() {
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, 0);
-	Audio*                            audio = Audio::get_ptr();
+	Scene_view scene(topx, topy, centerx, centery, ibuf);
+	Audio*     audio = Audio::get_ptr();
 	audio->stop_music();
 	MyMidiPlayer* midi = audio->get_midi();
 	if (midi) {
@@ -874,8 +876,6 @@ Shape_frame* SI_Game::get_menu_shape() {
 }
 
 void SI_Game::top_menu() {
-	const uint32                      menu_mouse_only = 1u << static_cast<int>(Image_window::UiLayerMousePointer);
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, menu_mouse_only);
 	Audio::get_ptr()->start_music(28, true, MyMidiPlayer::Force_None, MAINSHP_FLX);
 	sman->paint_shape(topx, topy, get_menu_shape());
 	pal->load(MAINSHP_FLX, PATCH_MAINSHP, 26);
@@ -883,8 +883,7 @@ void SI_Game::top_menu() {
 }
 
 void SI_Game::show_journey_failed() {
-	const uint32                      menu_mouse_only = 1u << static_cast<int>(Image_window::UiLayerMousePointer);
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, menu_mouse_only);
+	Scene_view scene(topx, topy, centerx, centery, ibuf, true);
 	pal->fade_out(50);
 	gwin->clear_screen(true);
 	sman->paint_shape(topx, topy, get_menu_shape());
@@ -1057,8 +1056,8 @@ std::vector<unsigned int> SI_Game::get_congratulations_messages() {
 void SI_Game::end_game(bool success, bool within_game) {
 	ignore_unused_variable_warning(success);
 	waitforspeech();
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, 0);
-	Audio*                            audio = Audio::get_ptr();
+	Scene_view scene(topx, topy, centerx, centery, ibuf);
+	Audio*     audio = Audio::get_ptr();
 	audio->stop_music();
 	MyMidiPlayer* midi = audio->get_midi();
 	if (midi) {
@@ -1360,16 +1359,14 @@ void SI_Game::end_game(bool success, bool within_game) {
 }
 
 void SI_Game::show_quotes() {
-	const uint32                      menu_mouse_only = 1u << static_cast<int>(Image_window::UiLayerMousePointer);
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, menu_mouse_only);
+	Scene_view scene(topx, topy, centerx, centery, ibuf);
 	Audio::get_ptr()->start_music(32, false, MyMidiPlayer::Force_None, MAINSHP_FLX);
 	TextScroller quotes(MAINSHP_FLX, 0x10, fontManager.get_font("MENU_FONT"), menushapes.extract_shape(0x14), true);
 	quotes.run(gwin);
 }
 
 void SI_Game::show_credits() {
-	const uint32                      menu_mouse_only = 1u << static_cast<int>(Image_window::UiLayerMousePointer);
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, menu_mouse_only);
+	Scene_view scene(topx, topy, centerx, centery, ibuf);
 	pal->load(MAINSHP_FLX, PATCH_MAINSHP, 26);
 	Audio::get_ptr()->start_music(30, false, MyMidiPlayer::Force_None, MAINSHP_FLX);
 	TextScroller credits(MAINSHP_FLX, 0x0E, fontManager.get_font("MENU_FONT"), menushapes.extract_shape(0x14), true);
@@ -1379,10 +1376,10 @@ void SI_Game::show_credits() {
 }
 
 bool SI_Game::new_game(Vga_file& shapes) {
-	const uint32                      menu_mouse_only = 1u << static_cast<int>(Image_window::UiLayerMousePointer);
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, menu_mouse_only);
-	const int                         menuy = topy + 110;
-	std::shared_ptr<Font>             font  = fontManager.get_font("MENU_FONT");
+	std::optional<Scene_view> scene;
+	scene.emplace(topx, topy, centerx, centery, ibuf, true);
+	const int             menuy = topy + 110;
+	std::shared_ptr<Font> font  = fontManager.get_font("MENU_FONT");
 
 	if (Mouse::mouse() && !Mouse::use_touch_input) {    // If not primarily touch input
 		Mouse::mouse()->show();                         // Attempt to make the mouse visible initially
@@ -1474,7 +1471,7 @@ bool SI_Game::new_game(Vga_file& shapes) {
 				const SDL_Rect rectOnward = {topx + 10, topy + 180, 130, 16};
 				const SDL_Rect rectReturn = {centerx + 10, topy + 180, 130, 16};
 				SDL_Point      point;
-				gwin->get_win()->screen_to_game(event.button.x, event.button.y, gwin->get_fastmouse(), point.x, point.y);
+				scene->screen_to_scene(event.button.x, event.button.y, point.x, point.y);
 				if (SDL_GetRectEnclosingPoints(&point, 1, &rectName, nullptr)) {
 					if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
 						selected = 0;
@@ -1627,6 +1624,9 @@ bool SI_Game::new_game(Vga_file& shapes) {
 		set_avname(npc_name);
 		set_avsex(skindata->is_female);
 		pal->fade_out(c_fade_out_time);
+		// Leave the scene before init_gamedat so its error dialog (a gump) is not
+		// hidden by the scene layer mask.
+		scene.reset();
 		gwin->clear_screen(true);
 		// Immediately restore the palette after clearing the screen incase
 		// init_gamedat errors and displays a yesno_gump

--- a/gamewin.h
+++ b/gamewin.h
@@ -446,6 +446,10 @@ public:
 		win->layer_set_visible(handle, visible);
 	}
 
+	void layer_set_opaque(int handle, bool opaque) {
+		win->layer_set_opaque(handle, opaque);
+	}
+
 	bool layer_is_visible(int handle) {
 		return win->layer_is_visible(handle);
 	}

--- a/gumps/Gump_manager.cc
+++ b/gumps/Gump_manager.cc
@@ -196,7 +196,7 @@ void Gump_manager::render_gump_part_to_layer(Gump* g, int z, int part, bool is_h
 	const float   f    = iwin->get_ui_scale_factor(ui_kind_for(g, is_hud));
 	int           csx;
 	int           csy;
-	iwin->game_to_screen(b.x + b.w / 2, b.y + b.h / 2, gwin->get_fastmouse(), csx, csy);
+	iwin->game_to_screen(b.x + b.w / 2, b.y + b.h / 2, false, csx, csy);
 	float dw = static_cast<float>(b.w) * f;
 	float dh = static_cast<float>(b.h) * f;
 	float dx = static_cast<float>(csx) - dw / 2.0f;
@@ -284,7 +284,7 @@ bool Gump_manager::map_game_to_gump(const Gump* g, int gx, int gy, int& lx, int&
 	}
 	int sx;
 	int sy;
-	gwin->get_win()->game_to_screen(gx, gy, gwin->get_fastmouse(), sx, sy);
+	gwin->get_win()->game_to_screen(gx, gy, false, sx, sy);
 	int        llx;
 	int        lly;
 	const bool inside = gwin->screen_to_layer(g->render_layer, sx, sy, llx, lly);
@@ -587,7 +587,7 @@ void Gump_manager::add_gump(
 		const int     gh    = shape->get_height();
 		int           csx;
 		int           csy;
-		iwin->game_to_screen(gleft + gw / 2, gtop + gh / 2, gwin->get_fastmouse(), csx, csy);
+		iwin->game_to_screen(gleft + gw / 2, gtop + gh / 2, false, csx, csy);
 		const float dw    = static_cast<float>(gw) * f;
 		const float dh    = static_cast<float>(gh) * f;
 		const float dispw = static_cast<float>(iwin->get_display_width());
@@ -611,8 +611,8 @@ void Gump_manager::add_gump(
 			int ngy;
 			int ogx;
 			int ogy;
-			iwin->screen_to_game(static_cast<int>(ncsx), static_cast<int>(ncsy), gwin->get_fastmouse(), ngx, ngy);
-			iwin->screen_to_game(csx, csy, gwin->get_fastmouse(), ogx, ogy);
+			iwin->screen_to_game(static_cast<int>(ncsx), static_cast<int>(ncsy), false, ngx, ngy);
+			iwin->screen_to_game(csx, csy, false, ogx, ogy);
 			x += ngx - ogx;
 			y += ngy - ogy;
 			cnt = 0;    // Restart the stagger since we wrapped back on-screen.

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -944,6 +944,13 @@ void Image_window::show(int x, int y, int w, int h) {
 	if (!ready()) {
 		return;
 	}
+	// While a full-screen scene layer is driving the display, the caller paints
+	// into the scene buffer (not the game buffer) and blits via the normal path
+	// (show(), palette apply/fade, FLI player). Re-upload the layers each show so
+	// the animated scene refreshes.
+	if (scene_mode) {
+		mark_all_layers_dirty();
+	}
 	// call EndPaintIntoGuardBand just in case. It is safe to call it when not
 	// needed
 	EndPaintIntoGuardBand();
@@ -1191,6 +1198,11 @@ void Image_window::EndPaintIntoGuardBand() {
 }
 
 void Image_window::FillGuardband() {
+	// In scene mode drawing goes to a full-screen scene layer buffer that has no
+	// guard band; the game window's guard band must not be filled from it.
+	if (scene_mode) {
+		return;
+	}
 	auto pixels = static_cast<uint8*>(draw_surface->pixels) + guard_band + guard_band * draw_surface->pitch;
 	// Bottom
 	auto read  = pixels + (ibuf->height - 1) * draw_surface->pitch;
@@ -1233,6 +1245,12 @@ int Image_window::get_display_height() {
 }
 
 void Image_window::screen_to_game(int sx, int sy, bool fast, int& gx, int& gy) {
+	// While a full-screen scene layer owns the display, map through it so mouse
+	// hit-testing lines up with widgets drawn in the (scaled) scene.
+	if (scene_mode && active_scene_layer >= 0) {
+		screen_to_layer(active_scene_layer, sx, sy, gx, gy);
+		return;
+	}
 	if (fast) {
 		gx = sx + get_start_x();
 		gy = sy + get_start_y();
@@ -1246,6 +1264,12 @@ void Image_window::screen_to_game(int sx, int sy, bool fast, int& gx, int& gy) {
 }
 
 void Image_window::game_to_screen(int gx, int gy, bool fast, int& sx, int& sy) {
+	// Inverse of screen_to_game while a full-screen scene layer owns the display
+	// (keeps the cursor aligned with the scaled scene).
+	if (scene_mode && active_scene_layer >= 0) {
+		layer_to_screen(active_scene_layer, gx, gy, sx, sy);
+		return;
+	}
 	if (fast) {
 		if (Mouse::mouse()) {
 			Mouse::mouse()->unapply_fast_offset(gx, gy);
@@ -1559,6 +1583,16 @@ void Image_window::layer_set_visible(int handle, bool visible) {
 		return;
 	}
 	layers[handle]->set_visible(visible);
+}
+
+void Image_window::layer_set_opaque(int handle, bool opaque) {
+	if (handle < 0 || handle >= static_cast<int>(layers.size()) || !layers[handle]) {
+		return;
+	}
+	if (layers[handle]->is_opaque() != opaque) {
+		layers[handle]->set_opaque(opaque);
+		layers[handle]->set_dirty();    // Re-upload with the new transparency.
+	}
 }
 
 bool Image_window::layer_is_visible(int handle) {
@@ -1944,6 +1978,21 @@ bool Image_window::screen_to_layer(int handle, int sx, int sy, int& lx, int& ly)
 	ly = static_cast<int>((static_cast<float>(sy) - dst.y) * layer.logh / dst.h);
 	return static_cast<float>(sx) >= dst.x && static_cast<float>(sy) >= dst.y && lx >= 0 && ly >= 0 && lx < layer.logw
 		   && ly < layer.logh;
+}
+
+bool Image_window::layer_to_screen(int handle, int lx, int ly, int& sx, int& sy) {
+	if (handle < 0 || handle >= static_cast<int>(layers.size()) || !layers[handle]) {
+		return false;
+	}
+	const Layer& layer = *layers[handle];
+	SDL_FRect    dst;
+	get_layer_dest(layer, dst);
+	if (dst.w <= 0 || dst.h <= 0 || layer.logw <= 0 || layer.logh <= 0) {
+		return false;
+	}
+	sx = static_cast<int>(dst.x + static_cast<float>(lx) * dst.w / layer.logw);
+	sy = static_cast<int>(dst.y + static_cast<float>(ly) * dst.h / layer.logh);
+	return true;
 }
 
 void Image_window::free_layer_textures() {

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -77,6 +77,7 @@ public:
 		UiLayerModalGumps,
 		UiLayerDisplayMap,
 		UiLayerTextEffects,
+		UiLayerFullScreenScene,
 		NumUiLayerKinds
 	};
 
@@ -172,6 +173,9 @@ public:
 		int                           logh;                 // Logical (game-pixel) height.
 		int                           fixed_scale;          // >0 forces integer scale, 0 = auto-fit.
 		unsigned char                 transparent;          // Palette index drawn as transparent.
+		bool                          opaque   = false;    // If set, NO index is transparent (a
+														  // full-screen opaque scene: every pixel
+														  // is drawn, even the 'transparent' index).
 		bool                          visible  = true;
 		bool                          dirty    = true;     // Buffer changed => re-upload.
 		int                           z        = 0;        // Composite order (higher = on top).
@@ -204,6 +208,14 @@ public:
 
 		unsigned char get_transparent() const {
 			return transparent;
+		}
+
+		bool is_opaque() const {
+			return opaque;
+		}
+
+		void set_opaque(bool o) {
+			opaque = o;
 		}
 
 		void set_dirty() {
@@ -293,9 +305,21 @@ protected:
 	int saved_game_height;             // Normally this is the same as game_height and is
 									   // used by the PaintIntoGuardBand code so it can
 									   // change and restore the value of game_height
-	int inter_width;
-	int inter_height;
-
+	// While a full-screen "scene" layer drives the display through the normal
+	// blit path (intro, endgame, cheat screen), scene_mode is on: the guard band
+	// is bypassed (the scene buffer has none) and every show() re-uploads the
+	// layers so an animated scene refreshes. get_game_width()/get_game_height()
+	// report the scene size so existing centring math lines up with the scene
+	// buffer.
+	bool scene_mode        = false;
+	int  scene_game_width  = 0;
+	int  scene_game_height = 0;
+	// When scene mode is on, the handle of the full-screen scene layer that owns
+	// the display, so screen_to_game()/game_to_screen() can map through it (mouse
+	// hit-testing + cursor placement line up with the scaled scene).
+	int  active_scene_layer = -1;
+	int  inter_width;
+	int  inter_height;
 	// Guardband around the edge of the draw surface to allow scalers to run
 	// without per pixel bounds checking and to allow rounding up to
 	// multiples of 4. It should  not be less than 4 and there is no reason for
@@ -570,11 +594,11 @@ public:
 	}
 
 	int get_game_width() {
-		return game_width;
+		return scene_mode ? scene_game_width : game_width;
 	}
 
 	int get_game_height() {
-		return game_height;
+		return scene_mode ? scene_game_height : game_height;
 	}
 
 	int get_end_x() {
@@ -698,6 +722,11 @@ public:
 	// Map a point in display/window coords to a layer's logical coords.
 	// Returns false if the layer is invalid or the point falls outside it.
 	bool screen_to_layer(int handle, int sx, int sy, int& lx, int& ly);
+	// Inverse of screen_to_layer: map a layer's logical coords to display coords.
+	bool layer_to_screen(int handle, int lx, int ly, int& sx, int& sy);
+	// Mark a layer as fully opaque: no palette index is treated as transparent
+	// (for a full-screen scene whose content may legitimately use index 255).
+	void layer_set_opaque(int handle, bool opaque);
 
 	// Set palette.
 	virtual void set_palette(const unsigned char* rgbs, int maxval, int brightness = 100) {
@@ -726,6 +755,11 @@ public:
 	// whether or not we should do guardband painting
 	// Criteria is using a scaler other than point and there is a guardband
 	bool ShouldPaintIntoGuardband() {
+		// A full-screen scene layer buffer has no guard band, so use the plain
+		// (point-scaler style) path with no guard band expansion.
+		if (scene_mode) {
+			return false;
+		}
 		// Only if actually scaling
 		if (draw_surface == display_surface) {
 			return false;
@@ -755,6 +789,37 @@ public:
 	void ShowFillGuardBand() {
 		FillGuardband();
 		show();
+	}
+
+	// Enter/leave "scene mode" while a full-screen scene layer is driving the
+	// display through the normal blit path. In scene mode the guard band fill is
+	// skipped (the scene buffer has no guard band) and every show() re-uploads
+	// the layers so an animated scene refreshes. get_game_width()/
+	// get_game_height() report the scene size so existing centring math lines up
+	// with the scene buffer.
+	void set_scene_mode(bool on, int scene_w = 0, int scene_h = 0, int layer_handle = -1) {
+		scene_mode         = on;
+		scene_game_width   = scene_w;
+		scene_game_height  = scene_h;
+		active_scene_layer = on ? layer_handle : -1;
+	}
+
+	bool in_scene_mode() const {
+		return scene_mode;
+	}
+
+	// The scene size reported by get_game_width()/get_game_height() while scene
+	// mode is on. Used to save/restore scene mode so scenes can nest.
+	int get_scene_game_width() const {
+		return scene_game_width;
+	}
+
+	int get_scene_game_height() const {
+		return scene_game_height;
+	}
+
+	int get_active_scene_layer() const {
+		return active_scene_layer;
 	}
 
 	/*

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -173,18 +173,18 @@ public:
 		int                           logh;                 // Logical (game-pixel) height.
 		int                           fixed_scale;          // >0 forces integer scale, 0 = auto-fit.
 		unsigned char                 transparent;          // Palette index drawn as transparent.
-		bool                          opaque   = false;    // If set, NO index is transparent (a
-														  // full-screen opaque scene: every pixel
-														  // is drawn, even the 'transparent' index).
-		bool                          visible  = true;
-		bool                          dirty    = true;     // Buffer changed => re-upload.
-		int                           z        = 0;        // Composite order (higher = on top).
-		bool                          has_dest = false;    // Explicit destination override?
-		SDL_FRect                     dest{};              // Destination rect (display coords).
-		UiLayerKind                   ui_kind      = UiLayerDefault;
-		int                           render_scale = 1;    // 1 = 1:1 upload; >1 = pre-scaled by
-														   // the game's scaler at this factor.
-		unsigned char alpha = 255;                         // Whole-layer opacity (255 = opaque).
+		bool                          opaque = false;       // If set, NO index is transparent (a
+															// full-screen opaque scene: every pixel
+															// is drawn, even the 'transparent' index).
+		bool        visible  = true;
+		bool        dirty    = true;     // Buffer changed => re-upload.
+		int         z        = 0;        // Composite order (higher = on top).
+		bool        has_dest = false;    // Explicit destination override?
+		SDL_FRect   dest{};              // Destination rect (display coords).
+		UiLayerKind ui_kind      = UiLayerDefault;
+		int         render_scale = 1;    // 1 = 1:1 upload; >1 = pre-scaled by
+										 // the game's scaler at this factor.
+		unsigned char alpha = 255;       // Whole-layer opacity (255 = opaque).
 		// Optional 256-entry ARGB override, one per palette index. A non-zero
 		// entry is used verbatim (with its own alpha) instead of the opaque
 		// palette colour, letting a layer draw translucent pixels.
@@ -317,9 +317,9 @@ protected:
 	// When scene mode is on, the handle of the full-screen scene layer that owns
 	// the display, so screen_to_game()/game_to_screen() can map through it (mouse
 	// hit-testing + cursor placement line up with the scaled scene).
-	int  active_scene_layer = -1;
-	int  inter_width;
-	int  inter_height;
+	int active_scene_layer = -1;
+	int inter_width;
+	int inter_height;
 	// Guardband around the edge of the draw surface to allow scalers to run
 	// without per pixel bounds checking and to allow rounding up to
 	// multiples of 4. It should  not be less than 4 and there is no reason for

--- a/imagewin/iwin8.cc
+++ b/imagewin/iwin8.cc
@@ -228,7 +228,7 @@ unique_ptr<unsigned char[]> Image_window8::mini_screenshot() {
  *  ARGB for one palette index within a layer.
  */
 uint32 Image_window8::layer_argb_pixel(const Layer& layer, unsigned char p) const {
-	if (p == layer.get_transparent()) {
+	if (!layer.is_opaque() && p == layer.get_transparent()) {
 		return 0;    // Fully transparent.
 	}
 	if (!layer.index_argb.empty() && layer.index_argb[p] != 0) {
@@ -298,6 +298,74 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 	// Fixed-palette override for this layer, if any (else the live palette).
 	const std::vector<unsigned char>& pal_ov      = get_ui_cfg(layer.ui_kind).ui_palette_colors;
 	const unsigned char*              palette_rgb = pal_ov.empty() ? colors : pal_ov.data();
+
+	// A fully opaque layer (a full-screen scene) has no transparent index and no
+	// translucency, so skip the transparency matting entirely: scale the colours
+	// once through the game scaler and mark every pixel opaque. Otherwise the
+	// scene's legitimate use of the 'transparent' index (e.g. index 255 in an
+	// FLI frame) would be matted away to see-through.
+	if (layer.is_opaque()) {
+		const int    ossw  = ((logw + 3) & ~3) + 2 * gb;
+		const int    ossh  = logh + 2 * gb;
+		SDL_Surface* osrc8 = SDL_CreateSurface(ossw, ossh, SDL_PIXELFORMAT_INDEX8);
+		SDL_Surface* odst  = SDL_CreateSurface(ossw * factor, ossh * factor, SDL_PIXELFORMAT_ARGB8888);
+		bool         done  = false;
+		if (osrc8 && odst) {
+			SDL_Palette* sdl_pal = SDL_CreateSurfacePalette(osrc8);
+			if (sdl_pal) {
+				SDL_Color cols[256];
+				for (int i = 0; i < 256; i++) {
+					cols[i].r = palette_rgb[3 * i];
+					cols[i].g = palette_rgb[3 * i + 1];
+					cols[i].b = palette_rgb[3 * i + 2];
+					cols[i].a = 255;
+				}
+				SDL_SetPaletteColors(sdl_pal, cols, 0, 256);
+				uint8*    sp       = static_cast<uint8*>(osrc8->pixels);
+				const int sp_pitch = osrc8->pitch;
+				// Copy content at (gb,gb), replicating edge pixels into the guard
+				// band so the scaler does not bleed a stray colour at the border.
+				for (int y = 0; y < logh; y++) {
+					uint8*               drow = sp + static_cast<size_t>(y + gb) * sp_pitch;
+					const unsigned char* srow = src + static_cast<size_t>(y) * spitch;
+					memset(drow, srow[0], gb);
+					memcpy(drow + gb, srow, logw);
+					memset(drow + gb + logw, srow[logw - 1], ossw - gb - logw);
+				}
+				for (int y = 0; y < gb; y++) {
+					memcpy(sp + static_cast<size_t>(y) * sp_pitch, sp + static_cast<size_t>(gb) * sp_pitch, ossw);
+				}
+				for (int y = logh + gb; y < ossh; y++) {
+					memcpy(sp + static_cast<size_t>(y) * sp_pitch, sp + static_cast<size_t>(logh + gb - 1) * sp_pitch, ossw);
+				}
+				if (scale_layer_color(layer, osrc8, logw, logh, odst)) {
+					auto          texpix = make_unique<uint32[]>(static_cast<size_t>(tex_w) * tex_h);
+					const uint32* pix    = static_cast<const uint32*>(odst->pixels);
+					const size_t  dpitch = static_cast<size_t>(odst->pitch) / sizeof(uint32);
+					const size_t  sgb    = static_cast<size_t>(factor) * gb;
+					for (int y = 0; y < tex_h; y++) {
+						const uint32* row  = pix + (static_cast<size_t>(y) + sgb) * dpitch + sgb;
+						uint32*       trow = texpix.get() + static_cast<size_t>(y) * tex_w;
+						for (int x = 0; x < tex_w; x++) {
+							trow[x] = 0xff000000u | (row[x] & 0x00ffffffu);
+						}
+					}
+					SDL_UpdateTexture(layer.texture, nullptr, texpix.get(), tex_w * static_cast<int>(sizeof(uint32)));
+					done = true;
+				}
+			}
+		}
+		if (odst) {
+			SDL_DestroySurface(odst);
+		}
+		if (osrc8) {
+			SDL_DestroySurface(osrc8);
+		}
+		if (done) {
+			return true;
+		}
+		// If the fast path failed, fall through to the normal (matting) path.
+	}
 
 	// Guard-banded 8-bit source (content at (gb,gb)) and a scaled 32-bit dest.
 	const int    ssw    = ((logw + 3) & ~3) + 2 * gb;

--- a/ios/Exult.xcodeproj/project.pbxproj
+++ b/ios/Exult.xcodeproj/project.pbxproj
@@ -1,4 +1,4 @@
-﻿// !$*UTF8*$!
+// !$*UTF8*$!
 {
 	archiveVersion = 1;
 	classes = {
@@ -430,6 +430,7 @@
 		8ADFFDF525DE791000FC4D3A /* verify.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = verify.h; path = ../verify.h; sourceTree = "<group>"; };
 		8ADFFDF725DE791000FC4D3A /* cheat_screen_strings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cheat_screen_strings.h; path = ../cheat_screen_strings.h; sourceTree = "<group>"; };
 		8ADFFDF825DE791000FC4D3A /* cheat_screen_actors.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cheat_screen_actors.cc; path = ../cheat_screen_actors.cc; sourceTree = "<group>"; };
+		8AE3D1093001610500BCB1FF /* scene_layer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = scene_layer.h; path = ../scene_layer.h; sourceTree = SOURCE_ROOT; };
 		8AE8B9BC2E400B4F0094DF3C /* SDL3.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SDL3.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AF2AFD62016707F00696E08 /* joypad-glass-southwest.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "joypad-glass-southwest.png"; sourceTree = "<group>"; };
 		8AF2AFD72016708000696E08 /* joypad-glass-north.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "joypad-glass-north.png"; sourceTree = "<group>"; };
@@ -1186,6 +1187,7 @@
 				8A38EB762E2AA11300450868 /* playscene.cc */,
 				E700DC781A6E30A7006C8BE4 /* readnpcs.cc */,
 				E700DC791A6E30A7006C8BE4 /* rect.h */,
+				8AE3D1093001610500BCB1FF /* scene_layer.h */,
 				E700DC7A1A6E30A7006C8BE4 /* schedule.cc */,
 				E700DC7B1A6E30A7006C8BE4 /* schedule.h */,
 				E700DC7D1A6E30A7006C8BE4 /* shapeid.cc */,

--- a/playscene.cc
+++ b/playscene.cc
@@ -27,6 +27,7 @@
 #include "game.h"
 #include "gamewin.h"
 #include "palette.h"
+#include "scene_layer.h"
 #include "txtscroll.h"
 #include "vgafile.h"
 
@@ -927,7 +928,14 @@ void ScenePlayer::play_scene() {
 	if (!scene_available() || !parse_info_file()) {
 		return;
 	}
-	Game_window::Scoped_ui_layer_mask scene_layers(gwin, 0);
+	// Render the scripted scene into a full-screen scene layer scaled to fill the
+	// display. ScenePlayer positions its content via gwin->get_width()/
+	// get_height() (scene-aware) and gwin->get_win()->get_ib8() (redirected into
+	// the scene), so it does not use the Game coordinate anchors that Scene_view
+	// rewrites; unused local anchors are passed for those.
+	int            anchor_x = 0, anchor_y = 0, anchor_cx = 0, anchor_cy = 0;
+	Image_buffer8* anchor_ibuf = nullptr;
+	Scene_view     scene(anchor_x, anchor_y, anchor_cx, anchor_cy, anchor_ibuf);
 
 	try {
 		// Save the current palette index to restore it later.

--- a/scene_layer.h
+++ b/scene_layer.h
@@ -144,6 +144,24 @@ public:
 		}
 	}
 
+	// Change the scene's composite order.
+	void set_z(int z) {
+		if (handle >= 0) {
+			Game_window::get_instance()->layer_set_z(handle, z);
+		}
+	}
+
+	// A scene normally sits on top of every other overlay. Lower it beneath the
+	// text-gump layers so a text gump (scroll/sign/book) can be shown ON TOP of
+	// the scene; call restore_z() afterwards to put the scene back on top.
+	void lower_beneath_gumps() {
+		set_z(1 << 18);
+	}
+
+	void restore_z() {
+		set_z(scene_layer_z);
+	}
+
 private:
 	// Above the gump/HUD/modal layers, below the display-map overlay and mouse.
 	constexpr static int           scene_layer_z     = 1 << 19;
@@ -184,16 +202,16 @@ public:
 	Scene_view(
 			int& topx, int& topy, int& centerx, int& centery, Image_buffer8*& ibuf, bool interactive = false, int width = 320,
 			int height = 200)
-			: scene(width, height), r_topx(topx), r_topy(topy), r_centerx(centerx), r_centery(centery), r_ibuf(ibuf),
-			  s_topx(topx), s_topy(topy), s_centerx(centerx), s_centery(centery), s_ibuf(ibuf) {
+			: scene(width, height), r_topx(topx), r_topy(topy), r_centerx(centerx), r_centery(centery), r_ibuf(ibuf), s_topx(topx),
+			  s_topy(topy), s_centerx(centerx), s_centery(centery), s_ibuf(ibuf) {
 		Game_window*  gwin = Game_window::get_instance();
 		Image_window* iwin = gwin->get_win();
 		// Save everything we are about to change so it can be restored (this is
 		// also what makes scenes nestable).
-		s_mask       = gwin->get_ui_layer_kind_mask();
-		s_scene_mode = iwin->in_scene_mode();
-		s_scene_w    = iwin->get_scene_game_width();
-		s_scene_h    = iwin->get_scene_game_height();
+		s_mask         = gwin->get_ui_layer_kind_mask();
+		s_scene_mode   = iwin->in_scene_mode();
+		s_scene_w      = iwin->get_scene_game_width();
+		s_scene_h      = iwin->get_scene_game_height();
 		s_scene_handle = iwin->get_active_scene_layer();
 
 		uint32 mask = 1u << static_cast<int>(Image_window::UiLayerFullScreenScene);
@@ -276,10 +294,10 @@ private:
 	int             s_centerx;
 	int             s_centery;
 	Image_buffer8*  s_ibuf;
-	uint32          s_mask       = 0;
-	bool            s_scene_mode = false;
-	int             s_scene_w    = 0;
-	int             s_scene_h    = 0;
+	uint32          s_mask         = 0;
+	bool            s_scene_mode   = false;
+	int             s_scene_w      = 0;
+	int             s_scene_h      = 0;
 	int             s_scene_handle = -1;
 };
 

--- a/scene_layer.h
+++ b/scene_layer.h
@@ -1,0 +1,286 @@
+/*
+ *  scene_layer.h - Full-screen "scene" overlay layer helper.
+ *
+ *  Copyright (C) 2026  The Exult Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#ifndef SCENE_LAYER_H
+#define SCENE_LAYER_H
+
+#include "gamewin.h"
+#include "ibuf8.h"
+
+/*
+ *  Manages a full-screen "scene" overlay layer for takeover screens such as the
+ *  cheat screen and the intro. The scene is drawn into a fixed-size 8-bit
+ *  buffer (default 320x200; an individual scene may request a different size)
+ *  and is composited scaled to fill the display using the main game video
+ *  settings. Those come from the UiLayerFullScreenScene layer, which is wired
+ *  to config/video/scale_method, fill_mode and fill_scaler (no per-scene
+ *  config).
+ *
+ *  Usage, once per rendered frame:
+ *      scene.begin_frame();   // black letterbox + redirect drawing to the scene
+ *      ... paint into scene.buffer() (and via the current render target) ...
+ *      scene.end_frame();     // restore target, mark the scene visible + dirty
+ *      gwin->get_win()->show();   // composite to the display
+ */
+class Scene_layer {
+public:
+	explicit Scene_layer(int width = 320, int height = 200) : scene_w(width > 0 ? width : 320), scene_h(height > 0 ? height : 200) {
+		Game_window*  gwin = Game_window::get_instance();
+		Image_window* iwin = gwin->get_win();
+		// Follow the main game video settings so the scene scales exactly like
+		// the game area (rather than a fixed scaler). No per-scene config.
+		gwin->set_ui_layer_config(
+				Image_window::UiLayerFullScreenScene, scene_w, scene_h, iwin->get_scaler(), iwin->get_fill_mode(),
+				iwin->get_fill_scaler());
+		handle = gwin->create_layer(scene_w, scene_h, transparent_index, 0, scene_layer_z);
+		if (handle >= 0) {
+			gwin->layer_set_ui_kind(handle, Image_window::UiLayerFullScreenScene);
+			// A scene is a full-screen opaque takeover: NO palette index is
+			// transparent, so content that legitimately uses the transparent
+			// index (e.g. index 255 in an FLI frame) is drawn, not seen through.
+			gwin->layer_set_opaque(handle, true);
+			// Stay hidden until the first frame has been painted so an early
+			// composite (e.g. a palette apply) does not show an uninitialised
+			// buffer.
+			gwin->layer_set_visible(handle, false);
+		}
+	}
+
+	~Scene_layer() {
+		restore_target();
+		if (handle >= 0) {
+			Game_window::get_instance()->destroy_layer(handle);
+			handle = -1;
+		}
+	}
+
+	Scene_layer(const Scene_layer&)            = delete;
+	Scene_layer& operator=(const Scene_layer&) = delete;
+
+	bool valid() const {
+		return handle >= 0;
+	}
+
+	int width() const {
+		return scene_w;
+	}
+
+	int height() const {
+		return scene_h;
+	}
+
+	int get_handle() const {
+		return handle;
+	}
+
+	// The 8-bit buffer to paint the scene into.
+	Image_buffer8* buffer() const {
+		return handle >= 0 ? Game_window::get_instance()->get_layer_ibuf(handle) : nullptr;
+	}
+
+	// Begin a frame: clear the game window to black (the letterbox behind the
+	// scaled scene), then redirect drawing to the scene buffer and clear it.
+	void begin_frame() {
+		Game_window* gwin = Game_window::get_instance();
+		// Recover if a previous frame's end_frame was skipped (e.g. an early
+		// break in the caller's render loop) so the render target is never left
+		// pointing at the scene buffer.
+		restore_target();
+		gwin->clear_screen();    // black background behind the scaled scene
+		Image_buffer8* lbuf = buffer();
+		if (!lbuf) {
+			return;
+		}
+		prev_target = gwin->push_render_target(lbuf);
+		painting    = true;
+		lbuf->clear_clip();
+		lbuf->fill8(0);    // opaque black scene background
+	}
+
+	// End a frame: restore the previous render target and mark the scene layer
+	// visible + dirty so the next show() composites it. The scene has no
+	// explicit destination, so it fills the display per the configured fill
+	// mode.
+	void end_frame() {
+		restore_target();
+		if (handle >= 0) {
+			Game_window* gwin = Game_window::get_instance();
+			gwin->layer_set_visible(handle, true);
+			gwin->layer_set_dirty(handle);
+		}
+	}
+
+	// Restore the previous render target if a frame is still redirecting
+	// drawing to the scene buffer. Safe to call at any time.
+	void restore_target() {
+		if (painting) {
+			Game_window::get_instance()->pop_render_target(prev_target);
+			painting    = false;
+			prev_target = nullptr;
+		}
+	}
+
+	// Hide/show the scene, e.g. while temporarily showing the game world.
+	void set_visible(bool visible) {
+		if (handle >= 0) {
+			Game_window::get_instance()->layer_set_visible(handle, visible);
+		}
+	}
+
+private:
+	// Above the gump/HUD/modal layers, below the display-map overlay and mouse.
+	constexpr static int           scene_layer_z     = 1 << 19;
+	constexpr static unsigned char transparent_index = 255;
+
+	int            handle = -1;
+	int            scene_w;
+	int            scene_h;
+	Image_buffer8* prev_target = nullptr;
+	bool           painting    = false;
+};
+
+/*
+ *  RAII driver for a full-screen "takeover" screen (intro, endgame, character
+ *  creation, the top menu, ...) rendered through a Scene_layer. On construction
+ *  it:
+ *    - creates the fixed-size scene layer,
+ *    - masks every UI layer except the scene (plus the mouse pointer when
+ *      'interactive'),
+ *    - clears the game window to black (the letterbox) and redirects all drawing
+ *      into the scene buffer,
+ *    - puts the window in "scene mode" (guard band bypassed; every show()
+ *      re-uploads the scene so animation refreshes) and makes the scene visible,
+ *    - rewrites the caller's game-coordinate anchors so 320x200-relative drawing
+ *      lands in the scene (topx=topy=0, centerx=w/2, centery=h/2).
+ *  Every piece of that state (render target, scene mode, coordinate anchors and
+ *  the layer mask) is saved and restored on destruction, so scenes may nest
+ *  (e.g. the intro launched from the layered top menu) and the whole thing is
+ *  exception-safe.
+ *
+ *  Typical use:
+ *      Scene_view scene(topx, topy, centerx, centery, ibuf, interactive);
+ *      ... draw the screen using the (now scene-relative) anchors ...
+ *  and the scene is torn down when 'scene' goes out of scope.
+ */
+class Scene_view {
+public:
+	Scene_view(
+			int& topx, int& topy, int& centerx, int& centery, Image_buffer8*& ibuf, bool interactive = false, int width = 320,
+			int height = 200)
+			: scene(width, height), r_topx(topx), r_topy(topy), r_centerx(centerx), r_centery(centery), r_ibuf(ibuf),
+			  s_topx(topx), s_topy(topy), s_centerx(centerx), s_centery(centery), s_ibuf(ibuf) {
+		Game_window*  gwin = Game_window::get_instance();
+		Image_window* iwin = gwin->get_win();
+		// Save everything we are about to change so it can be restored (this is
+		// also what makes scenes nestable).
+		s_mask       = gwin->get_ui_layer_kind_mask();
+		s_scene_mode = iwin->in_scene_mode();
+		s_scene_w    = iwin->get_scene_game_width();
+		s_scene_h    = iwin->get_scene_game_height();
+		s_scene_handle = iwin->get_active_scene_layer();
+
+		uint32 mask = 1u << static_cast<int>(Image_window::UiLayerFullScreenScene);
+		if (interactive) {
+			mask |= 1u << static_cast<int>(Image_window::UiLayerMousePointer);
+		}
+		gwin->set_ui_layer_kind_mask(mask);
+
+		if (scene.valid()) {
+			scene.begin_frame();    // letterbox + redirect drawing to the scene
+			iwin->set_scene_mode(true, scene.width(), scene.height(), scene.get_handle());
+			gwin->layer_set_visible(scene.get_handle(), true);
+			gwin->layer_set_dirty(scene.get_handle());
+			r_ibuf = scene.buffer();
+			// In scene mode get_width()/get_height() report the scene size, so
+			// these evaluate to topx=topy=0, centerx=w/2, centery=h/2.
+			r_topx    = (gwin->get_width() - scene.width()) / 2;
+			r_topy    = (gwin->get_height() - scene.height()) / 2;
+			r_centerx = gwin->get_width() / 2;
+			r_centery = gwin->get_height() / 2;
+		}
+	}
+
+	~Scene_view() {
+		Game_window*  gwin = Game_window::get_instance();
+		Image_window* iwin = gwin->get_win();
+		scene.restore_target();    // pop the render target back
+		if (scene.valid()) {
+			gwin->layer_set_visible(scene.get_handle(), false);
+		}
+		// Restore scene mode (to the parent scene when nested, or off).
+		iwin->set_scene_mode(s_scene_mode, s_scene_w, s_scene_h, s_scene_handle);
+		r_topx    = s_topx;
+		r_topy    = s_topy;
+		r_centerx = s_centerx;
+		r_centery = s_centery;
+		r_ibuf    = s_ibuf;
+		gwin->set_ui_layer_kind_mask(s_mask);
+		// The scene layer itself is destroyed by the Scene_layer member dtor.
+	}
+
+	Scene_view(const Scene_view&)            = delete;
+	Scene_view& operator=(const Scene_view&) = delete;
+
+	bool valid() const {
+		return scene.valid();
+	}
+
+	Scene_layer& layer() {
+		return scene;
+	}
+
+	int get_handle() const {
+		return scene.get_handle();
+	}
+
+	// Map a display/screen point to scene-buffer (game-relative) coordinates for
+	// hit-testing widgets drawn into the scene. The scene is scaled to fill the
+	// display, so raw screen_to_game() coordinates do not line up with widgets
+	// laid out in the 320x200 scene. Falls back to screen_to_game() when the
+	// scene is unavailable.
+	bool screen_to_scene(int sx, int sy, int& lx, int& ly) const {
+		Game_window* gwin = Game_window::get_instance();
+		if (scene.valid()) {
+			return gwin->get_win()->screen_to_layer(scene.get_handle(), sx, sy, lx, ly);
+		}
+		gwin->get_win()->screen_to_game(sx, sy, gwin->get_fastmouse(), lx, ly);
+		return true;
+	}
+
+private:
+	Scene_layer     scene;
+	int&            r_topx;
+	int&            r_topy;
+	int&            r_centerx;
+	int&            r_centery;
+	Image_buffer8*& r_ibuf;
+	int             s_topx;
+	int             s_topy;
+	int             s_centerx;
+	int             s_centery;
+	Image_buffer8*  s_ibuf;
+	uint32          s_mask       = 0;
+	bool            s_scene_mode = false;
+	int             s_scene_w    = 0;
+	int             s_scene_h    = 0;
+	int             s_scene_handle = -1;
+};
+
+#endif

--- a/usecode/conversation.cc
+++ b/usecode/conversation.cc
@@ -851,7 +851,7 @@ int Conversation::conversation_choice(int x, int y) {
 	// the world, so map the click through the layer's placement.
 	int sx;
 	int sy;
-	gwin->get_win()->game_to_screen(x, y, gwin->get_fastmouse(), sx, sy);
+	gwin->get_win()->game_to_screen(x, y, false, sx, sy);
 	int lx;
 	int ly;
 	if (!gwin->screen_to_layer(conv_layer, sx, sy, lx, ly)) {


### PR DESCRIPTION
Converted every non-game scene and screen into a layer to have their sizes out of sync with the main game area.

Displayed at 320x200:
- our splash logo
- the game menus, quotes, credits, start a new game
- playscene scenes

Displayed at 360x225 (to give these more space but neither make them too tiny nor too big):
- the Exult menu, quotes, credits
- cheat screen
- shape browser
 
These resolutions are hardcoded and not user configurable. For now and if no one sees a point in making it configurable (I don't :)), forever :)

In the process also fixed the soundtester (control text was not rendered on the scroll) and fullscreen fastmouse (clicks on layers were not aligned).

Edit: on mobile all scale to 320x200.