### PR TITLE
SI defaultkeys: Fix comments/help text for walking vs. running.

### DIFF
--- a/data/si/defaultkeys.txt
+++ b/data/si/defaultkeys.txt
@@ -18,19 +18,19 @@ KP1		walk_south_west	# Run south west
 KP2		walk_south	# Run south
 KP3		walk_south_east	# Run south-east
 
-Shift-right	walk_east	1	# Run east
-Shift-left	walk_west	1	# Run west
-Shift-up	walk_north	1	# Run north
-Shift-down	walk_south	1	# Run south
+Shift-right	walk_east	1	# Walk east
+Shift-left	walk_west	1	# Walk west
+Shift-up	walk_north	1	# Walk north
+Shift-down	walk_south	1	# Walk south
 
-Shift-KP7	walk_north_west	1	# Run north-west
-Shift-KP8	walk_north	1	# Run north
-Shift-KP9	walk_north_east	1	# Run north-east
-Shift-KP4	walk_west	1	# Run west
-Shift-KP6	walk_east	1	# Run east
-Shift-KP1	walk_south_west	1	# Run south west
-Shift-KP2	walk_south	1	# Run south
-Shift-KP3	walk_south_east	1	# Run south-east
+Shift-KP7	walk_north_west	1	# Walk north-west
+Shift-KP8	walk_north	1	# Walk north
+Shift-KP9	walk_north_east	1	# Walk north-east
+Shift-KP4	walk_west	1	# Walk west
+Shift-KP6	walk_east	1	# Walk east
+Shift-KP1	walk_south_west	1	# Walk south west
+Shift-KP2	walk_south	1	# Walk south
+Shift-KP3	walk_south_east	1	# Walk south-east
 
 Alt-right	scroll_right
 Alt-left	scroll_left


### PR DESCRIPTION
Before, both keypad and shift-keypad had "run" comments which carry-over to the keybindings help screen. However, shift-keypad is walking, so fix the comments for those actions.

Before:
<img width="1164" height="961" alt="Screenshot from 2026-07-13 18-37-28" src="https://github.com/user-attachments/assets/14c7580e-b7d2-407d-a27d-8b4bec1bd4c0" />

After:
<img width="1154" height="1002" alt="Screenshot from 2026-07-13 18-38-11" src="https://github.com/user-attachments/assets/83defe60-472c-4f23-ad31-706210fbfdc9" />
