### PR TITLE
Translucency, Palette Cycling and Shape Animation for Exult Studio

### DIFF
--- a/mapedit/chunklst.cc
+++ b/mapedit/chunklst.cc
@@ -32,6 +32,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "exult_constants.h"
 #include "ibuf8.h"
 #include "shapegroup.h"
+#include "shapevga.h"
 #include "u7drag.h"
 #include "vgafile.h"
 
@@ -222,6 +223,8 @@ void Chunk_chooser::render_chunk(
 		Image_buffer8* rwin,        // Where to draw it
 		int xoff, int yoff          // Where to draw it in rwin.
 ) {
+	auto        shapes = dynamic_cast<Shapes_vga_file*>(ifile);
+	const auto& xforms = ExultStudio::get_instance()->GetXform();
 	for (int pass = 1; pass <= 2; pass++) {
 		unsigned char* data = get_chunk(chunknum);
 		int            y    = c_tilesize;
@@ -239,20 +242,29 @@ void Chunk_chooser::render_chunk(
 					shapenum = l + 256 * h;
 					framenum = Read1(data);
 				}
-				Shape_frame* s = ifile->get_shape(shapenum, framenum);
+				Shape_frame* s      = ifile->get_shape(shapenum, framenum);
+				auto         shinfo = shapes ? &shapes->get_info(shapenum) : nullptr;
 				// First pass over non RLE flats :
 				//  8x8 tiles, shapenum < 150,
 				//  Default origin -1, -1 to be reset,
 				//  Not clickable nor Hack-Movable.
 				if (s && pass == 1 && !s->is_rle()) {
-					s->paint(rwin, xoff + x, yoff + y);
+					if (shinfo && !shinfo->has_translucency() || xforms.empty()) {
+						s->paint(rwin, xoff + x, yoff + y);
+					} else {
+						s->paint_rle_translucent(rwin, xoff + x, yoff + y, xforms.data(), xforms.size());
+					}
 				}
 				// Second pass over RLE flats :
 				//  Larger than 8*8 tiles, shapenum >= 150,
 				//  Valid origin,
 				//  Clikable show Name and Outline, Hack-Movable.
 				if (s && pass == 2 && s->is_rle()) {
-					s->paint(rwin, xoff + x - 1, yoff + y - 1);
+					if (shinfo && !shinfo->has_translucency() || xforms.empty()) {
+						s->paint(rwin, xoff + x - 1, yoff + y - 1);
+					} else {
+						s->paint_rle_translucent(rwin, xoff + x - 1, yoff + y - 1, xforms.data(), xforms.size());
+					}
 				}
 			}
 		}

--- a/mapedit/chunklst.cc
+++ b/mapedit/chunklst.cc
@@ -249,7 +249,7 @@ void Chunk_chooser::render_chunk(
 				//  Default origin -1, -1 to be reset,
 				//  Not clickable nor Hack-Movable.
 				if (s && pass == 1 && !s->is_rle()) {
-					if (shinfo && !shinfo->has_translucency() || xforms.empty()) {
+					if ((shinfo && !shinfo->has_translucency()) || xforms.empty()) {
 						s->paint(rwin, xoff + x, yoff + y);
 					} else {
 						s->paint_rle_translucent(rwin, xoff + x, yoff + y, xforms.data(), xforms.size());
@@ -260,7 +260,7 @@ void Chunk_chooser::render_chunk(
 				//  Valid origin,
 				//  Clikable show Name and Outline, Hack-Movable.
 				if (s && pass == 2 && s->is_rle()) {
-					if (shinfo && !shinfo->has_translucency() || xforms.empty()) {
+					if ((shinfo && !shinfo->has_translucency()) || xforms.empty()) {
 						s->paint(rwin, xoff + x - 1, yoff + y - 1);
 					} else {
 						s->paint_rle_translucent(rwin, xoff + x - 1, yoff + y - 1, xforms.data(), xforms.size());

--- a/mapedit/chunklst.h
+++ b/mapedit/chunklst.h
@@ -89,10 +89,6 @@ class Chunk_chooser : public Object_browser, public Shape_draw {
 	void setup_info(bool savepos = true) override;
 	void setup_shapes_info();
 
-	void set_background_color(guint32 c) override {
-		Shape_draw::set_background_color(c);
-	}
-
 	int get_selected_id() override {
 		return selected < 0 ? -1 : info[selected].num;
 	}

--- a/mapedit/combo.cc
+++ b/mapedit/combo.cc
@@ -402,12 +402,13 @@ void Combo::draw(
 		if (!shape) {
 			continue;
 		}
+		const auto& info = shapes_file->get_info(m->shapenum);
 		// But draw_shape uses top-left.
 		x -= shape->get_xleft();
 		y -= shape->get_yabove();
 		x += xoff;
 		y += yoff;    // Add offset within area.
-		draw->draw_shape(shape, x, y);
+		draw->draw_shape(shape, x, y, info.has_translucency());
 		if (it - members.begin() == selected) {
 			selx     = x;    // Save coords for selected.
 			sely     = y;

--- a/mapedit/combo.h
+++ b/mapedit/combo.h
@@ -203,10 +203,6 @@ class Combo_chooser : public Object_browser, public Shape_draw {
 	void setup_shapes_info();
 	void render() override;    // Draw list.
 
-	void set_background_color(guint32 c) override {
-		Shape_draw::set_background_color(c);
-	}
-
 	int get_selected_id() override {
 		return selected < 0 ? -1 : info[selected].num;
 	}

--- a/mapedit/eggedit.cc
+++ b/mapedit/eggedit.cc
@@ -202,7 +202,7 @@ void ExultStudio::open_egg_window(
 						return (shnum >= c_first_obj_shape) && (shnum < c_max_shapes);
 					},
 					get_widget("monst_frame"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(), get_widget("egg_monster_draw"),
-					false, Shape_single::Trans_type::Enabled);
+					false, Shape_single::TA_type::Enabled);
 			egg_missile_single = new Shape_single(
 					get_widget("missile_shape"), nullptr,
 					[](int shnum) -> bool {

--- a/mapedit/eggedit.cc
+++ b/mapedit/eggedit.cc
@@ -201,7 +201,8 @@ void ExultStudio::open_egg_window(
 					[](int shnum) -> bool {
 						return (shnum >= c_first_obj_shape) && (shnum < c_max_shapes);
 					},
-					get_widget("monst_frame"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(), get_widget("egg_monster_draw"));
+					get_widget("monst_frame"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(), get_widget("egg_monster_draw"),
+					false, Shape_single::Trans_type::Enabled);
 			egg_missile_single = new Shape_single(
 					get_widget("missile_shape"), nullptr,
 					[](int shnum) -> bool {

--- a/mapedit/exult_studio.glade
+++ b/mapedit/exult_studio.glade
@@ -27786,7 +27786,7 @@
         <property name="margin-bottom">2</property>
         <property name="orientation">vertical</property>
         <child>
-          <!-- n-columns=2 n-rows=5 -->
+          <!-- n-columns=2 n-rows=7 -->
           <object class="GtkGrid" id="table23">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -27798,6 +27798,7 @@
             <property name="margin-bottom">1</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
+            <property name="row-homogeneous">True</property>            
             <child>
               <object class="GtkFrame" id="frame122">
                 <property name="visible">True</property>
@@ -28192,6 +28193,222 @@
               <packing>
                 <property name="left-attach">1</property>
                 <property name="top-attach">4</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="frame_prefs_transl_label">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">fill</property>
+                <property name="valign">fill</property>
+                <property name="margin-start">0</property>
+                <property name="margin-end">2</property>
+                <property name="margin-top">1</property>
+                <property name="margin-bottom">0</property>
+                <property name="hexpand">False</property>
+                <property name="vexpand">True</property>
+                <property name="label-xalign">0</property>
+                <child>
+                  <object class="GtkLabel" id="label_prefs_transl">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-start">4</property>
+                    <property name="margin-end">4</property>
+                    <property name="margin-top">2</property>
+                    <property name="margin-bottom">2</property>
+                    <property name="label" translatable="yes">Translucent Rendering:</property>
+                    <property name="xalign">0.100</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">5</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="frame_prefs_transl">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">fill</property>
+                <property name="valign">fill</property>
+                <property name="margin-start">2</property>
+                <property name="margin-end">0</property>
+                <property name="margin-top">1</property>
+                <property name="margin-bottom">0</property>
+                <property name="hexpand">False</property>
+                <property name="vexpand">False</property>
+                <property name="label-xalign">0</property>
+                <child>
+                  <object class="GtkCheckButton" id="prefs_transl">
+                    <property name="label" translatable="yes"></property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="halign">fill</property>
+                    <property name="valign">center</property>
+                    <property name="margin-start">0</property>
+                    <property name="margin-end">2</property>
+                    <property name="margin-top">0</property>
+                    <property name="margin-bottom">1</property>
+                    <property name="hexpand">False</property>
+                    <property name="vexpand">False</property>
+                    <property name="use-underline">True</property>
+                    <property name="draw-indicator">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">5</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+           <child>
+              <object class="GtkFrame" id="frame_prefs_palcyc_label">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">fill</property>
+                <property name="valign">fill</property>
+                <property name="margin-start">0</property>
+                <property name="margin-end">2</property>
+                <property name="margin-top">1</property>
+                <property name="margin-bottom">0</property>
+                <property name="hexpand">False</property>
+                <property name="vexpand">True</property>
+                <property name="label-xalign">0</property>
+                <child>
+                  <object class="GtkLabel" id="label_prefs_palcyc">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-start">4</property>
+                    <property name="margin-end">4</property>
+                    <property name="margin-top">2</property>
+                    <property name="margin-bottom">2</property>
+                    <property name="label" translatable="yes">Palette Cycling:</property>
+                    <property name="xalign">0.100</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">6</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="frame_prefs_palcyc">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">fill</property>
+                <property name="valign">fill</property>
+                <property name="margin-start">2</property>
+                <property name="margin-end">0</property>
+                <property name="margin-top">1</property>
+                <property name="margin-bottom">0</property>
+                <property name="hexpand">False</property>
+                <property name="vexpand">False</property>
+                <property name="label-xalign">0</property>
+                <child>
+                  <object class="GtkCheckButton" id="prefs_palcyc">
+                    <property name="label" translatable="yes"></property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="halign">fill</property>
+                    <property name="valign">center</property>
+                    <property name="margin-start">0</property>
+                    <property name="margin-end">2</property>
+                    <property name="margin-top">0</property>
+                    <property name="margin-bottom">1</property>
+                    <property name="hexpand">False</property>
+                    <property name="vexpand">False</property>
+                    <property name="use-underline">True</property>
+                    <property name="draw-indicator">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">6</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+           <child>
+              <object class="GtkFrame" id="frame_prefs_animsh_label">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">fill</property>
+                <property name="valign">fill</property>
+                <property name="margin-start">0</property>
+                <property name="margin-end">2</property>
+                <property name="margin-top">1</property>
+                <property name="margin-bottom">0</property>
+                <property name="hexpand">False</property>
+                <property name="vexpand">True</property>
+                <property name="label-xalign">0</property>
+                <child>
+                  <object class="GtkLabel" id="label_prefs_animsh">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-start">4</property>
+                    <property name="margin-end">4</property>
+                    <property name="margin-top">2</property>
+                    <property name="margin-bottom">2</property>
+                    <property name="label" translatable="yes">Shape Animations:</property>
+                    <property name="xalign">0.100</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">7</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="frame_prefs_animsh">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">fill</property>
+                <property name="valign">fill</property>
+                <property name="margin-start">2</property>
+                <property name="margin-end">0</property>
+                <property name="margin-top">1</property>
+                <property name="margin-bottom">0</property>
+                <property name="hexpand">False</property>
+                <property name="vexpand">False</property>
+                <property name="label-xalign">0</property>
+                <child>
+                  <object class="GtkCheckButton" id="prefs_animsh">
+                    <property name="label" translatable="yes"></property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="halign">fill</property>
+                    <property name="valign">center</property>
+                    <property name="margin-start">0</property>
+                    <property name="margin-end">2</property>
+                    <property name="margin-top">0</property>
+                    <property name="margin-bottom">1</property>
+                    <property name="hexpand">False</property>
+                    <property name="vexpand">False</property>
+                    <property name="use-underline">True</property>
+                    <property name="draw-indicator">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">7</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>

--- a/mapedit/npcedit.cc
+++ b/mapedit/npcedit.cc
@@ -279,7 +279,7 @@ void ExultStudio::open_npc_window(
 						return (shnum >= c_first_obj_shape) && (shnum < c_max_shapes);
 					},
 					get_widget("npc_frame"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(), get_widget("npc_draw"), false,
-					Shape_single::Trans_type::Enabled);    // Exult always draws NPCs translucent so doing the same here
+					Shape_single::TA_type::Enabled);    // Exult always draws NPCs translucent so doing the same here
 		}
 		if (facefile && palbuf) {
 			npc_face_single = new Shape_single(

--- a/mapedit/npcedit.cc
+++ b/mapedit/npcedit.cc
@@ -278,7 +278,8 @@ void ExultStudio::open_npc_window(
 					[](int shnum) -> bool {
 						return (shnum >= c_first_obj_shape) && (shnum < c_max_shapes);
 					},
-					get_widget("npc_frame"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(), get_widget("npc_draw"));
+					get_widget("npc_frame"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(), get_widget("npc_draw"), false,
+					Shape_single::Trans_type::Enabled);    // Exult always draws NPCs translucent so doing the same here
 		}
 		if (facefile && palbuf) {
 			npc_face_single = new Shape_single(

--- a/mapedit/npcpresets.cc
+++ b/mapedit/npcpresets.cc
@@ -245,7 +245,7 @@ bool Npc_preset_file::write() {
 		}
 		modified = false;
 		return true;
-	} catch (std::exception& e) {
+	} catch (std::exception&) {
 		return false;
 	}
 }
@@ -290,7 +290,7 @@ bool Npc_preset_file::read(const char* nm) {
 		}
 		modified = false;
 		return true;
-	} catch (std::exception& e) {
+	} catch (std::exception&) {
 		return false;
 	}
 }

--- a/mapedit/npcpresets.cc
+++ b/mapedit/npcpresets.cc
@@ -333,7 +333,7 @@ void ExultStudio::setup_npc_presets_list() {
 		if (preset->has_value("face")) {
 			const int face_num = std::atoi(preset->get_value("face").c_str());
 			if (face_num >= 0 && facefile) {
-				GdkPixbuf* full_pixbuf = shape_image(facefile->get_ifile(), face_num, 0, true);
+				GdkPixbuf* full_pixbuf = shape_image(facefile->get_ifile(), face_num, 0, true, true);
 				if (full_pixbuf) {
 					const int width  = gdk_pixbuf_get_width(full_pixbuf);
 					const int height = gdk_pixbuf_get_height(full_pixbuf);
@@ -347,7 +347,7 @@ void ExultStudio::setup_npc_presets_list() {
 		if (preset->has_value("shape")) {
 			const int shape_num = std::atoi(preset->get_value("shape").c_str());
 			if (shape_num > 0 && vgafile) {
-				GdkPixbuf* full_pixbuf = shape_image(vgafile->get_ifile(), shape_num, 0, true);
+				GdkPixbuf* full_pixbuf = shape_image(vgafile->get_ifile(), shape_num, 0, true, true);
 				if (full_pixbuf) {
 					const int width  = gdk_pixbuf_get_width(full_pixbuf);
 					const int height = gdk_pixbuf_get_height(full_pixbuf);

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -861,7 +861,7 @@ Shape_single::WidgetChangedConnect::WidgetChangedConnect(
 }
 
 Shape_single::WidgetChangedConnect::~WidgetChangedConnect() {
-	if (connect) {
+	if (connect && g_signal_handler_is_connected(G_OBJECT(widget), connect)) {
 		g_signal_handler_disconnect(G_OBJECT(widget), connect);
 		connect = 0;
 	}

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -227,6 +227,9 @@ Shape_draw::~Shape_draw() {
 // Get animated frame using an Animation_info object
 
 int Shape_draw::GetAnimInfoFrame(const Animation_info* aniinf, unsigned short first_frame, unsigned short shape_frames) {
+	if (!ExultStudio::IsShapeAnimationEnabled()) {
+		return first_frame;
+	}
 	//
 	// Variables that represent the fields in the Frame_animator class
 	//
@@ -710,43 +713,47 @@ gboolean Shape_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, g
 	simpleai.set(Animation_info::AniType::FA_LOOPING);
 	auto animinfo = single->aniinf;
 
-	switch (single->animating) {
-	case TA_type::Enabled:
-		if (!animinfo) {
-			animinfo = &simpleai;
-		}
-		break;
+	if (ExultStudio::IsShapeAnimationEnabled()) {
+		switch (single->animating) {
+		case TA_type::Enabled:
+			if (!animinfo) {
+				animinfo = &simpleai;
+			}
+			break;
 
-	case TA_type::shapeinfo: {
-		// Get it from Shapeinfo
-		// set animating if the shape info wants it
-		if (shinfo) {
-			if (!animinfo && shinfo->is_animated()) {
-				animinfo = shinfo->get_animation_info();
-				if (!animinfo) {
-					animinfo = &simpleai;
+		case TA_type::shapeinfo: {
+			// Get it from Shapeinfo
+			// set animating if the shape info wants it
+			if (shinfo) {
+				if (!animinfo && shinfo->is_animated()) {
+					animinfo = shinfo->get_animation_info();
+					if (!animinfo) {
+						animinfo = &simpleai;
+					}
 				}
 			}
+			break;
+
+		case TA_type::widget: {
+			if (!studio->get_toggle("shinfo_animated_check")) {
+				animinfo = nullptr;
+			}
+		} break;
 		}
-	case TA_type::widget: {
-		if (!studio->get_toggle("shinfo_animated_check")) {
+
+		default:
 			animinfo = nullptr;
+			;
+			break;
 		}
-	} break;
-	}
 
-	default:
-		animinfo = nullptr;
-		;
-		break;
-	}
-
-	if (animinfo) {
-		// makesure animation is emabled if needed
-		if (single->IsAnimatingStopped()) {
-			single->PauseAnimating(0);
-		} else {
-			frnum = single->GetAnimInfoFrame(animinfo, frnum, num_frames);
+		if (animinfo) {
+			// makesure animation is emabled if needed
+			if (single->IsAnimatingStopped()) {
+				single->PauseAnimating(0);
+			} else {
+				frnum = single->GetAnimInfoFrame(animinfo, frnum, num_frames);
+			}
 		}
 	}
 
@@ -1055,7 +1062,7 @@ void Shape_shape_single::on_widget_state(GtkWidget* widget, GtkStateFlags flags,
 }
 
 void Shape_shape_single::setup_aniinf() {
-	if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(shape_animated.widget))) {
+	if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(shape_animated.widget)) || !ExultStudio::IsShapeAnimationEnabled()) {
 		animating = Shape_single::TA_type::Disabled;
 		PauseAnimating();
 		aniinf = nullptr;

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -252,7 +252,7 @@ void Shape_draw::update_palette(const unsigned char* palbuf, unsigned start, uns
 		palette->colors[i] = c;
 	}
 	if (changed) {
-		render();
+		gtk_widget_queue_draw(draw);
 	}
 }
 

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -99,7 +99,7 @@ void Shape_draw::show(
  */
 
 void Shape_draw::draw_shape(Shape_frame* shape, int x, int y, bool trans) {
-	if (trans) {
+	if (trans && shape->is_rle()) {
 		const auto& xform = ExultStudio::get_instance()->GetXform();
 		shape->paint_rle_translucent(iwin, x + shape->get_xleft(), y + shape->get_yabove(), xform.data(), xform.size());
 	} else {
@@ -1191,7 +1191,7 @@ GdkPixbuf* ExultStudio::shape_image(Vga_file* shpfile, int shnum, int frnum, boo
 	Image_buffer8 tbuf(w, h);    // Create buffer to render to.
 	tbuf.fill8(0xff);            // Fill with 'transparent' pixel.
 	unsigned char* tbits = tbuf.get_bits();
-	if (!translucent) {
+	if (!translucent || !shape->is_rle()) {
 		shape->paint(&tbuf, w - 1 - xright, h - 1 - ybelow);
 	} else {
 		shape->paint_rle_translucent(&tbuf, w - 1 - xright, h - 1 - ybelow, xforms.data(), xforms.size());

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -43,6 +43,7 @@ using std::endl;
  * Base class Shape_draw : Displays a Shape or many Shapes from a .vga file.
  * -------------------------------------------------------------------------
  */
+Shape_draw* Shape_draw::list_head = nullptr;
 
 /*
  *  Blit onto screen.
@@ -195,7 +196,10 @@ Shape_draw::Shape_draw(
 		)
 		: ifile(i), draw(drw), drawgc(nullptr), drawfg(0), iwin(nullptr), palette(nullptr), drop_callback(nullptr),
 		  drop_user_data(nullptr), dragging(false) {
-	palette = new ExultRgbCmap;
+	// add this to the list
+	list_next = list_head;
+	list_head = this;
+	palette   = new ExultRgbCmap;
 	for (int i = 0; i < 256; i++) {
 		palette->colors[i] = (palbuf[3 * i] << 16) * 4 + (palbuf[3 * i + 1] << 8) * 4 + palbuf[3 * i + 2] * 4;
 	}
@@ -208,6 +212,15 @@ Shape_draw::Shape_draw(
 Shape_draw::~Shape_draw() {
 	delete palette;
 	delete iwin;
+
+	// Remove this from the linked list
+	for (Shape_draw** list = &list_head; *list; list = &(*list)->list_next) {
+		if (this == *list) {
+			*list     = list_next;
+			list_next = nullptr;
+			break;
+		}
+	}
 }
 
 /*

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -31,6 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "ibuf8.h"
 #include "shapefile.h"
 #include "shapeinf.h"
+#include "shapevga.h"
 #include "u7drag.h"
 #include "vgafile.h"
 
@@ -75,7 +76,7 @@ void Shape_draw::show(
 			// Using GdkPixbuf scaling :
 			const bool zoom_bilinear = ExultStudio::get_instance()->get_shape_bilinear();
 			GdkPixbuf* zoom_pixbuf   = gdk_pixbuf_scale_simple(
-					pixbuf, (w * zoom_scale) / 2, (h * zoom_scale) / 2, (zoom_bilinear ? GDK_INTERP_BILINEAR : GDK_INTERP_NEAREST));
+                    pixbuf, (w * zoom_scale) / 2, (h * zoom_scale) / 2, (zoom_bilinear ? GDK_INTERP_BILINEAR : GDK_INTERP_NEAREST));
 			gdk_cairo_set_source_pixbuf(drawgc, zoom_pixbuf, (x * zoom_scale) / 2, (y * zoom_scale) / 2);
 			cairo_rectangle(drawgc, (x * zoom_scale) / 2, (y * zoom_scale) / 2, (w * zoom_scale) / 2, (h * zoom_scale) / 2);
 			cairo_fill(drawgc);
@@ -95,21 +96,26 @@ void Shape_draw::show(
  *  Draw one shape at a particular place.
  */
 
-void Shape_draw::draw_shape(Shape_frame* shape, int x, int y) {
-	shape->paint(iwin, x + shape->get_xleft(), y + shape->get_yabove());
+void Shape_draw::draw_shape(Shape_frame* shape, int x, int y, bool trans) {
+	if (trans) {
+		const auto& xform = ExultStudio::get_instance()->GetXform();
+		shape->paint_rle_translucent(iwin, x + shape->get_xleft(), y + shape->get_yabove(), xform.data(), xform.size());
+	} else {
+		shape->paint(iwin, x + shape->get_xleft(), y + shape->get_yabove());
+	}
 }
 
 /*
  *  Draw one shape at a particular place.
  */
 
-void Shape_draw::draw_shape(int shapenum, int framenum, int x, int y) {
+void Shape_draw::draw_shape(int shapenum, int framenum, int x, int y, bool trans) {
 	if (shapenum < 0 || shapenum >= ifile->get_num_shapes()) {
 		return;
 	}
 	Shape_frame* shape = ifile->get_shape(shapenum, framenum);
 	if (shape) {
-		draw_shape(shape, x, y);
+		draw_shape(shape, x, y, trans);
 	}
 }
 
@@ -145,7 +151,7 @@ void Shape_draw::draw_shape_outline(
 
 void Shape_draw::draw_shape_centered(
 		int shapenum,    // -1 to not draw shape.
-		int framenum, int& x, int& y) {
+		int framenum, int& x, int& y, bool trans) {
 	// Guard: ensure image buffer is available before using it.
 	if (iwin == nullptr) {
 		return;
@@ -174,7 +180,7 @@ void Shape_draw::draw_shape_centered(
 	} else {
 		x = (ZoomDown(alloc.width) - shape->get_width()) / 2;
 		y = (ZoomDown(alloc.height) - shape->get_height()) / 2;
-		draw_shape(shape, x, y);
+		draw_shape(shape, x, y, trans);
 	}
 }
 
@@ -385,9 +391,9 @@ static inline int extract_value(GtkWidget* widget) {
 
 Shape_single::Shape_single(
 		GtkWidget* shp, GtkWidget* shpnm, bool (*shvalid)(int), GtkWidget* frm, int vgnum, Vga_file* vg,
-		const unsigned char* palbuf, GtkWidget* drw, bool hdd)
+		const unsigned char* palbuf, GtkWidget* drw, bool hdd, Shape_single::Trans_type translucent)
 		: Shape_draw(vg, palbuf, drw), shape(shp), shapename(shpnm), shapevalid(shvalid), frame(frm), vganum(vgnum), hide(hdd),
-		  shape_connect(0), frame_connect(0), draw_connect(0), drop_connect(0), hide_connect(0) {
+		  translucent(translucent), shape_connect(0), frame_connect(0), draw_connect(0), drop_connect(0), hide_connect(0) {
 	if (shape && (GTK_IS_SPIN_BUTTON(shape) || GTK_IS_ENTRY(shape))) {
 		shape_connect = g_signal_connect(G_OBJECT(shape), "changed", G_CALLBACK(Shape_single::on_shape_changed), this);
 	}
@@ -501,9 +507,30 @@ gboolean Shape_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, g
 	if ((shnum == 0) && !(single->shapevalid(0))) {
 		shnum = -1;
 	}
+	bool trans = false;
+	switch (single->translucent) {
+	case Trans_type::Enabled:
+		trans = true;
+		break;
+
+	case Trans_type::shapeinfo: {
+		// Get it frm Shapeinfo
+		if (auto shapesvga = dynamic_cast<Shapes_vga_file*>(single->ifile)) {
+			// set translucent if the shape info wants it
+			const auto shinfo = shapesvga->get_info(shnum);
+			trans             = shinfo.has_translucency();
+		}
+		break;
+	}
+
+	default:
+		trans = false;
+		break;
+	}
+
 	// make sure there is enough space for bbox if needed
 	int x, y;
-	single->draw_shape_centered(shnum, frnum, x, y);
+	single->draw_shape_centered(shnum, frnum, x, y, trans);
 	single->show(ZoomDown(area.x), ZoomDown(area.y), ZoomDown(area.width), ZoomDown(area.height));
 	single->set_graphic_context(nullptr);
 	return true;
@@ -549,13 +576,13 @@ void Shape_single::on_shape_dropped(int filenum, int shapenum, int framenum, gpo
 
 Shape_gump_single::Shape_gump_single(
 		GtkWidget* shp, GtkWidget* shpnm, bool (*shvalid)(int), GtkWidget* frm, int vgnum, Vga_file* vg,
-		const unsigned char* palbuf, GtkWidget* drw, bool hdd)
-		: Shape_single(shp, shpnm, shvalid, frm, vgnum, vg, palbuf, drw, hdd), container_x_widget(nullptr), container_x_connect(0),
-		  container_y_widget(nullptr), container_y_connect(0), container_w_widget(nullptr), container_w_connect(0),
-		  container_h_widget(nullptr), container_h_connect(0), show_container_widget(nullptr), show_container_connect(0),
-		  show_container_altered(0), checkmark_x_widget(nullptr), checkmark_x_connect(0), checkmark_y_widget(nullptr),
-		  checkmark_y_connect(0), checkmark_shape_widget(nullptr), checkmark_shape_connect(0), show_checkmark_widget(nullptr),
-		  show_checkmark_connect(0), show_checkmark_altered(0) {
+		const unsigned char* palbuf, GtkWidget* drw, bool hdd, Trans_type translucent)
+		: Shape_single(shp, shpnm, shvalid, frm, vgnum, vg, palbuf, drw, hdd, translucent), container_x_widget(nullptr),
+		  container_x_connect(0), container_y_widget(nullptr), container_y_connect(0), container_w_widget(nullptr),
+		  container_w_connect(0), container_h_widget(nullptr), container_h_connect(0), show_container_widget(nullptr),
+		  show_container_connect(0), show_container_altered(0), checkmark_x_widget(nullptr), checkmark_x_connect(0),
+		  checkmark_y_widget(nullptr), checkmark_y_connect(0), checkmark_shape_widget(nullptr), checkmark_shape_connect(0),
+		  show_checkmark_widget(nullptr), show_checkmark_connect(0), show_checkmark_altered(0) {
 	if (draw_connect && g_signal_handler_is_connected(G_OBJECT(draw), draw_connect)) {
 		g_signal_handler_disconnect(G_OBJECT(draw), draw_connect);
 		draw_connect = 0;
@@ -688,7 +715,7 @@ gboolean Shape_gump_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cai
 		shnum = -1;
 	}
 	int x, y;
-	single->draw_shape_centered(shnum, frnum, x, y);
+	single->draw_shape_centered(shnum, frnum, x, y, single->translucent == Shape_single::Trans_type::Enabled);
 	if (shnum >= 0 && gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(single->show_checkmark_widget))
 		&& gtk_widget_is_sensitive(GTK_WIDGET(single->show_checkmark_widget))) {
 		const int checkmark_shnum = extract_value(single->checkmark_shape_widget);
@@ -701,7 +728,7 @@ gboolean Shape_gump_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cai
 					   extract_value(single->checkmark_y_widget) + shape->get_height() - 1 - shape->get_ybelow()
 							   - check->get_height() + 1 + check->get_ybelow(),
 					   check->get_width(), check->get_height()};
-			single->draw_shape(check, x + overlay.x, y + overlay.y);
+			single->draw_shape(check, x + overlay.x, y + overlay, single->translucent == Shape_single::Trans_type::Enabled);
 		}
 	}
 	single->show(ZoomDown(area.x), ZoomDown(area.y), ZoomDown(area.width), ZoomDown(area.height));
@@ -743,14 +770,16 @@ gboolean Shape_gump_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cai
 Shape_shape_single::Shape_shape_single(
 		GtkWidget* shp, GtkWidget* shpnm, bool (*shvalid)(int), GtkWidget* frm, int vgnum, Vga_file* vg,
 		const unsigned char* palbuf, GtkWidget* drw, bool hdd)
-		: Shape_single(shp, shpnm, shvalid, frm, vgnum, vg, palbuf, drw, hdd), shape_3d_x_widget(nullptr), shape_3d_x_connect(0),
-		  shape_3d_y_widget(nullptr), shape_3d_y_connect(0), shape_3d_z_widget(nullptr), shape_3d_z_connect(0),
-		  show_shape_3d_widget(nullptr), show_shape_3d_connect(0) {
+		: Shape_single(shp, shpnm, shvalid, frm, vgnum, vg, palbuf, drw, hdd, Shape_single::Trans_type::Disabled),
+		  shape_3d_x_widget(nullptr), shape_3d_x_connect(0), shape_3d_y_widget(nullptr), shape_3d_y_connect(0),
+		  shape_3d_z_widget(nullptr), shape_3d_z_connect(0), show_shape_3d_widget(nullptr), show_shape_3d_connect(0),
+		  shape_trans_connect(0) {
 	auto* studio         = ExultStudio::get_instance();
 	shape_3d_x_widget    = studio->get_widget("shinfo_xtiles");
 	shape_3d_y_widget    = studio->get_widget("shinfo_ytiles");
 	shape_3d_z_widget    = studio->get_widget("shinfo_ztiles");
 	show_shape_3d_widget = studio->get_widget("shinfo_tiles_preview");
+	shape_trans_widget   = studio->get_widget("shinfo_transl_check");
 	shape_3d_x_connect
 			= g_signal_connect(G_OBJECT(shape_3d_x_widget), "changed", G_CALLBACK(Shape_shape_single::on_widget_changed), this);
 	shape_3d_y_connect
@@ -759,6 +788,13 @@ Shape_shape_single::Shape_shape_single(
 			= g_signal_connect(G_OBJECT(shape_3d_z_widget), "changed", G_CALLBACK(Shape_shape_single::on_widget_changed), this);
 	show_shape_3d_connect
 			= g_signal_connect(G_OBJECT(show_shape_3d_widget), "toggled", G_CALLBACK(Shape_shape_single::on_widget_changed), this);
+	if (shape_trans_widget) {
+		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(shape_trans_widget))) {
+			translucent = Shape_single::Trans_type::Enabled;
+		}
+		shape_trans_connect = g_signal_connect(
+				G_OBJECT(shape_trans_widget), "toggled", G_CALLBACK(Shape_shape_single::on_widget_changed), this);
+	}
 }
 
 Shape_shape_single::~Shape_shape_single() {
@@ -778,11 +814,23 @@ Shape_shape_single::~Shape_shape_single() {
 		g_signal_handler_disconnect(G_OBJECT(show_shape_3d_widget), show_shape_3d_connect);
 		show_shape_3d_connect = 0;
 	}
+	if (shape_trans_connect && g_signal_handler_is_connected(G_OBJECT(shape_trans_widget), shape_trans_connect)) {
+		g_signal_handler_disconnect(G_OBJECT(shape_trans_widget), shape_trans_connect);
+		shape_trans_connect = 0;
+	}
 }
 
 void Shape_shape_single::on_widget_changed(GtkWidget* widget, gpointer user_data) {
 	ignore_unused_variable_warning(widget);
 	auto* single = static_cast<Shape_shape_single*>(user_data);
+
+	if (widget && widget == single->shape_trans_widget) {
+		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(single->shape_trans_widget))) {
+			single->translucent = Shape_single::Trans_type::Enabled;
+		} else {
+			single->translucent = Shape_single::Trans_type::Disabled;
+		}
+	}
 	gtk_widget_queue_draw(single->draw);
 }
 
@@ -792,10 +840,10 @@ void Shape_shape_single::on_widget_state(GtkWidget* widget, GtkStateFlags flags,
 	gtk_widget_queue_draw(single->draw);
 }
 
-void Shape_shape_single::draw_shape(Shape_frame* shape, int x, int y) {
+void Shape_shape_single::draw_shape(Shape_frame* shape, int x, int y, bool trans) {
 	if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(show_shape_3d_widget))) {
 		// draw shape
-		Shape_draw::draw_shape(shape, x, y);
+		Shape_draw::draw_shape(shape, x, y, trans);
 		return;
 	}
 
@@ -828,7 +876,7 @@ void Shape_shape_single::draw_shape(Shape_frame* shape, int x, int y) {
 	// If all bbox are zero, no bbox to draw
 	if (!bbox_x && !bbox_y && !bbox_z) {
 		// draw shape
-		Shape_draw::draw_shape(shape, x, y);
+		Shape_draw::draw_shape(shape, x, y, trans);
 		return;
 	}
 
@@ -840,7 +888,7 @@ void Shape_shape_single::draw_shape(Shape_frame* shape, int x, int y) {
 	info.paint_bbox(x + shape->get_xleft(), y + shape->get_yabove(), 0, iwin, outline_color, 2);
 
 	//  draw shape
-	Shape_draw::draw_shape(shape, x, y);
+	Shape_draw::draw_shape(shape, x, y, trans);
 
 	// finally draw front lines
 	info.paint_bbox(x + shape->get_xleft(), y + shape->get_yabove(), 0, iwin, outline_color, 1);
@@ -899,7 +947,7 @@ GdkPixbuf* ExultStudio::shape_image(Vga_file* shpfile, int shnum, int frnum, boo
 		// Using GdkPixbuf scaling :
 		const bool zoom_bilinear = ExultStudio::get_instance()->get_shape_bilinear();
 		GdkPixbuf* zoom_pixbuf   = gdk_pixbuf_scale_simple(
-				pixbuf, (w * zoom_scale) / 2, (h * zoom_scale) / 2, (zoom_bilinear ? GDK_INTERP_BILINEAR : GDK_INTERP_NEAREST));
+                pixbuf, (w * zoom_scale) / 2, (h * zoom_scale) / 2, (zoom_bilinear ? GDK_INTERP_BILINEAR : GDK_INTERP_NEAREST));
 		g_object_unref(pixbuf);
 		pixbuf = zoom_pixbuf;
 	}

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -658,6 +658,7 @@ void Shape_single::on_state_changed(GtkWidget* widget, GtkStateFlags flags, gpoi
 
 gboolean Shape_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, gpointer user_data) {
 	ignore_unused_variable_warning(widget);
+	auto         studio = ExultStudio::get_instance();
 	auto*        single = static_cast<Shape_single*>(user_data);
 	GdkRectangle area   = {0, 0, 0, 0};
 	gdk_cairo_get_clip_rectangle(cairo, &area);
@@ -680,9 +681,10 @@ gboolean Shape_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, g
 	auto  shapesvga = dynamic_cast<Shapes_vga_file*>(single->ifile);
 	auto* shinfo    = shapesvga ? &(shapesvga->get_info(shnum)) : nullptr;
 	switch (single->translucent) {
-	case TA_type::Enabled:
+	case TA_type::Enabled: {
 		trans = true;
 		break;
+	}
 
 	case TA_type::shapeinfo: {
 		// Get it frm Shapeinfo
@@ -693,14 +695,21 @@ gboolean Shape_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, g
 		break;
 	}
 
+	case TA_type::widget: {
+		trans = studio->get_toggle("shinfo_transl_check");
+		break;
+	}
+
 	default:
 		trans = false;
 		break;
 	}
+
 	Animation_info simpleai;
 	int            num_frames = shnum > 0 ? single->ifile->get_num_frames(shnum) : 0;
 	simpleai.set(Animation_info::AniType::FA_LOOPING);
 	auto animinfo = single->aniinf;
+
 	switch (single->animating) {
 	case TA_type::Enabled:
 		if (!animinfo) {
@@ -719,7 +728,11 @@ gboolean Shape_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, g
 				}
 			}
 		}
-		break;
+	case TA_type::widget: {
+		if (!studio->get_toggle("shinfo_animated_check")) {
+			animinfo = nullptr;
+		}
+	} break;
 	}
 
 	default:
@@ -727,6 +740,7 @@ gboolean Shape_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, g
 		;
 		break;
 	}
+
 	if (animinfo) {
 		// makesure animation is emabled if needed
 		if (single->IsAnimatingStopped()) {

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "shapedraw.h"
 
+#include "aniinf.h"
 #include "ibuf8.h"
 #include "shapefile.h"
 #include "shapeinf.h"
@@ -221,6 +222,115 @@ Shape_draw::~Shape_draw() {
 			break;
 		}
 	}
+}
+
+// Get animated frame using an Animation_info object
+
+int Shape_draw::GetAnimInfoFrame(const Animation_info* aniinf, unsigned short first_frame, unsigned short shape_frames) {
+	//
+	// Variables that represent the fields in the Frame_animator class
+	//
+	unsigned short currpos;          // Current position in the animation.
+	unsigned short nframes;          // Number of frames in cycle.
+	unsigned short frame_counter;    // When to increase frame.
+	unsigned short last_frame;       // To check if we need to re init
+
+	//
+	// Code from Frame_animator::Initialize
+	//
+	unsigned short initial = first_frame;
+	last_frame             = first_frame & ~(1 << 5);
+
+	const int cnt = aniinf->get_frame_count();
+	if (cnt < 0) {
+		nframes = shape_frames;
+	} else {
+		nframes = cnt;
+	}
+	if (nframes == shape_frames) {
+		first_frame = 0;
+	} else {
+		first_frame = last_frame - (last_frame % nframes);
+	}
+	// Ensure proper bounds.
+	if (first_frame + nframes >= shape_frames) {
+		nframes = shape_frames - first_frame;
+	}
+	assert(nframes > 0);
+
+	frame_counter = aniinf->get_frame_delay();
+
+	//
+	// Code from Frame_animator::get_next_frame
+	//
+	if (nframes == 1 || IsAnimatingPaused()) {    // No reason to do anything else.
+		return initial;
+	}
+
+	int framenum;
+	switch (aniinf->get_type()) {
+	case Animation_info::FA_HOURLY:
+		// Use 10 real seconds to represent an hour here
+		// An hour in game is 150 secomnds or 2 and a half minutes
+		// That is way too long to reasonably replicate here
+		framenum = ((animation_frame / 100) + initial) % nframes;
+		break;
+
+	case Animation_info::FA_NON_LOOPING:
+		currpos = animation_frame + initial;
+		if (currpos >= nframes) {
+			currpos = nframes - 1;
+		}
+		framenum = first_frame + currpos;
+		break;
+
+	case Animation_info::FA_TIMESYNCHED: {
+		currpos = animation_frame / aniinf->get_frame_delay() + initial;
+		currpos %= nframes;
+		framenum = first_frame + currpos;
+		break;
+	}
+
+	case Animation_info::FA_LOOPING:
+	default: {
+		// No random freeze first here
+		if (aniinf->get_freeze_first_chance() != 0 || initial != 0) {
+			currpos              = animation_frame + initial;
+			const int rec        = aniinf->get_recycle();
+			auto      first_rec  = nframes - rec;
+			int       loop_start = 0;
+			bool      looped     = false;
+			if (rec && currpos > first_rec) {
+				currpos -= first_rec;
+				loop_start = first_rec;
+				looped     = currpos >= rec;
+				currpos %= rec;
+				currpos += first_rec;
+			} else {
+				looped = currpos >= nframes;
+				currpos %= nframes;
+			}
+			// if it has looped and the loop start is zero and it should pause on zero indefinitely
+			// set frame to 0
+			if (looped && loop_start == 0 && aniinf->get_freeze_first_chance() == 0) {
+				framenum = 0;
+
+			} else {
+				framenum = first_frame + currpos;
+			}
+		} else {
+			framenum = initial;
+		}
+		break;
+	}
+
+	case Animation_info::FA_RANDOM_FRAMES:
+		currpos  = rand() % nframes;
+		framenum = first_frame + currpos;
+		break;
+	}
+
+	return framenum;
 }
 
 /*
@@ -587,38 +697,42 @@ gboolean Shape_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, g
 		trans = false;
 		break;
 	}
-	bool anim = false;
+	Animation_info simpleai;
+	int            num_frames = shnum > 0 ? single->ifile->get_num_frames(shnum) : 0;
+	simpleai.set(Animation_info::AniType::FA_LOOPING);
+	auto animinfo = single->aniinf;
 	switch (single->animating) {
 	case TA_type::Enabled:
-		anim = true;
+		if (!animinfo) {
+			animinfo = &simpleai;
+		}
 		break;
 
 	case TA_type::shapeinfo: {
 		// Get it from Shapeinfo
 		// set animating if the shape info wants it
 		if (shinfo) {
-			anim = shinfo->is_animated();
+			if (!animinfo && shinfo->is_animated()) {
+				animinfo = shinfo->get_animation_info();
+				if (!animinfo) {
+					animinfo = &simpleai;
+				}
+			}
 		}
 		break;
 	}
 
 	default:
-		anim = false;
+		animinfo = nullptr;
+		;
 		break;
 	}
-	if (anim) {
+	if (animinfo) {
 		// makesure animation is emabled if needed
 		if (single->IsAnimatingStopped()) {
 			single->PauseAnimating(0);
 		} else {
-			// want animation and animating is enabled so update the frame number
-			int num = single->ifile->get_num_frames(shnum);
-			int af  = single->animation_frame;
-			// avoid overflow if af is near to INT_MAX
-			if (af > num) {
-				af -= num;
-			}
-			frnum = (frnum + af) % num;
+			frnum = single->GetAnimInfoFrame(animinfo, frnum, num_frames);
 		}
 	}
 
@@ -883,7 +997,9 @@ Shape_shape_single::Shape_shape_single(
 		const unsigned char* palbuf, GtkWidget* drw, bool hdd)
 		: Shape_single(
 				  shp, shpnm, shvalid, frm, vgnum, vg, palbuf, drw, hdd, Shape_single::TA_type::Disabled,
-				  Shape_single::TA_type::Disabled) {}
+				  Shape_single::TA_type::Disabled) {
+	setup_aniinf();
+}
 
 Shape_shape_single::~Shape_shape_single() {}
 
@@ -913,6 +1029,8 @@ void Shape_shape_single::on_widget_changed(GtkWidget* widget, gpointer user_data
 			single->translucent = Shape_single::TA_type::Disabled;
 		}
 	}
+	single->setup_aniinf();
+
 	gtk_widget_queue_draw(single->draw);
 }
 
@@ -920,6 +1038,56 @@ void Shape_shape_single::on_widget_state(GtkWidget* widget, GtkStateFlags flags,
 	ignore_unused_variable_warning(widget, flags);
 	auto* single = static_cast<Shape_shape_single*>(user_data);
 	gtk_widget_queue_draw(single->draw);
+}
+
+void Shape_shape_single::setup_aniinf() {
+	if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(shape_animated.widget))) {
+		animating = Shape_single::TA_type::Disabled;
+		PauseAnimating();
+		aniinf = nullptr;
+	} else {
+		animating = Shape_single::TA_type::Enabled;
+		PauseAnimating(CHANGE_ANIM_PAUSE_FRAMES);
+		if (!up_aniinf) {
+			up_aniinf = std::make_unique<Animation_info>();
+		}
+		aniinf = up_aniinf.get();
+		if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(shinfo_animation_check.widget))) {
+			// shinfo_animation_check isn't checked, the widget values are in an unspecified state
+			// and should not be used. use a generic looping aniinf
+			up_aniinf->set(Animation_info::FA_LOOPING);
+			return;
+		}
+
+		auto type = static_cast<Animation_info::AniType>(gtk_combo_box_get_active(GTK_COMBO_BOX(shinfo_animation_type.widget)));
+		up_aniinf->set_type(type);
+		const int count   = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(shinfo_animation_frcount.widget));
+		int       shnum   = extract_value(shape);
+		const int nframes = ifile->get_num_frames(shnum);
+		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(shinfo_animation_frtype.widget)) || count == nframes) {
+			up_aniinf->set_frame_count(-1);
+		} else {
+			up_aniinf->set_frame_count(count);
+		}
+		if (type != Animation_info::FA_NON_LOOPING) {
+			up_aniinf->set_frame_delay(gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(shinfo_animation_ticks.widget)));
+			if (type == Animation_info::FA_LOOPING) {
+				const int menu   = gtk_combo_box_get_active(GTK_COMBO_BOX(shinfo_animation_freezefirst.widget));
+				const int chance = menu == 0 ? 100
+											 : (menu == 1 ? 0
+														  : gtk_spin_button_get_value_as_int(
+																	GTK_SPIN_BUTTON(shinfo_animation_freezechance.widget)));
+				up_aniinf->set_freeze_first_chance(chance);
+				int rec;
+				if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(shinfo_animation_rectype.widget))) {
+					rec = nframes;
+				} else {
+					rec = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(shinfo_animation_recycle.widget));
+				}
+				up_aniinf->set_recycle(rec == nframes ? 0 : rec);
+			}
+		}
+	}
 }
 
 void Shape_shape_single::draw_shape(Shape_frame* shape, int x, int y, bool trans) {

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -333,7 +333,7 @@ int Shape_draw::GetAnimInfoFrame(
 		if (framenum == first_frame && freeze_chance > 0 && pausable && !IsAnimatingPaused()) {
 			int pause_counter = 0;
 
-			while (rng() % 100 >= freeze_chance) {
+			while (rng() % 100 >= unsigned(freeze_chance)) {
 				++pause_counter;
 			}
 

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -240,6 +240,25 @@ void Shape_draw::set_background_color(guint32 c) {
 	render();
 }
 
+void Shape_draw::animate() {
+	if (animating_paused > 0) {
+		if (animating_paused != INT_MAX) {
+			animating_paused--;
+		}
+	} else {
+		if (animation_frame == INT_MAX) {
+			// No integer wrap around to INT_MIN allowed
+			// Not likely to happen as it would take 6 years of continuous running but best to do things right
+			// resetting back to 0 may cause a discontinuity but that is better than who knows what happens if it goes negative
+			animation_frame = 0;
+		} else {
+			animation_frame++;
+		}
+		// animating_frame has changed so queue a draw by calling rander
+		render();
+	}
+}
+
 /*
  *  Configure the viewing window.
  */
@@ -404,9 +423,10 @@ static inline int extract_value(GtkWidget* widget) {
 
 Shape_single::Shape_single(
 		GtkWidget* shp, GtkWidget* shpnm, bool (*shvalid)(int), GtkWidget* frm, int vgnum, Vga_file* vg,
-		const unsigned char* palbuf, GtkWidget* drw, bool hdd, Shape_single::Trans_type translucent)
+		const unsigned char* palbuf, GtkWidget* drw, bool hdd, Shape_single::TA_type translucent, TA_type animating)
 		: Shape_draw(vg, palbuf, drw), shape(shp), shapename(shpnm), shapevalid(shvalid), frame(frm), vganum(vgnum), hide(hdd),
-		  translucent(translucent), shape_connect(0), frame_connect(0), draw_connect(0), drop_connect(0), hide_connect(0) {
+		  translucent(translucent), animating(animating), shape_connect(0), frame_connect(0), draw_connect(0), drop_connect(0),
+		  hide_connect(0) {
 	if (shape && (GTK_IS_SPIN_BUTTON(shape) || GTK_IS_ENTRY(shape))) {
 		shape_connect = g_signal_connect(G_OBJECT(shape), "changed", G_CALLBACK(Shape_single::on_shape_changed), this);
 	}
@@ -473,6 +493,10 @@ void Shape_single::on_shape_changed(GtkWidget* widget, gpointer user_data) {
 			gtk_widget_set_visible(single->draw, false);
 		}
 	}
+	// pause animating on a change
+	if (!single->IsAnimatingStopped()) {
+		single->PauseAnimating(CHANGE_ANIM_PAUSE_FRAMES);
+	}
 	single->render();
 }
 
@@ -486,6 +510,12 @@ void Shape_single::on_frame_changed(GtkWidget* widget, gpointer user_data) {
 			gtk_widget_set_visible(single->draw, false);
 		}
 	}
+
+	// pause animating on a change
+	if (!single->IsAnimatingStopped()) {
+		single->PauseAnimating(CHANGE_ANIM_PAUSE_FRAMES);
+	}
+
 	single->render();
 }
 
@@ -520,18 +550,19 @@ gboolean Shape_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, g
 	if ((shnum == 0) && !(single->shapevalid(0))) {
 		shnum = -1;
 	}
-	bool trans = false;
+	bool  trans     = false;
+	auto  shapesvga = dynamic_cast<Shapes_vga_file*>(single->ifile);
+	auto* shinfo    = shapesvga ? &(shapesvga->get_info(shnum)) : nullptr;
 	switch (single->translucent) {
-	case Trans_type::Enabled:
+	case TA_type::Enabled:
 		trans = true;
 		break;
 
-	case Trans_type::shapeinfo: {
+	case TA_type::shapeinfo: {
 		// Get it frm Shapeinfo
-		if (auto shapesvga = dynamic_cast<Shapes_vga_file*>(single->ifile)) {
-			// set translucent if the shape info wants it
-			const auto shinfo = shapesvga->get_info(shnum);
-			trans             = shinfo.has_translucency();
+		// set translucent if the shape info wants it
+		if (shinfo) {
+			trans = shinfo->has_translucency();
 		}
 		break;
 	}
@@ -539,6 +570,40 @@ gboolean Shape_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, g
 	default:
 		trans = false;
 		break;
+	}
+	bool anim = false;
+	switch (single->animating) {
+	case TA_type::Enabled:
+		anim = true;
+		break;
+
+	case TA_type::shapeinfo: {
+		// Get it from Shapeinfo
+		// set animating if the shape info wants it
+		if (shinfo) {
+			anim = shinfo->is_animated();
+		}
+		break;
+	}
+
+	default:
+		anim = false;
+		break;
+	}
+	if (anim) {
+		// makesure animation is emabled if needed
+		if (single->IsAnimatingStopped()) {
+			single->PauseAnimating(0);
+		} else {
+			// want animation and animating is enabled so update the frame number
+			int num = single->ifile->get_num_frames(shnum);
+			int af  = single->animation_frame;
+			// avoid overflow if af is near to INT_MAX
+			if (af > num) {
+				af -= num;
+			}
+			frnum = (frnum + af) % num;
+		}
 	}
 
 	// make sure there is enough space for bbox if needed
@@ -589,7 +654,7 @@ void Shape_single::on_shape_dropped(int filenum, int shapenum, int framenum, gpo
 
 Shape_gump_single::Shape_gump_single(
 		GtkWidget* shp, GtkWidget* shpnm, bool (*shvalid)(int), GtkWidget* frm, int vgnum, Vga_file* vg,
-		const unsigned char* palbuf, GtkWidget* drw, bool hdd, Trans_type translucent)
+		const unsigned char* palbuf, GtkWidget* drw, bool hdd, TA_type translucent)
 		: Shape_single(shp, shpnm, shvalid, frm, vgnum, vg, palbuf, drw, hdd, translucent), container_x_widget(nullptr),
 		  container_x_connect(0), container_y_widget(nullptr), container_y_connect(0), container_w_widget(nullptr),
 		  container_w_connect(0), container_h_widget(nullptr), container_h_connect(0), show_container_widget(nullptr),
@@ -633,6 +698,22 @@ Shape_gump_single::Shape_gump_single(
 			= g_signal_connect(G_OBJECT(show_checkmark_widget), "toggled", G_CALLBACK(Shape_gump_single::on_widget_changed), this);
 	show_checkmark_altered = g_signal_connect(
 			G_OBJECT(show_checkmark_widget), "state-flags-changed", G_CALLBACK(Shape_gump_single::on_widget_state), this);
+}
+
+Shape_single::WidgetChangedConnect::WidgetChangedConnect(
+		const char* name, const char* signal, void (*on_widget_changed)(GtkWidget* widget, gpointer user_data),
+		gpointer user_data) {
+	widget = ExultStudio::get_instance()->get_widget(name);
+	if (widget) {
+		connect = g_signal_connect(G_OBJECT(widget), signal, G_CALLBACK(on_widget_changed), user_data);
+	}
+}
+
+Shape_single::WidgetChangedConnect::~WidgetChangedConnect() {
+	if (connect) {
+		g_signal_handler_disconnect(G_OBJECT(widget), connect);
+		connect = 0;
+	}
 }
 
 Shape_gump_single::~Shape_gump_single() {
@@ -685,6 +766,7 @@ Shape_gump_single::~Shape_gump_single() {
 void Shape_gump_single::on_widget_changed(GtkWidget* widget, gpointer user_data) {
 	ignore_unused_variable_warning(widget);
 	auto* single = static_cast<Shape_gump_single*>(user_data);
+
 	gtk_widget_queue_draw(single->draw);
 }
 
@@ -728,7 +810,7 @@ gboolean Shape_gump_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cai
 		shnum = -1;
 	}
 	int x, y;
-	single->draw_shape_centered(shnum, frnum, x, y, single->translucent == Shape_single::Trans_type::Enabled);
+	single->draw_shape_centered(shnum, frnum, x, y, single->translucent == Shape_single::TA_type::Enabled);
 	if (shnum >= 0 && gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(single->show_checkmark_widget))
 		&& gtk_widget_is_sensitive(GTK_WIDGET(single->show_checkmark_widget))) {
 		const int checkmark_shnum = extract_value(single->checkmark_shape_widget);
@@ -741,7 +823,7 @@ gboolean Shape_gump_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cai
 					   extract_value(single->checkmark_y_widget) + shape->get_height() - 1 - shape->get_ybelow()
 							   - check->get_height() + 1 + check->get_ybelow(),
 					   check->get_width(), check->get_height()};
-			single->draw_shape(check, x + overlay.x, y + overlay, single->translucent == Shape_single::Trans_type::Enabled);
+			single->draw_shape(check, x + overlay.x, y + overlay, single->translucent == Shape_single::TA_type::Enabled);
 		}
 	}
 	single->show(ZoomDown(area.x), ZoomDown(area.y), ZoomDown(area.width), ZoomDown(area.height));
@@ -783,65 +865,36 @@ gboolean Shape_gump_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cai
 Shape_shape_single::Shape_shape_single(
 		GtkWidget* shp, GtkWidget* shpnm, bool (*shvalid)(int), GtkWidget* frm, int vgnum, Vga_file* vg,
 		const unsigned char* palbuf, GtkWidget* drw, bool hdd)
-		: Shape_single(shp, shpnm, shvalid, frm, vgnum, vg, palbuf, drw, hdd, Shape_single::Trans_type::Disabled),
-		  shape_3d_x_widget(nullptr), shape_3d_x_connect(0), shape_3d_y_widget(nullptr), shape_3d_y_connect(0),
-		  shape_3d_z_widget(nullptr), shape_3d_z_connect(0), show_shape_3d_widget(nullptr), show_shape_3d_connect(0),
-		  shape_trans_connect(0) {
-	auto* studio         = ExultStudio::get_instance();
-	shape_3d_x_widget    = studio->get_widget("shinfo_xtiles");
-	shape_3d_y_widget    = studio->get_widget("shinfo_ytiles");
-	shape_3d_z_widget    = studio->get_widget("shinfo_ztiles");
-	show_shape_3d_widget = studio->get_widget("shinfo_tiles_preview");
-	shape_trans_widget   = studio->get_widget("shinfo_transl_check");
-	shape_3d_x_connect
-			= g_signal_connect(G_OBJECT(shape_3d_x_widget), "changed", G_CALLBACK(Shape_shape_single::on_widget_changed), this);
-	shape_3d_y_connect
-			= g_signal_connect(G_OBJECT(shape_3d_y_widget), "changed", G_CALLBACK(Shape_shape_single::on_widget_changed), this);
-	shape_3d_z_connect
-			= g_signal_connect(G_OBJECT(shape_3d_z_widget), "changed", G_CALLBACK(Shape_shape_single::on_widget_changed), this);
-	show_shape_3d_connect
-			= g_signal_connect(G_OBJECT(show_shape_3d_widget), "toggled", G_CALLBACK(Shape_shape_single::on_widget_changed), this);
-	if (shape_trans_widget) {
-		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(shape_trans_widget))) {
-			translucent = Shape_single::Trans_type::Enabled;
-		}
-		shape_trans_connect = g_signal_connect(
-				G_OBJECT(shape_trans_widget), "toggled", G_CALLBACK(Shape_shape_single::on_widget_changed), this);
-	}
-}
+		: Shape_single(
+				  shp, shpnm, shvalid, frm, vgnum, vg, palbuf, drw, hdd, Shape_single::TA_type::Disabled,
+				  Shape_single::TA_type::Disabled) {}
 
-Shape_shape_single::~Shape_shape_single() {
-	if (shape_3d_x_connect && g_signal_handler_is_connected(G_OBJECT(shape_3d_x_widget), shape_3d_x_connect)) {
-		g_signal_handler_disconnect(G_OBJECT(shape_3d_x_widget), shape_3d_x_connect);
-		shape_3d_x_connect = 0;
-	}
-	if (shape_3d_y_connect && g_signal_handler_is_connected(G_OBJECT(shape_3d_y_widget), shape_3d_y_connect)) {
-		g_signal_handler_disconnect(G_OBJECT(shape_3d_y_widget), shape_3d_y_connect);
-		shape_3d_y_connect = 0;
-	}
-	if (shape_3d_z_connect && g_signal_handler_is_connected(G_OBJECT(shape_3d_z_widget), shape_3d_z_connect)) {
-		g_signal_handler_disconnect(G_OBJECT(shape_3d_z_widget), shape_3d_z_connect);
-		shape_3d_z_connect = 0;
-	}
-	if (show_shape_3d_connect && g_signal_handler_is_connected(G_OBJECT(show_shape_3d_widget), show_shape_3d_connect)) {
-		g_signal_handler_disconnect(G_OBJECT(show_shape_3d_widget), show_shape_3d_connect);
-		show_shape_3d_connect = 0;
-	}
-	if (shape_trans_connect && g_signal_handler_is_connected(G_OBJECT(shape_trans_widget), shape_trans_connect)) {
-		g_signal_handler_disconnect(G_OBJECT(shape_trans_widget), shape_trans_connect);
-		shape_trans_connect = 0;
-	}
-}
+Shape_shape_single::~Shape_shape_single() {}
 
 void Shape_shape_single::on_widget_changed(GtkWidget* widget, gpointer user_data) {
 	ignore_unused_variable_warning(widget);
 	auto* single = static_cast<Shape_shape_single*>(user_data);
 
-	if (widget && widget == single->shape_trans_widget) {
-		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(single->shape_trans_widget))) {
-			single->translucent = Shape_single::Trans_type::Enabled;
+	if (widget && widget == single->shape_animated.widget) {
+		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(single->shape_animated.widget))) {
+			single->animating = Shape_single::TA_type::Enabled;
+			single->PauseAnimating(0);
 		} else {
-			single->translucent = Shape_single::Trans_type::Disabled;
+			single->animating = Shape_single::TA_type::Disabled;
+			single->PauseAnimating();
+		}
+	} else {
+		// if any other widget changed pause animating
+		if (!single->IsAnimatingStopped()) {
+			single->PauseAnimating(CHANGE_ANIM_PAUSE_FRAMES);
+		}
+	}
+
+	if (widget && widget == single->shape_trans.widget) {
+		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(single->shape_trans.widget))) {
+			single->translucent = Shape_single::TA_type::Enabled;
+		} else {
+			single->translucent = Shape_single::TA_type::Disabled;
 		}
 	}
 	gtk_widget_queue_draw(single->draw);
@@ -854,15 +907,15 @@ void Shape_shape_single::on_widget_state(GtkWidget* widget, GtkStateFlags flags,
 }
 
 void Shape_shape_single::draw_shape(Shape_frame* shape, int x, int y, bool trans) {
-	if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(show_shape_3d_widget))) {
+	if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(show_shape_3d.widget))) {
 		// draw shape
 		Shape_draw::draw_shape(shape, x, y, trans);
 		return;
 	}
 
-	int bbox_x = extract_value(shape_3d_x_widget);
-	int bbox_y = extract_value(shape_3d_y_widget);
-	int bbox_z = extract_value(shape_3d_z_widget);
+	int bbox_x = extract_value(shape_3d_x.widget);
+	int bbox_y = extract_value(shape_3d_y.widget);
+	int bbox_z = extract_value(shape_3d_z.widget);
 	int minx   = bbox_x * c_tilesize + bbox_z * c_tilesize / 2 + 1 - shape->get_xleft();
 	int miny   = bbox_y * c_tilesize + bbox_z * c_tilesize / 2 + 1 - shape->get_yabove();
 

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -36,6 +36,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "u7drag.h"
 #include "vgafile.h"
 
+#include <random>
+
 using std::cout;
 using std::endl;
 
@@ -271,6 +273,8 @@ int Shape_draw::GetAnimInfoFrame(
 		return initial;
 	}
 
+	static std::default_random_engine rng;
+
 	int framenum;
 	switch (aniinf->get_type()) {
 	case Animation_info::FA_HOURLY:
@@ -329,7 +333,7 @@ int Shape_draw::GetAnimInfoFrame(
 		if (framenum == first_frame && freeze_chance > 0 && pausable && !IsAnimatingPaused()) {
 			int pause_counter = 0;
 
-			while (rand() % 100 >= freeze_chance) {
+			while (rng() % 100 >= freeze_chance) {
 				++pause_counter;
 			}
 
@@ -340,7 +344,7 @@ int Shape_draw::GetAnimInfoFrame(
 	} break;
 
 	case Animation_info::FA_RANDOM_FRAMES:
-		currpos  = rand() % nframes;
+		currpos  = rng() % nframes;
 		framenum = first_frame + currpos;
 		break;
 	}

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -226,7 +226,8 @@ Shape_draw::~Shape_draw() {
 
 // Get animated frame using an Animation_info object
 
-int Shape_draw::GetAnimInfoFrame(const Animation_info* aniinf, unsigned short first_frame, unsigned short shape_frames) {
+int Shape_draw::GetAnimInfoFrame(
+		const Animation_info* aniinf, unsigned short first_frame, unsigned short shape_frames, bool pausable) {
 	if (!ExultStudio::IsShapeAnimationEnabled()) {
 		return first_frame;
 	}
@@ -266,7 +267,7 @@ int Shape_draw::GetAnimInfoFrame(const Animation_info* aniinf, unsigned short fi
 	//
 	// Code from Frame_animator::get_next_frame
 	//
-	if (nframes == 1 || IsAnimatingPaused()) {    // No reason to do anything else.
+	if (nframes == 1) {
 		return initial;
 	}
 
@@ -296,8 +297,8 @@ int Shape_draw::GetAnimInfoFrame(const Animation_info* aniinf, unsigned short fi
 
 	case Animation_info::FA_LOOPING:
 	default: {
-		// No random freeze first here
-		if (aniinf->get_freeze_first_chance() != 0 || initial != 0) {
+		int freeze_chance = aniinf->get_freeze_first_chance();
+		if (freeze_chance != 0 || initial != 0) {
 			currpos              = animation_frame + initial;
 			const int rec        = aniinf->get_recycle();
 			auto      first_rec  = nframes - rec;
@@ -324,8 +325,19 @@ int Shape_draw::GetAnimInfoFrame(const Animation_info* aniinf, unsigned short fi
 		} else {
 			framenum = initial;
 		}
-		break;
-	}
+		// random freeze on first frame
+		if (framenum == first_frame && freeze_chance > 0 && pausable && !IsAnimatingPaused()) {
+			int pause_counter = 0;
+
+			while (rand() % 100 >= freeze_chance) {
+				++pause_counter;
+			}
+
+			if (pause_counter) {
+				PauseAnimating(pause_counter + 1, false);
+			}
+		}
+	} break;
 
 	case Animation_info::FA_RANDOM_FRAMES:
 		currpos  = rand() % nframes;
@@ -374,7 +386,9 @@ void Shape_draw::animate() {
 		if (animating_paused != INT_MAX) {
 			animating_paused--;
 		}
-	} else {
+	}
+	// If animation pausing just ended increment the frame now too
+	if (animating_paused == 0) {
 		if (animation_frame == INT_MAX) {
 			// No integer wrap around to INT_MIN allowed
 			// Not likely to happen as it would take 6 years of continuous running but best to do things right
@@ -383,7 +397,7 @@ void Shape_draw::animate() {
 		} else {
 			animation_frame++;
 		}
-		// animating_frame has changed so queue a draw by calling rander
+		// animating_frame has changed so do a render
 		render();
 	}
 }
@@ -752,7 +766,7 @@ gboolean Shape_single::on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, g
 			if (single->IsAnimatingStopped()) {
 				single->PauseAnimating(0);
 			} else {
-				frnum = single->GetAnimInfoFrame(animinfo, frnum, num_frames);
+				frnum = single->GetAnimInfoFrame(animinfo, frnum, num_frames, true);
 			}
 		}
 	}

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -240,6 +240,22 @@ void Shape_draw::set_background_color(guint32 c) {
 	render();
 }
 
+void Shape_draw::update_palette(const unsigned char* palbuf, unsigned start, unsigned count) {
+	auto end = start + count;
+	if (end > 256 || !palbuf) {
+		return;
+	}
+	bool changed = false;
+	for (unsigned i = start; i < end; i++) {
+		guint32 c = (palbuf[3 * i] << 16) * 4 + (palbuf[3 * i + 1] << 8) * 4 + palbuf[3 * i + 2] * 4;
+		changed |= palette->colors[i] != c;
+		palette->colors[i] = c;
+	}
+	if (changed) {
+		render();
+	}
+}
+
 void Shape_draw::animate() {
 	if (animating_paused > 0) {
 		if (animating_paused != INT_MAX) {

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -238,7 +238,6 @@ int Shape_draw::GetAnimInfoFrame(
 	//
 	unsigned short currpos;          // Current position in the animation.
 	unsigned short nframes;          // Number of frames in cycle.
-	unsigned short frame_counter;    // When to increase frame.
 	unsigned short last_frame;       // To check if we need to re init
 
 	//
@@ -264,7 +263,6 @@ int Shape_draw::GetAnimInfoFrame(
 	}
 	assert(nframes > 0);
 
-	frame_counter = aniinf->get_frame_delay();
 
 	//
 	// Code from Frame_animator::get_next_frame

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -980,7 +980,7 @@ void Shape_shape_single::draw_shape(Shape_frame* shape, int x, int y, bool trans
  *  Build an Image out of a Shape
  */
 
-GdkPixbuf* ExultStudio::shape_image(Vga_file* shpfile, int shnum, int frnum, bool transparent) {
+GdkPixbuf* ExultStudio::shape_image(Vga_file* shpfile, int shnum, int frnum, bool transparent, bool translucent) {
 	if (shnum < 0) {
 		return nullptr;
 	}
@@ -1002,7 +1002,11 @@ GdkPixbuf* ExultStudio::shape_image(Vga_file* shpfile, int shnum, int frnum, boo
 	Image_buffer8 tbuf(w, h);    // Create buffer to render to.
 	tbuf.fill8(0xff);            // Fill with 'transparent' pixel.
 	unsigned char* tbits = tbuf.get_bits();
-	shape->paint(&tbuf, w - 1 - xright, h - 1 - ybelow);
+	if (!translucent) {
+		shape->paint(&tbuf, w - 1 - xright, h - 1 - ybelow);
+	} else {
+		shape->paint_rle_translucent(&tbuf, w - 1 - xright, h - 1 - ybelow, xforms.data(), xforms.size());
+	}
 	// Put shape on a pixmap.
 	GdkPixbuf* pixbuf  = gdk_pixbuf_new(GDK_COLORSPACE_RGB, transparent, 8, w, h);
 	guchar*    pixels  = gdk_pixbuf_get_pixels(pixbuf);

--- a/mapedit/shapedraw.h
+++ b/mapedit/shapedraw.h
@@ -196,6 +196,7 @@ public:
 		Disabled  = 0,
 		Enabled   = 1,
 		shapeinfo = 2,    // For a shape from Shapes.vgs, use shapeinfo to determine things
+		widget    = 3,    // use the checkbox from the shapeinfo widget
 	};
 
 	struct WidgetChangedConnect {

--- a/mapedit/shapedraw.h
+++ b/mapedit/shapedraw.h
@@ -49,6 +49,11 @@ protected:
 	void*          drop_user_data;
 	bool           dragging;    // Dragging from here.
 
+	int animation_frame = 0;    // Current animation frame
+
+	int animating_paused = INT_MAX;    // Number of frames to pause animating for, While this is >0 animating_frame wont increment.
+									   // If this is INT_MAX animating is disabled
+
 private:
 	// Linked List Pointers
 
@@ -100,6 +105,28 @@ public:
 		}
 	} iteratable;
 
+	// Call with timeout <= 0 to unpause animating
+	// Call with timeout = INT_MAX to stop animating until explicitly unpaused
+	// Call with other timeout values to temporarily to pause for the specified number of frames with the animation automatically
+	// unpausing
+	void PauseAnimating(int timeout = INT_MAX, bool reset_frame = true) {
+		if (timeout < 0) {
+			timeout = 0;
+		}
+		animating_paused = timeout;
+		if (reset_frame) {
+			animation_frame = 0;
+		}
+	}
+
+	bool IsAnimatingPaused() {
+		return animating_paused > 0;
+	}
+
+	bool IsAnimatingStopped() {
+		return animating_paused == INT_MAX;
+	}
+
 	static const int outline_color = 249;    // Palette index of outline color
 
 	Shape_draw(Vga_file* i, const unsigned char* palbuf, GtkWidget* drw);
@@ -133,8 +160,8 @@ public:
 	void         draw_shape_centered(int shapenum, int framenum, int& x, int& y, bool trans = false);
 	virtual void render();    // Update what gets shown.
 	void         set_background_color(guint32 c);
-
-	void configure();    // Configure when created/resized.
+	virtual void animate();
+	void         configure();    // Configure when created/resized.
 	// Handler for drop.
 	static void drag_data_received(
 			GtkWidget* widget, GdkDragContext* context, gint x, gint y, GtkSelectionData* seldata, guint info, guint time,
@@ -160,10 +187,19 @@ class Shape_gump_single;
 
 class Shape_single : public Shape_draw {
 public:
-	enum class Trans_type {
+	enum class TA_type {
 		Disabled  = 0,
 		Enabled   = 1,
 		shapeinfo = 2,    // For a shape from Shapes.vgs, use shapeinfo to determine things
+	};
+
+	struct WidgetChangedConnect {
+		GtkWidget* widget  = nullptr;
+		gulong     connect = 0;
+		WidgetChangedConnect(
+				const char* name, const char* signal, void (*on_widget_changed)(GtkWidget* widget, gpointer user_data),
+				gpointer user_data);
+		~WidgetChangedConnect();
 	};
 
 protected:
@@ -173,7 +209,8 @@ protected:
 	GtkWidget* frame;             // The FrameID   holding GtkWidget: GtkSpinButton / GtkEntry.
 	int        vganum;            // For a Drag and Drop enabled Shape_single :
 	bool       hide;              // Whether the Shape should be hidden.
-	Trans_type translucent;       // How translucent drawing should be handled
+	TA_type    translucent;       // How translucent drawing should be handled
+	TA_type    animating;         // How shape animation should be handled
 	gulong     shape_connect;     // The Shape Widget g_signal_connect changed ID
 	gulong     frame_connect;     // The Frame Widget g_signal_connect changed ID
 	gulong     draw_connect;      // The Draw  Widget g_signal_connect draw ID
@@ -182,18 +219,21 @@ protected:
 
 public:
 	Shape_single(
-			GtkWidget* shp,                                     // The ShapeID   holding GtkWidget.
-			GtkWidget* shpnm,                                   // The ShapeName holding GtkWidget.
-			bool (*shvld)(int),                                 // The ShapeUD   validating lambda.
-			GtkWidget*           frm,                           // The FrameID   holding GtkWidget.
-			int                  vgnum,                         // The D&D U7_SHAPE_xxx VGA file category.
-			Vga_file*            vg,                            // The VGA File for the Shape_draw ctor.
-			const unsigned char* palbuf,                        // The Palette for the Shape_draw ctor.
-			GtkWidget*           drw,                           // The GtkDrawingArea for the Shape_draw ctor.
-			bool                 hdd = false,                   // Whether the Shape should be hidden.
-			Trans_type translucent   = Trans_type::shapeinfo    // How translucent drawing should be handled, defaults to shapeinfo
+			GtkWidget* shp,                                   // The ShapeID   holding GtkWidget.
+			GtkWidget* shpnm,                                 // The ShapeName holding GtkWidget.
+			bool (*shvld)(int),                               // The ShapeUD   validating lambda.
+			GtkWidget*           frm,                         // The FrameID   holding GtkWidget.
+			int                  vgnum,                       // The D&D U7_SHAPE_xxx VGA file category.
+			Vga_file*            vg,                          // The VGA File for the Shape_draw ctor.
+			const unsigned char* palbuf,                      // The Palette for the Shape_draw ctor.
+			GtkWidget*           drw,                         // The GtkDrawingArea for the Shape_draw ctor.
+			bool                 hdd = false,                 // Whether the Shape should be hidden.
+			TA_type translucent      = TA_type::shapeinfo,    // How translucent drawing should be handled, defaults to shapeinfo
+			TA_type animating        = TA_type::shapeinfo     // How shape animation should be handled, defaults to shapeinfo
 
 	);
+	constexpr static int CHANGE_ANIM_PAUSE_FRAMES = 20;
+
 	~Shape_single() override;
 	static void     on_shape_changed(GtkWidget* widget, gpointer user_data);
 	static void     on_frame_changed(GtkWidget* widget, gpointer user_data);
@@ -251,7 +291,7 @@ public:
 			const unsigned char* palbuf,    // The Palette for the Shape_draw ctor.
 			GtkWidget*           drw,       // The GtkDrawingArea for the Shape_draw ctor.
 			bool                 hdd         = false,
-			Trans_type           translucent = Trans_type::Disabled);    // Whether the Shape should be hidden.
+			TA_type              translucent = TA_type::Disabled);    // Whether the Shape should be hidden.
 	~Shape_gump_single() override;
 	static gboolean on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, gpointer user_data);
 
@@ -272,16 +312,12 @@ public:
 
 class Shape_shape_single : public Shape_single {
 protected:
-	GtkWidget* shape_3d_x_widget;
-	gulong     shape_3d_x_connect;
-	GtkWidget* shape_3d_y_widget;
-	gulong     shape_3d_y_connect;
-	GtkWidget* shape_3d_z_widget;
-	gulong     shape_3d_z_connect;
-	GtkWidget* show_shape_3d_widget;
-	gulong     show_shape_3d_connect;
-	GtkWidget* shape_trans_widget;
-	gulong     shape_trans_connect;
+	WidgetChangedConnect shape_3d_x     = {"shinfo_xtiles", "changed", on_widget_changed, this};
+	WidgetChangedConnect shape_3d_y     = {"shinfo_ytiles", "changed", on_widget_changed, this};
+	WidgetChangedConnect shape_3d_z     = {"shinfo_ztiles", "changed", on_widget_changed, this};
+	WidgetChangedConnect show_shape_3d  = {"shinfo_tiles_preview", "toggled", on_widget_changed, this};
+	WidgetChangedConnect shape_trans    = {"shinfo_transl_check", "toggled", on_widget_changed, this};
+	WidgetChangedConnect shape_animated = {"shinfo_animated_check", "toggled", on_widget_changed, this};
 
 public:
 	Shape_shape_single(

--- a/mapedit/shapedraw.h
+++ b/mapedit/shapedraw.h
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 class Vga_file;
 class Shape_frame;
 class Image_buffer8;
+class Animation_info;
 
 using Drop_callback = void (*)(int filenum, int shapenum, int framenum, void* udata);
 
@@ -119,6 +120,8 @@ public:
 		}
 	}
 
+	constexpr static int CHANGE_ANIM_PAUSE_FRAMES = 20;
+
 	bool IsAnimatingPaused() {
 		return animating_paused > 0;
 	}
@@ -129,6 +132,7 @@ public:
 
 	static const int outline_color = 50;    // Palette index of outline color
 
+	int GetAnimInfoFrame(const Animation_info* aniinfm, unsigned short first_frame, unsigned short nframes);
 	Shape_draw(Vga_file* i, const unsigned char* palbuf, GtkWidget* drw);
 	virtual ~Shape_draw();
 
@@ -207,16 +211,17 @@ protected:
 	GtkWidget* shape;             // The ShapeID   holding GtkWidget: GtkSpinButton / GtkEntry, or GtkFrame ( NPCEditor NPC Face ).
 	GtkWidget* shapename;         // The ShapeName holding GtkLabel.
 	bool (*shapevalid)(int s);    // The ShapeID   validating lambda.
-	GtkWidget* frame;             // The FrameID   holding GtkWidget: GtkSpinButton / GtkEntry.
-	int        vganum;            // For a Drag and Drop enabled Shape_single :
-	bool       hide;              // Whether the Shape should be hidden.
-	TA_type    translucent;       // How translucent drawing should be handled
-	TA_type    animating;         // How shape animation should be handled
-	gulong     shape_connect;     // The Shape Widget g_signal_connect changed ID
-	gulong     frame_connect;     // The Frame Widget g_signal_connect changed ID
-	gulong     draw_connect;      // The Draw  Widget g_signal_connect draw ID
-	gulong     drop_connect;      // The Draw  Widget g_signal_connect drop ID
-	gulong     hide_connect;      // The Hide  Widget g_signal_connect changed ID
+	GtkWidget*            frame;               // The FrameID   holding GtkWidget: GtkSpinButton / GtkEntry.
+	int                   vganum;              // For a Drag and Drop enabled Shape_single :
+	bool                  hide;                // Whether the Shape should be hidden.
+	TA_type               translucent;         // How translucent drawing should be handled
+	TA_type               animating;           // How shape animation should be handled
+	const Animation_info* aniinf = nullptr;    // Ifset use this for animation if animating is not Disabled
+	gulong                shape_connect;       // The Shape Widget g_signal_connect changed ID
+	gulong                frame_connect;       // The Frame Widget g_signal_connect changed ID
+	gulong                draw_connect;        // The Draw  Widget g_signal_connect draw ID
+	gulong                drop_connect;        // The Draw  Widget g_signal_connect drop ID
+	gulong                hide_connect;        // The Hide  Widget g_signal_connect changed ID
 
 public:
 	Shape_single(
@@ -233,7 +238,6 @@ public:
 			TA_type animating        = TA_type::shapeinfo     // How shape animation should be handled, defaults to shapeinfo
 
 	);
-	constexpr static int CHANGE_ANIM_PAUSE_FRAMES = 20;
 
 	~Shape_single() override;
 	static void     on_shape_changed(GtkWidget* widget, gpointer user_data);
@@ -313,12 +317,24 @@ public:
 
 class Shape_shape_single : public Shape_single {
 protected:
-	WidgetChangedConnect shape_3d_x     = {"shinfo_xtiles", "changed", on_widget_changed, this};
-	WidgetChangedConnect shape_3d_y     = {"shinfo_ytiles", "changed", on_widget_changed, this};
-	WidgetChangedConnect shape_3d_z     = {"shinfo_ztiles", "changed", on_widget_changed, this};
-	WidgetChangedConnect show_shape_3d  = {"shinfo_tiles_preview", "toggled", on_widget_changed, this};
-	WidgetChangedConnect shape_trans    = {"shinfo_transl_check", "toggled", on_widget_changed, this};
-	WidgetChangedConnect shape_animated = {"shinfo_animated_check", "toggled", on_widget_changed, this};
+	WidgetChangedConnect shape_3d_x    = {"shinfo_xtiles", "changed", on_widget_changed, this};
+	WidgetChangedConnect shape_3d_y    = {"shinfo_ytiles", "changed", on_widget_changed, this};
+	WidgetChangedConnect shape_3d_z    = {"shinfo_ztiles", "changed", on_widget_changed, this};
+	WidgetChangedConnect show_shape_3d = {"shinfo_tiles_preview", "toggled", on_widget_changed, this};
+	WidgetChangedConnect shape_trans   = {"shinfo_transl_check", "toggled", on_widget_changed, this};
+
+	WidgetChangedConnect shape_animated                = {"shinfo_animated_check", "toggled", on_widget_changed, this};
+	WidgetChangedConnect shinfo_animation_check        = {"shinfo_animation_check", "toggled", on_widget_changed, this};
+	WidgetChangedConnect shinfo_animation_frcount      = {"shinfo_animation_frcount", "changed", on_widget_changed, this};
+	WidgetChangedConnect shinfo_animation_frtype       = {"shinfo_animation_frtype", "toggled", on_widget_changed, this};
+	WidgetChangedConnect shinfo_animation_type         = {"shinfo_animation_type", "changed", on_widget_changed, this};
+	WidgetChangedConnect shinfo_animation_ticks        = {"shinfo_animation_ticks", "changed", on_widget_changed, this};
+	WidgetChangedConnect shinfo_animation_freezefirst  = {"shinfo_animation_freezefirst", "changed", on_widget_changed, this};
+	WidgetChangedConnect shinfo_animation_rectype      = {"shinfo_animation_rectype", "toggled", on_widget_changed, this};
+	WidgetChangedConnect shinfo_animation_recycle      = {"shinfo_animation_recycle", "changed", on_widget_changed, this};
+	WidgetChangedConnect shinfo_animation_freezechance = {"shinfo_animation_freezechance", "changed", on_widget_changed, this};
+
+	std::unique_ptr<Animation_info> up_aniinf;
 
 public:
 	Shape_shape_single(
@@ -340,6 +356,7 @@ public:
 
 	static void on_widget_changed(GtkWidget* widget, gpointer user_data);
 	static void on_widget_state(GtkWidget* widget, GtkStateFlags flags, gpointer user_data);
+	void        setup_aniinf();
 };
 
 #endif

--- a/mapedit/shapedraw.h
+++ b/mapedit/shapedraw.h
@@ -48,7 +48,58 @@ protected:
 	Drop_callback  drop_callback;    // Called when a shape is dropped here.
 	void*          drop_user_data;
 	bool           dragging;    // Dragging from here.
+
+private:
+	// Linked List Pointers
+
+	static Shape_draw* list_head;
+	Shape_draw*        list_next;
+
 public:
+	// A simple iterator class for the linked list
+	struct iterator {
+		Shape_draw* node;
+
+		iterator(Shape_draw* node) : node(node) {}
+
+		Shape_draw* operator*() {
+			return node;
+		}
+
+		Shape_draw* operator->() {
+			return node;
+		}
+
+		iterator& operator++(int) {
+			node = node->list_next;
+			return *this;
+		}
+
+		iterator operator++() {
+			iterator ret = *this;
+			node         = node->list_next;
+			return ret;
+		}
+
+		bool operator==(const iterator& other) {
+			return node == other.node;
+		}
+
+		bool operator!=(const iterator& other) {
+			return node != other.node;
+		}
+	};
+
+	static inline const struct {
+		iterator begin() const {
+			return list_head;
+		}
+
+		iterator end() const {
+			return nullptr;
+		}
+	} iteratable;
+
 	static const int outline_color = 249;    // Palette index of outline color
 
 	Shape_draw(Vga_file* i, const unsigned char* palbuf, GtkWidget* drw);

--- a/mapedit/shapedraw.h
+++ b/mapedit/shapedraw.h
@@ -127,7 +127,7 @@ public:
 		return animating_paused == INT_MAX;
 	}
 
-	static const int outline_color = 249;    // Palette index of outline color
+	static const int outline_color = 50;    // Palette index of outline color
 
 	Shape_draw(Vga_file* i, const unsigned char* palbuf, GtkWidget* drw);
 	virtual ~Shape_draw();

--- a/mapedit/shapedraw.h
+++ b/mapedit/shapedraw.h
@@ -132,7 +132,7 @@ public:
 
 	static const int outline_color = 50;    // Palette index of outline color
 
-	int GetAnimInfoFrame(const Animation_info* aniinfm, unsigned short first_frame, unsigned short nframes);
+	int GetAnimInfoFrame(const Animation_info* aniinfm, unsigned short first_frame, unsigned short nframes, bool pausable = false);
 	Shape_draw(Vga_file* i, const unsigned char* palbuf, GtkWidget* drw);
 	virtual ~Shape_draw();
 

--- a/mapedit/shapedraw.h
+++ b/mapedit/shapedraw.h
@@ -160,6 +160,7 @@ public:
 	void         draw_shape_centered(int shapenum, int framenum, int& x, int& y, bool trans = false);
 	virtual void render();    // Update what gets shown.
 	void         set_background_color(guint32 c);
+	void         update_palette(const unsigned char* palbuf, unsigned start, unsigned count);
 	virtual void animate();
 	void         configure();    // Configure when created/resized.
 	// Handler for drop.

--- a/mapedit/shapedraw.h
+++ b/mapedit/shapedraw.h
@@ -76,10 +76,10 @@ public:
 		return palette->colors[i];
 	}
 
-	virtual void draw_shape(Shape_frame* shape, int x, int y);
-	void         draw_shape(int shapenum, int framenum, int x, int y);
+	virtual void draw_shape(Shape_frame* shape, int x, int y, bool trans = false);
+	void         draw_shape(int shapenum, int framenum, int x, int y, bool trans = false);
 	void         draw_shape_outline(int shapenum, int framenum, int x, int y, unsigned char color);
-	void         draw_shape_centered(int shapenum, int framenum, int& x, int& y);
+	void         draw_shape_centered(int shapenum, int framenum, int& x, int& y, bool trans = false);
 	virtual void render();    // Update what gets shown.
 	void         set_background_color(guint32 c);
 
@@ -108,6 +108,13 @@ class Shape_shape_single;
 class Shape_gump_single;
 
 class Shape_single : public Shape_draw {
+public:
+	enum class Trans_type {
+		Disabled  = 0,
+		Enabled   = 1,
+		shapeinfo = 2,    // For a shape from Shapes.vgs, use shapeinfo to determine things
+	};
+
 protected:
 	GtkWidget* shape;             // The ShapeID   holding GtkWidget: GtkSpinButton / GtkEntry, or GtkFrame ( NPCEditor NPC Face ).
 	GtkWidget* shapename;         // The ShapeName holding GtkLabel.
@@ -115,6 +122,7 @@ protected:
 	GtkWidget* frame;             // The FrameID   holding GtkWidget: GtkSpinButton / GtkEntry.
 	int        vganum;            // For a Drag and Drop enabled Shape_single :
 	bool       hide;              // Whether the Shape should be hidden.
+	Trans_type translucent;       // How translucent drawing should be handled
 	gulong     shape_connect;     // The Shape Widget g_signal_connect changed ID
 	gulong     frame_connect;     // The Frame Widget g_signal_connect changed ID
 	gulong     draw_connect;      // The Draw  Widget g_signal_connect draw ID
@@ -123,15 +131,18 @@ protected:
 
 public:
 	Shape_single(
-			GtkWidget* shp,                 // The ShapeID   holding GtkWidget.
-			GtkWidget* shpnm,               // The ShapeName holding GtkWidget.
-			bool (*shvld)(int),             // The ShapeUD   validating lambda.
-			GtkWidget*           frm,       // The FrameID   holding GtkWidget.
-			int                  vgnum,     // The D&D U7_SHAPE_xxx VGA file category.
-			Vga_file*            vg,        // The VGA File for the Shape_draw ctor.
-			const unsigned char* palbuf,    // The Palette for the Shape_draw ctor.
-			GtkWidget*           drw,       // The GtkDrawingArea for the Shape_draw ctor.
-			bool                 hdd = false);              // Whether the Shape should be hidden.
+			GtkWidget* shp,                                     // The ShapeID   holding GtkWidget.
+			GtkWidget* shpnm,                                   // The ShapeName holding GtkWidget.
+			bool (*shvld)(int),                                 // The ShapeUD   validating lambda.
+			GtkWidget*           frm,                           // The FrameID   holding GtkWidget.
+			int                  vgnum,                         // The D&D U7_SHAPE_xxx VGA file category.
+			Vga_file*            vg,                            // The VGA File for the Shape_draw ctor.
+			const unsigned char* palbuf,                        // The Palette for the Shape_draw ctor.
+			GtkWidget*           drw,                           // The GtkDrawingArea for the Shape_draw ctor.
+			bool                 hdd = false,                   // Whether the Shape should be hidden.
+			Trans_type translucent   = Trans_type::shapeinfo    // How translucent drawing should be handled, defaults to shapeinfo
+
+	);
 	~Shape_single() override;
 	static void     on_shape_changed(GtkWidget* widget, gpointer user_data);
 	static void     on_frame_changed(GtkWidget* widget, gpointer user_data);
@@ -188,7 +199,8 @@ public:
 			Vga_file*            vg,        // The VGA File for the Shape_draw ctor.
 			const unsigned char* palbuf,    // The Palette for the Shape_draw ctor.
 			GtkWidget*           drw,       // The GtkDrawingArea for the Shape_draw ctor.
-			bool                 hdd = false);              // Whether the Shape should be hidden.
+			bool                 hdd         = false,
+			Trans_type           translucent = Trans_type::Disabled);    // Whether the Shape should be hidden.
 	~Shape_gump_single() override;
 	static gboolean on_draw_expose_event(GtkWidget* widget, cairo_t* cairo, gpointer user_data);
 
@@ -217,6 +229,8 @@ protected:
 	gulong     shape_3d_z_connect;
 	GtkWidget* show_shape_3d_widget;
 	gulong     show_shape_3d_connect;
+	GtkWidget* shape_trans_widget;
+	gulong     shape_trans_connect;
 
 public:
 	Shape_shape_single(
@@ -230,7 +244,7 @@ public:
 			GtkWidget*           drw,       // The GtkDrawingArea for the Shape_draw ctor.
 			bool                 hdd = false);              // Whether the Shape should be hidden.
 	~Shape_shape_single() override;
-	void draw_shape(Shape_frame* shape, int x, int y) override;
+	void draw_shape(Shape_frame* shape, int x, int y, bool trans) override;
 
 	Shape_shape_single* get_shape_shape_single() override {
 		return this;

--- a/mapedit/shapeedit.cc
+++ b/mapedit/shapeedit.cc
@@ -1101,7 +1101,7 @@ C_EXPORT void on_shinfo_effhps_update_clicked(GtkButton* btn, gpointer user_data
 		GdkPixbuf*  nshape = studio->shape_image(
                 static_cast<Shape_file_info*>(g_object_get_data(G_OBJECT(studio->get_widget("shape_window")), "file_info"))
                         ->get_ifile(),
-                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true);
+                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true, studio->get_toggle("shinfo_transl_check"));
 		if (cmp > 0) {
 			gtk_tree_store_insert_after(store, &newiter, nullptr, iter.get());
 		} else {
@@ -1236,7 +1236,7 @@ C_EXPORT void on_shinfo_brightness_update_clicked(GtkButton* btn, gpointer user_
 		GdkPixbuf*  nshape = studio->shape_image(
                 static_cast<Shape_file_info*>(g_object_get_data(G_OBJECT(studio->get_widget("shape_window")), "file_info"))
                         ->get_ifile(),
-                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true);
+                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true, studio->get_toggle("shinfo_transl_check"));
 		if (cmp > 0) {
 			gtk_tree_store_insert_after(store, &newiter, nullptr, iter.get());
 		} else {
@@ -1335,7 +1335,7 @@ C_EXPORT void on_shinfo_warmth_update_clicked(GtkButton* btn, gpointer user_data
 		GdkPixbuf*  nshape = studio->shape_image(
                 static_cast<Shape_file_info*>(g_object_get_data(G_OBJECT(studio->get_widget("shape_window")), "file_info"))
                         ->get_ifile(),
-                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true);
+                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true, studio->get_toggle("shinfo_transl_check"));
 		if (cmp > 0) {
 			gtk_tree_store_insert_after(store, &newiter, nullptr, iter.get());
 		} else {
@@ -1430,10 +1430,11 @@ C_EXPORT void on_shinfo_cntrules_update_clicked(GtkButton* btn, gpointer user_da
 	const int      cmp = Find_unary_iter(model, iter, newshnum);
 	if (cmp) {
 		GtkTreeIter newiter;
-		GdkPixbuf*  nshape = studio->shape_image(
-                static_cast<Shape_file_info*>(g_object_get_data(G_OBJECT(studio->get_widget("shape_window")), "file_info"))
-                        ->get_ifile(),
-                static_cast<int>(newshnum), 0, true);
+		auto vgafile = static_cast<Shape_file_info*>(g_object_get_data(G_OBJECT(studio->get_widget("shape_window")), "file_info"))
+							   ->get_ifile();
+		auto       shapesvga = dynamic_cast<Shapes_vga_file*>(vgafile);
+		GdkPixbuf* nshape    = studio->shape_image(
+                vgafile, static_cast<int>(newshnum), 0, true, shapesvga ? shapesvga->get_info(newshnum).has_translucency() : false);
 		if (cmp > 0) {
 			gtk_tree_store_insert_after(store, &newiter, nullptr, iter.get());
 		} else {
@@ -1547,7 +1548,7 @@ C_EXPORT void on_shinfo_frameflags_update_clicked(GtkButton* btn, gpointer user_
 		GdkPixbuf*  nshape = studio->shape_image(
                 static_cast<Shape_file_info*>(g_object_get_data(G_OBJECT(studio->get_widget("shape_window")), "file_info"))
                         ->get_ifile(),
-                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true);
+                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true, studio->get_toggle("shinfo_transl_check"));
 		if (cmp > 0) {
 			gtk_tree_store_insert_after(store, &newiter, nullptr, iter.get());
 		} else {
@@ -1655,7 +1656,7 @@ C_EXPORT void on_shinfo_frameusecode_update_clicked(GtkButton* btn, gpointer use
 		GdkPixbuf*  nshape = studio->shape_image(
                 static_cast<Shape_file_info*>(g_object_get_data(G_OBJECT(studio->get_widget("shape_window")), "file_info"))
                         ->get_ifile(),
-                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true);
+                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true, studio->get_toggle("shinfo_transl_check"));
 		if (cmp > 0) {
 			gtk_tree_store_insert_after(store, &newiter, nullptr, iter.get());
 		} else {
@@ -1833,7 +1834,7 @@ C_EXPORT void on_shinfo_framenames_update_clicked(GtkButton* btn, gpointer user_
 		GdkPixbuf*  nshape = studio->shape_image(
                 static_cast<Shape_file_info*>(g_object_get_data(G_OBJECT(studio->get_widget("shape_window")), "file_info"))
                         ->get_ifile(),
-                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true);
+                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true, studio->get_toggle("shinfo_transl_check"));
 		if (cmp > 0) {
 			gtk_tree_store_insert_after(store, &newiter, nullptr, iter.get());
 		} else {
@@ -2092,7 +2093,7 @@ C_EXPORT void on_shinfo_objpaperdoll_update_clicked(GtkButton* btn, gpointer use
 		GdkPixbuf*  nshape = studio->shape_image(
                 static_cast<Shape_file_info*>(g_object_get_data(G_OBJECT(studio->get_widget("shape_window")), "file_info"))
                         ->get_ifile(),
-                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true);
+                studio->get_num_entry("shinfo_shape"), static_cast<int>(newfrnum), true, studio->get_toggle("shinfo_transl_check"));
 		if (cmp > 0) {
 			gtk_tree_store_insert_after(store, &newiter, nullptr, iter.get());
 		} else {
@@ -2918,7 +2919,7 @@ void ExultStudio::init_shape_notebook(
 			if (!first) {
 				first = &hps;
 			}
-			GdkPixbuf* nshape = shape_image(shpfile, shnum, hps.get_frame(), true);
+			GdkPixbuf* nshape = shape_image(shpfile, shnum, hps.get_frame(), true, info.has_translucency());
 			gtk_tree_store_append(store, &iter, nullptr);
 			gtk_tree_store_set(
 					store, &iter, HP_FRAME_COLUMN, hps.get_frame(), HP_QUALITY_COLUMN, hps.get_quality(), HP_HIT_POINTS,
@@ -2958,7 +2959,7 @@ void ExultStudio::init_shape_notebook(
 			if (!first) {
 				first = &light;
 			}
-			GdkPixbuf* nshape = shape_image(shpfile, shnum, light.get_frame(), true);
+			GdkPixbuf* nshape = shape_image(shpfile, shnum, light.get_frame(), true, info.has_translucency());
 			gtk_tree_store_append(store, &iter, nullptr);
 			gtk_tree_store_set(
 					store, &iter, BRIGHTNESS_FRAME_COLUMN, light.get_frame(), BRIGHTNESS_VALUE_COLUMN, light.get_light(),
@@ -2999,7 +3000,7 @@ void ExultStudio::init_shape_notebook(
 			if (!first) {
 				first = &warm;
 			}
-			GdkPixbuf* nshape = shape_image(shpfile, shnum, warm.get_frame(), true);
+			GdkPixbuf* nshape = shape_image(shpfile, shnum, warm.get_frame(), true, info.has_translucency());
 			gtk_tree_store_append(store, &iter, nullptr);
 			gtk_tree_store_set(
 					store, &iter, WARM_FRAME_COLUMN, warm.get_frame(), WARM_VALUE_COLUMN, warm.get_warmth(), WARM_FROM_PATCH,
@@ -3039,7 +3040,7 @@ void ExultStudio::init_shape_notebook(
 			if (!first) {
 				first = &cntr;
 			}
-			GdkPixbuf* nshape = shape_image(shpfile, cntr.get_shape(), 0, true);
+			GdkPixbuf* nshape = shape_image(shpfile, cntr.get_shape(), 0, true, info.has_translucency());
 			gtk_tree_store_append(store, &iter, nullptr);
 			gtk_tree_store_set(
 					store, &iter, CNT_SHAPE_COLUMN, cntr.get_shape(), CNT_ACCEPT_COLUMN, cntr.accepts_shape(), CNT_FROM_PATCH,
@@ -3079,7 +3080,7 @@ void ExultStudio::init_shape_notebook(
 			if (!first) {
 				first = &frflag;
 			}
-			GdkPixbuf* nshape = shape_image(shpfile, shnum, frflag.get_frame(), true);
+			GdkPixbuf* nshape = shape_image(shpfile, shnum, frflag.get_frame(), true, info.has_translucency());
 			gtk_tree_store_append(store, &iter, nullptr);
 			gtk_tree_store_set(
 					store, &iter, FRFLAG_FRAME_COLUMN, frflag.get_frame(), FRFLAG_QUAL_COLUMN, frflag.get_quality(),
@@ -3127,7 +3128,7 @@ void ExultStudio::init_shape_notebook(
 			} else {
 				ucfun << frucfun.get_usecode();
 			}
-			GdkPixbuf* nshape = shape_image(shpfile, shnum, frucfun.get_frame(), true);
+			GdkPixbuf* nshape = shape_image(shpfile, shnum, frucfun.get_frame(), true, info.has_translucency());
 			gtk_tree_store_append(store, &iter, nullptr);
 			gtk_tree_store_set(
 					store, &iter, FRUC_FRAME_COLUMN, frucfun.get_frame(), FRUC_QUAL_COLUMN, frucfun.get_quality(),
@@ -3186,7 +3187,7 @@ void ExultStudio::init_shape_notebook(
 					= otype == -255 ? sname : (otype == -1 || otmsg >= get_num_misc_names() ? nullptr : get_misc_name(otmsg));
 			const string utf8msg(convertToUTF8(msgstr));
 			const string utf8otmsg(convertToUTF8(otmsgstr));
-			GdkPixbuf*   nshape = shape_image(shpfile, shnum, nmit.get_frame(), true);
+			GdkPixbuf*   nshape = shape_image(shpfile, shnum, nmit.get_frame(), true, info.has_translucency());
 			gtk_tree_store_append(store, &iter, nullptr);
 			gtk_tree_store_set(
 					store, &iter, FNAME_FRAME, nmit.get_frame(), FNAME_QUALITY, nmit.get_quality(), FNAME_MSGTYPE, type,
@@ -3236,7 +3237,7 @@ void ExultStudio::init_shape_notebook(
 			if (!first) {
 				first = &doll;
 			}
-			GdkPixbuf* nshape = shape_image(shpfile, shnum, doll.get_world_frame(), true);
+			GdkPixbuf* nshape = shape_image(shpfile, shnum, doll.get_world_frame(), true, doll.is_translucent());
 			gtk_tree_store_append(store, &iter, nullptr);
 			gtk_tree_store_set(
 					store, &iter, DOLL_WORLD_FRAME, doll.get_world_frame(), DOLL_SPOT, doll.get_object_spot(), DOLL_TRANSLUCENT,

--- a/mapedit/shapeedit.cc
+++ b/mapedit/shapeedit.cc
@@ -3972,7 +3972,8 @@ void ExultStudio::open_shape_window(
 				[](int shnum) -> bool {
 					return shnum >= 0;
 				},
-				nullptr, U7_SHAPE_SPRITES, spritefile->get_ifile(), palbuf.get(), get_widget("shinfo_explosion_draw"));
+				nullptr, U7_SHAPE_SPRITES, spritefile->get_ifile(), palbuf.get(), get_widget("shinfo_explosion_draw"), false,
+				Shape_single::Trans_type::Enabled);
 	}
 	delete weapon_family_single;
 	weapon_family_single = nullptr;

--- a/mapedit/shapeedit.cc
+++ b/mapedit/shapeedit.cc
@@ -4045,35 +4045,36 @@ void ExultStudio::open_shape_window(
 					return (shnum >= c_first_obj_shape) && (shnum < c_max_shapes);
 				},
 				get_widget("shinfo_frameflags_frame_num"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(),
-				get_widget("shinfo_frameflags_frame_draw"), true);
+				get_widget("shinfo_frameflags_frame_draw"), true, Shape_single::TA_type::widget, Shape_single::TA_type::Disabled);
 		effhps_frame_single = new Shape_single(
 				get_widget("shinfo_shape"), nullptr,
 				[](int shnum) -> bool {
 					return (shnum >= c_first_obj_shape) && (shnum < c_max_shapes);
 				},
 				get_widget("shinfo_effhps_frame_num"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(),
-				get_widget("shinfo_effhps_frame_draw"), true);
+				get_widget("shinfo_effhps_frame_draw"), true, Shape_single::TA_type::widget, Shape_single::TA_type::Disabled);
 		framenames_frame_single = new Shape_single(
 				get_widget("shinfo_shape"), nullptr,
 				[](int shnum) -> bool {
 					return (shnum >= c_first_obj_shape) && (shnum < c_max_shapes);
 				},
 				get_widget("shinfo_framenames_frame_num"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(),
-				get_widget("shinfo_framenames_frame_draw"), true);
+				get_widget("shinfo_framenames_frame_draw"), true, Shape_single::TA_type::widget, Shape_single::TA_type::Disabled);
 		frameusecode_frame_single = new Shape_single(
 				get_widget("shinfo_shape"), nullptr,
 				[](int shnum) -> bool {
 					return (shnum >= c_first_obj_shape) && (shnum < c_max_shapes);
 				},
 				get_widget("shinfo_frameusecode_frame_num"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(),
-				get_widget("shinfo_frameusecode_frame_draw"), true);
+				get_widget("shinfo_frameusecode_frame_draw"), true, Shape_single::TA_type::widget, Shape_single::TA_type::Disabled);
 		objpaperdoll_wframe_single = new Shape_single(
 				get_widget("shinfo_shape"), nullptr,
 				[](int shnum) -> bool {
 					return (shnum >= c_first_obj_shape) && (shnum < c_max_shapes);
 				},
 				get_widget("shinfo_objpaperdoll_wframe"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(),
-				get_widget("shinfo_objpaperdoll_wframe_draw"), true);
+				get_widget("shinfo_objpaperdoll_wframe_draw"), true, Shape_single::TA_type::widget,
+				Shape_single::TA_type::Disabled);
 		objpaperdoll_spotframe_single = new Shape_single(
 				get_widget("shinfo_shape"), nullptr,
 				[](int shnum) -> bool {
@@ -4087,14 +4088,14 @@ void ExultStudio::open_shape_window(
 					return (shnum >= c_first_obj_shape) && (shnum < c_max_shapes);
 				},
 				get_widget("shinfo_brightness_frame_num"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(),
-				get_widget("shinfo_brightness_frame_draw"), true);
+				get_widget("shinfo_brightness_frame_draw"), true, Shape_single::TA_type::widget, Shape_single::TA_type::Disabled);
 		warmth_frame_single = new Shape_single(
 				get_widget("shinfo_shape"), nullptr,
 				[](int shnum) -> bool {
 					return (shnum >= c_first_obj_shape) && (shnum < c_max_shapes);
 				},
 				get_widget("shinfo_warmth_frame_num"), U7_SHAPE_SHAPES, vgafile->get_ifile(), palbuf.get(),
-				get_widget("shinfo_warmth_frame_draw"), true);
+				get_widget("shinfo_warmth_frame_draw"), true, Shape_single::TA_type::widget, Shape_single::TA_type::Disabled);
 	}
 	delete npcpaperdoll_aframe_single;
 	npcpaperdoll_aframe_single = nullptr;

--- a/mapedit/shapeedit.cc
+++ b/mapedit/shapeedit.cc
@@ -3973,7 +3973,7 @@ void ExultStudio::open_shape_window(
 					return shnum >= 0;
 				},
 				nullptr, U7_SHAPE_SPRITES, spritefile->get_ifile(), palbuf.get(), get_widget("shinfo_explosion_draw"), false,
-				Shape_single::Trans_type::Enabled);
+				Shape_single::TA_type::Enabled);
 	}
 	delete weapon_family_single;
 	weapon_family_single = nullptr;

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -187,7 +187,7 @@ void Shape_chooser::render() {
 				const int sy = info[index].box.y - voffset;
 				// Get the shapeinfo for translucency flag
 				// for choosers other than shapes.vga translucency is always used
-				if (((!shapes_file || shapes_file->get_info(shapenum).has_translucency())) && xforms.size()) {
+				if (((!shapes_file || shapes_file->get_info(shapenum).has_translucency())) && xforms.size() && shape->is_rle()) {
 					shape->paint_rle_translucent(
 							iwin, sx + shape->get_xleft(), sy + shape->get_yabove(), xforms.data(), xforms.size());
 				} else {

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "shapelst.h"
 
+#include "aniinf.h"
 #include "databuf.h"
 #include "fontgen.h"
 #include "frnameinf.h"
@@ -151,15 +152,35 @@ void Shape_chooser::render() {
 	const gint winh = ZoomDown(alloc.height);
 	// Clear window first.
 	iwin->fill8(255);    // Set to background_color.
-	int         curr_y     = -row0_voffset;
-	const auto& xforms     = ExultStudio::get_instance()->GetXform();
+	int         curr_y = -row0_voffset;
+	const auto& xforms = ExultStudio::get_instance()->GetXform();
 	for (unsigned rownum = row0; curr_y < winh && rownum < rows.size(); ++rownum) {
 		const Shape_row& row  = rows[rownum];
 		unsigned         cols = get_num_cols(rownum);
 		for (unsigned index = row.index0; cols; --cols, ++index) {
-			const int    shapenum = info[index].shapenum;
-			const int    framenum = info[index].framenum;
-			Shape_frame* shape    = ifile->get_shape(shapenum, framenum);
+			const int shapenum = info[index].shapenum;
+			int       framenum = info[index].framenum;
+			if (shapes_file) {
+				auto& shinfo = shapes_file->get_info(shapenum);
+				// do not do animation in all frames ,ode
+				if (!frames_mode && shinfo.is_animated()) {
+					// makesure animation is emabled if needed
+					if (IsAnimatingStopped()) {
+						PauseAnimating(0);
+					} else {
+						auto nframes = shapes_file->get_num_frames(shapenum);
+
+						if (auto animinfo = shinfo.get_animation_info()) {
+							framenum = GetAnimInfoFrame(animinfo, framenum, nframes);
+						} else {
+							Animation_info simpleai;
+							simpleai.set(Animation_info::AniType::FA_LOOPING, nframes);
+							framenum = GetAnimInfoFrame(&simpleai, framenum, nframes);
+						}
+					}
+				}
+			}
+			Shape_frame* shape = ifile->get_shape(shapenum, framenum);
 
 			if (shape) {
 				const int sx = info[index].box.x - hoffset;
@@ -278,11 +299,22 @@ void Shape_chooser::setup_shapes_info() {
 		const int    shapenum = group ? (*group)[index] : index;
 		const int    framenum = shapenum == selshape ? selframe : framenum0;
 		Shape_frame* shape    = ifile->get_shape(shapenum, framenum);
-		if (!shape) {
+
+		int sh = shape ? shape->get_height() : 0;
+		int sw = shape ? shape->get_width() : 0;
+		// if animated shape in shapes.vga set width and height to max of all frames
+		if (shapes_file && shapes_file->get_info(shapenum).is_animated()) {
+			int num_frames = shapes_file->get_num_frames(shapenum);
+			for (int f = 0; f < num_frames; f++) {
+				if (auto sf = ifile->get_shape(shapenum, f)) {
+					sh = std::max(sh, sf->get_height());
+					sw = std::max(sw, sf->get_width());
+				}
+			}
+		}
+		if (sh == 0 && sw == 0) {
 			continue;
 		}
-		const int sh = shape->get_height();
-		const int sw = shape->get_width();
 		// Check if we've exceeded max width
 		if (x + sw > winw && x) {    // But don't leave row empty.
 			// Next line.
@@ -2009,6 +2041,8 @@ void Shape_chooser::frame_changed(
 		if (chooser->frames_mode) {    // Get sel. frame in view.
 			chooser->scroll_to_frame();
 		}
+		chooser->PauseAnimating(CHANGE_ANIM_PAUSE_FRAMES);
+
 		chooser->render();
 		chooser->update_statusbar();
 	}
@@ -2024,8 +2058,10 @@ void Shape_chooser::all_frames_toggled(GtkToggleButton* btn, gpointer data) {
 	chooser->frames_mode = on;
 	if (on) {    // Frame => show horiz. scrollbar.
 		gtk_widget_set_visible(chooser->hscroll, true);
+		chooser->PauseAnimating();
 	} else {
 		gtk_widget_set_visible(chooser->hscroll, false);
+		chooser->PauseAnimating(0);
 	}
 	int indx  = -1;
 	int shnum = -1;

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -153,7 +153,6 @@ void Shape_chooser::render() {
 	iwin->fill8(255);    // Set to background_color.
 	int         curr_y     = -row0_voffset;
 	const auto& xforms     = ExultStudio::get_instance()->GetXform();
-	bool        is_sprites = this->ifile == ExultStudio::get_instance()->get_spritefile()->get_ifile();
 	for (unsigned rownum = row0; curr_y < winh && rownum < rows.size(); ++rownum) {
 		const Shape_row& row  = rows[rownum];
 		unsigned         cols = get_num_cols(rownum);
@@ -166,8 +165,8 @@ void Shape_chooser::render() {
 				const int sx = info[index].box.x - hoffset;
 				const int sy = info[index].box.y - voffset;
 				// Get the shapeinfo for translucency flag
-				// for sprites, transparency is always true
-				if (((shapes_file && shapes_file->get_info(shapenum).has_translucency()) || is_sprites) && xforms.size()) {
+				// for choosers other than shapes.vga translucency is always used
+				if (((!shapes_file || shapes_file->get_info(shapenum).has_translucency())) && xforms.size()) {
 					shape->paint_rle_translucent(
 							iwin, sx + shape->get_xleft(), sy + shape->get_yabove(), xforms.data(), xforms.size());
 				} else {

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -163,7 +163,7 @@ void Shape_chooser::render() {
 			if (shapes_file) {
 				auto& shinfo = shapes_file->get_info(shapenum);
 				// do not do animation in all frames ,ode
-				if (!frames_mode && shinfo.is_animated()) {
+				if (!frames_mode && shinfo.is_animated() && ExultStudio::IsShapeAnimationEnabled()) {
 					// makesure animation is emabled if needed
 					if (IsAnimatingStopped()) {
 						PauseAnimating(0);
@@ -302,8 +302,8 @@ void Shape_chooser::setup_shapes_info() {
 
 		int sh = shape ? shape->get_height() : 0;
 		int sw = shape ? shape->get_width() : 0;
-		// if animated shape in shapes.vga set width and height to max of all frames
-		if (shapes_file && shapes_file->get_info(shapenum).is_animated()) {
+		// if animated shape in shapes.vga set width and height to max of all frames  if animation is enabled
+		if (shapes_file && shapes_file->get_info(shapenum).is_animated() && ExultStudio::IsShapeAnimationEnabled()) {
 			int num_frames = shapes_file->get_num_frames(shapenum);
 			for (int f = 0; f < num_frames; f++) {
 				if (auto sf = ifile->get_shape(shapenum, f)) {

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -151,7 +151,9 @@ void Shape_chooser::render() {
 	const gint winh = ZoomDown(alloc.height);
 	// Clear window first.
 	iwin->fill8(255);    // Set to background_color.
-	int curr_y = -row0_voffset;
+	int         curr_y     = -row0_voffset;
+	const auto& xforms     = ExultStudio::get_instance()->GetXform();
+	bool        is_sprites = this->ifile == ExultStudio::get_instance()->get_spritefile()->get_ifile();
 	for (unsigned rownum = row0; curr_y < winh && rownum < rows.size(); ++rownum) {
 		const Shape_row& row  = rows[rownum];
 		unsigned         cols = get_num_cols(rownum);
@@ -159,10 +161,18 @@ void Shape_chooser::render() {
 			const int    shapenum = info[index].shapenum;
 			const int    framenum = info[index].framenum;
 			Shape_frame* shape    = ifile->get_shape(shapenum, framenum);
+
 			if (shape) {
 				const int sx = info[index].box.x - hoffset;
 				const int sy = info[index].box.y - voffset;
-				shape->paint(iwin, sx + shape->get_xleft(), sy + shape->get_yabove());
+				// Get the shapeinfo for translucency flag
+				// for sprites, transparency is always true
+				if (((shapes_file && shapes_file->get_info(shapenum).has_translucency()) || is_sprites) && xforms.size()) {
+					shape->paint_rle_translucent(
+							iwin, sx + shape->get_xleft(), sy + shape->get_yabove(), xforms.data(), xforms.size());
+				} else {
+					shape->paint(iwin, sx + shape->get_xleft(), sy + shape->get_yabove());
+				}
 				last_shape = shapenum;
 			}
 		}
@@ -744,10 +754,8 @@ void Shape_chooser::edit_shape_info() {
 	Shape_info*  info   = nullptr;
 	const char*  name   = nullptr;
 	if (shapes_file) {
-		// Read info. the first time.
-		if (shapes_file->read_info(studio->get_game_type(), true)) {
-			studio->set_shapeinfo_modified();
-		}
+		// Set shape info modified
+		studio->set_shapeinfo_modified();
 		if (!shapes_file->has_info(shnum)) {
 			shapes_file->set_info(shnum, Shape_info());
 		}

--- a/mapedit/shapelst.h
+++ b/mapedit/shapelst.h
@@ -122,7 +122,6 @@ class Shape_chooser : public Object_browser, public Shape_draw {
 	void tell_server_shape();    // Tell Exult what shape is selected.
 	void render() override;      // Draw list.
 
-	void setup_info(bool savepos = true) override;
 	void setup_shapes_info();
 	void setup_frames_info();
 	void scroll_to_frame();             // Scroll so sel. frame is visible.
@@ -130,6 +129,7 @@ class Shape_chooser : public Object_browser, public Shape_draw {
 	void goto_index(unsigned index);    // Get desired index in view.
 
 public:
+	void setup_info(bool savepos = true) override;
 	void select(int new_sel) override;    // Show new selection.
 
 	int get_selected_id() override {

--- a/mapedit/shapelst.h
+++ b/mapedit/shapelst.h
@@ -122,10 +122,6 @@ class Shape_chooser : public Object_browser, public Shape_draw {
 	void tell_server_shape();    // Tell Exult what shape is selected.
 	void render() override;      // Draw list.
 
-	void set_background_color(guint32 c) override {
-		Shape_draw::set_background_color(c);
-	}
-
 	void setup_info(bool savepos = true) override;
 	void setup_shapes_info();
 	void setup_frames_info();

--- a/mapedit/shapepresets.cc
+++ b/mapedit/shapepresets.cc
@@ -187,7 +187,7 @@ bool Shape_preset_file::write() {
 		}
 		modified = false;
 		return true;
-	} catch (std::exception& e) {
+	} catch (std::exception&) {
 		return false;
 	}
 }
@@ -232,7 +232,7 @@ bool Shape_preset_file::read(const char* nm) {
 		}
 		modified = false;
 		return true;
-	} catch (std::exception& e) {
+	} catch (std::exception&) {
 		return false;
 	}
 }

--- a/mapedit/shapepresets.cc
+++ b/mapedit/shapepresets.cc
@@ -277,7 +277,10 @@ void ExultStudio::setup_presets_list() {
 
 			// Get shape preview image
 			if (vgafile && shape_num >= 0) {
-				GdkPixbuf* full_pixbuf = shape_image(vgafile->get_ifile(), shape_num, 0, true);
+				auto shapes = dynamic_cast<Shapes_vga_file*>(vgafile->get_ifile());
+
+				GdkPixbuf* full_pixbuf = shape_image(
+						vgafile->get_ifile(), shape_num, 0, true, shapes ? shapes->get_info(shape_num).has_translucency() : false);
 				if (full_pixbuf) {
 					// Scale to half size
 					const int width  = gdk_pixbuf_get_width(full_pixbuf);

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -1648,12 +1648,15 @@ void ExultStudio::set_game_path(const string& gamename, const string& modname) {
 	palbuf[3 * 255]     = (background_color >> 18) & 0x3f;
 	palbuf[3 * 255 + 1] = (background_color >> 10) & 0x3f;
 	palbuf[3 * 255 + 2] = (background_color >> 2) & 0x3f;
-	files               = new Shape_file_set();
-	vgafile             = open_shape_file("shapes.vga");
-	facefile            = open_shape_file("faces.vga");
-	fontfile            = open_shape_file("fonts.vga");
-	gumpfile            = open_shape_file("gumps.vga");
-	spritefile          = open_shape_file("sprites.vga");
+	// Load xforms after palette loaded and background colour has been set
+	load_xforms();
+
+	files      = new Shape_file_set();
+	vgafile    = open_shape_file("shapes.vga");
+	facefile   = open_shape_file("faces.vga");
+	fontfile   = open_shape_file("fonts.vga");
+	gumpfile   = open_shape_file("gumps.vga");
+	spritefile = open_shape_file("sprites.vga");
 	if (game_type == SERPENT_ISLE) {
 		paperdolfile = open_shape_file("paperdol.vga");
 	} else if (game_type == BLACK_GATE) {
@@ -2476,6 +2479,61 @@ void ExultStudio::show_unused_shapes(
 	// FIXME: gtk_text_set_point(text, 0);  // Scroll back to top.
 }
 
+void ExultStudio::load_xforms() {
+	xforms.clear();
+
+	// Find the colour nearest to the background that is index 0xFF
+	uint_fast8_t nearest_bg = 0xff;
+
+	// This code was copied from Palette::find_color()
+	// because Exult studio doesn't compile the Palette class
+	long         best_distance = LONG_MAX;
+	uint_fast8_t bgr = palbuf[255 * 3], bgg = palbuf[255 * 3 + 1], bgb = palbuf[255 * 3 + 2];
+	// Only search for colour nearest to background in non cycled colours
+	for (int i = 0; i < 0xE0; i++) {
+		// Get deltas.
+		const long dr = bgr - palbuf[3 * i];
+		const long dg = bgg - palbuf[3 * i + 1];
+		const long db = bgb - palbuf[3 * i + 2];
+		// Figure distance-squared.
+		const long dist = dr * dr + dg * dg + db * db;
+		if (dist < best_distance) {    // Better than prev?
+			nearest_bg    = i;
+			best_distance = dist;
+			if (dist == 0) {
+				// Found a perfect match so leave
+				break;
+			}
+		}
+	}
+
+	// Load xform tables
+	// Code copied from Shape_manager::load()
+
+	if (U7exists(XFORMTBL) || U7exists(PATCH_XFORMS)) {
+		// Read in translucency tables.
+		U7multifile xformfile(XFORMTBL, PATCH_XFORMS);
+		// Allow loading of all xform tables including the ones Exult can't. Shouldn't make much of a difference
+		// Minimum size of 17 so all expected tables exist
+		xforms.resize(std::max<size_t>(17, xformfile.number_of_objects()));
+		const size_t nxforms = xforms.size();
+		for (size_t i = 0; i < nxforms; i++) {
+			auto ds = xformfile.retrieve(i);
+			if (!ds.good()) {
+				// No XForm data at all. Make this XForm into an
+				// identity transformation.
+				for (size_t j = 0; j < sizeof(xforms[0].colors); j++) {
+					xforms[nxforms - 1 - i].colors[j] = static_cast<uint8>(j);
+				}
+			} else {
+				ds.read(xforms[nxforms - 1 - i].colors, sizeof(xforms[0].colors));
+			}
+			// copy the nearest background xform colour to FF
+			xforms[nxforms - 1 - i].colors[0xff] = xforms[nxforms - 1 - i].colors[nearest_bg];
+		}
+	}
+}
+
 /*
  *  Open a shape (or chunks) file in 'patch' or 'static' directory.
  *
@@ -3116,6 +3174,8 @@ void ExultStudio::save_preferences() {
 	palbuf[3 * 255]     = (background_color >> 18) & 0x3f;
 	palbuf[3 * 255 + 1] = (background_color >> 10) & 0x3f;
 	palbuf[3 * 255 + 2] = (background_color >> 2) & 0x3f;
+	// Xform loading uses background colour so reload them
+	load_xforms();
 	if (browser) {    // Repaint browser.
 		browser->set_background_color(background_color);
 	}

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -1665,6 +1665,8 @@ void ExultStudio::set_game_path(const string& gamename, const string& modname) {
 			paperdolfile = nullptr;
 		}
 	}
+	// Make sure shapeinfo is read
+	static_cast<Shapes_vga_file*>(vgafile->get_ifile())->read_info(game_type, true);
 	Setup_text(game_type == SERPENT_ISLE, expansion, sibeta,
 			   gameinfo->get_game_language());    // Read in shape names.
 	misc_name_map.clear();

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -440,17 +440,47 @@ void ExultStudio::on_play_button_toggled(GtkToggleButton* button, gpointer user_
 	studio->update_play_button(playing);
 }
 
-gboolean ExultStudio::on_animation_timeout(gpointer ) {
+gboolean ExultStudio::on_animation_timeout(gpointer) {
+	// Palette cycling
+	unsigned ranges[][2] = {
+			{0xfc, 3},
+            {0xf8, 4},
+            {0xf4, 4},
+            {0xf0, 4},
+            {0xe8, 8},
+            {0xe0, 8}
+    };
+	// If ranges changes update these values as needed
+	unsigned min = 0xe0, limit = 0xff;
 
-	// call animate on all shapedraws
+	for (const auto range : ranges) {
+		auto first = range[0] * 3;
+		auto cnt   = range[1] * 3;
 
-	for (auto draw : Shape_draw::iteratable)
-	{
+		unsigned char* start  = self->palbuf.get() + first;
+		unsigned char* finish = start + cnt;
+		// Shift upward.
+		std::rotate(start, finish - 3, finish);
+	}
+
+	// call animate and update palette on all shapedraws
+
+	for (auto draw : Shape_draw::iteratable) {
+		if (auto b = dynamic_cast<Object_browser*>(draw)) {
+			// If its a browser and not current do nothing
+			if (b != self->browser) {
+				continue;
+			}
+		}
+
+		if (min < limit) {
+			draw->update_palette(self->palbuf.get(), min, limit - min);
+		}
+
 		draw->animate();
 	}
 
 	return G_SOURCE_CONTINUE;
-	
 }
 
 C_EXPORT void on_tile_grid_button_toggled(GtkToggleButton* button, gpointer user_data) {
@@ -915,7 +945,7 @@ ExultStudio::ExultStudio(int argc, char** argv)
 	}
 	// start antimation timer
 	animation_timeout_id = g_timeout_add(ANIMATION_TIMEOUT_MS, on_animation_timeout, nullptr);
-	
+
 	// Set initial state for menus and toolbar - disconnected
 	update_menu_items(false);
 	int w;

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -441,43 +441,50 @@ void ExultStudio::on_play_button_toggled(GtkToggleButton* button, gpointer user_
 }
 
 gboolean ExultStudio::on_animation_timeout(gpointer) {
-	// Palette cycling
-	unsigned ranges[][2] = {
-			{0xfc, 3},
-            {0xf8, 4},
-            {0xf4, 4},
-            {0xf0, 4},
-            {0xe8, 8},
-            {0xe0, 8}
-    };
-	// If ranges changes update these values as needed
-	unsigned min = 0xe0, limit = 0xff;
+	unsigned min = UINT_MAX, limit = 0;
 
-	for (const auto range : ranges) {
-		auto first = range[0] * 3;
-		auto cnt   = range[1] * 3;
+	if (self->palette_cycling) {
+		const unsigned ranges[][2] = {
+				{0xfc, 3},
+                {0xf8, 4},
+                {0xf4, 4},
+                {0xf0, 4},
+                {0xe8, 8},
+                {0xe0, 8}
+        };
 
-		unsigned char* start  = self->palbuf.get() + first;
-		unsigned char* finish = start + cnt;
-		// Shift upward.
-		std::rotate(start, finish - 3, finish);
+		for (const auto range : ranges) {
+			auto first = range[0] * 3;
+			auto cnt   = range[1] * 3;
+
+			min   = std::min(min, range[0]);
+			limit = std::max(limit, range[0] + range[1]);
+
+			unsigned char* start  = self->palbuf.get() + first;
+			unsigned char* finish = start + cnt;
+			// Shift upward.
+			std::rotate(start, finish - 3, finish);
+		}
 	}
-
 	// call animate and update palette on all shapedraws
 
-	for (auto draw : Shape_draw::iteratable) {
-		if (auto b = dynamic_cast<Object_browser*>(draw)) {
-			// If its a browser and doesn't have a parent do nothing
-			if (!gtk_widget_get_parent(b->get_widget())) {
-				continue;
+	if (self->animating_shapes || self->palette_cycling) {
+		for (auto draw : Shape_draw::iteratable) {
+			if (auto b = dynamic_cast<Object_browser*>(draw)) {
+				// If its a browser and doesn't have a parent do nothing
+				if (!gtk_widget_get_parent(b->get_widget())) {
+					continue;
+				}
+			}
+
+			if (min < limit) {
+				draw->update_palette(self->palbuf.get(), min, limit - min);
+			}
+
+			if (self->animating_shapes) {
+				draw->animate();
 			}
 		}
-
-		if (min < limit) {
-			draw->update_palette(self->palbuf.get(), min, limit - min);
-		}
-
-		draw->animate();
 	}
 
 	return G_SOURCE_CONTINUE;
@@ -840,6 +847,11 @@ ExultStudio::ExultStudio(int argc, char** argv)
 	config->value("config/disk/data_path", data_path, EXULT_DATADIR);
 	setup_data_dir(data_path, argv[0]);
 	string datastr;
+
+	config->value("config/estudio/animating_shapes", animating_shapes, animating_shapes);
+	config->value("config/estudio/palette_cycling", palette_cycling, palette_cycling);
+	config->value("config/estudio/translucent_drawing", translucent_drawing, translucent_drawing);
+
 #ifdef MACOSX
 	if (is_system_path_defined("<BUNDLE>")) {
 		datastr = get_system_path("<BUNDLE>");
@@ -2527,7 +2539,10 @@ void ExultStudio::show_unused_shapes(
 
 void ExultStudio::load_xforms() {
 	xforms.clear();
-
+	// If Translucemcy is disabled, do nothing other than clearing the vector
+	if (!translucent_drawing) {
+		return;
+	}
 	// Find the colour nearest to the background that is index 0xFF
 	uint_fast8_t nearest_bg = 0xff;
 
@@ -3191,7 +3206,14 @@ void ExultStudio::open_preferences() {
 	g_object_set_data(G_OBJECT(backgrnd), "user_data", reinterpret_cast<gpointer>(uintptr(background_color)));
 	GtkWidget* win = get_widget("prefs_window");
 	g_signal_connect(G_OBJECT(get_widget("prefs_background")), "draw", G_CALLBACK(on_prefs_background_expose_event), this);
+
+	set_toggle("prefs_transl", translucent_drawing);
+	set_toggle("prefs_palcyc", palette_cycling);
+	set_toggle("prefs_animsh", animating_shapes);
+
 	gtk_widget_set_visible(win, true);
+
+	//	ExultStudio::IsShapeAnimationEnabled()
 }
 
 /*
@@ -3202,25 +3224,34 @@ void ExultStudio::save_preferences() {
 	const char* text = get_text_entry("prefs_image_editor");
 	g_free(image_editor);
 	image_editor = g_strdup(text);
-	config->set("config/estudio/image_editor", image_editor, true);
+	config->set("config/estudio/image_editor", image_editor, false);
 	// Save image type from combobox: 0 = .PNG, 1 = .SHP
 	int         ftype_index = get_optmenu("prefs_image_type");
 	const char* ftype_str   = (ftype_index == 1) ? ".SHP" : ".PNG";
 	g_free(edit_filetype);
 	edit_filetype = g_strdup(ftype_str);
-	config->set("config/estudio/edit_filetype", edit_filetype, true);
+	config->set("config/estudio/edit_filetype", edit_filetype, false);
 	text = get_text_entry("prefs_default_game");
 	g_free(default_game);
 	default_game = g_strdup(text);
-	config->set("config/estudio/default_game", default_game, true);
+	config->set("config/estudio/default_game", default_game, false);
 	GtkWidget* backgrnd = get_widget("prefs_background");
 	set_background_color(reinterpret_cast<uintptr>(g_object_get_data(G_OBJECT(backgrnd), "user_data")));
-	config->set("config/estudio/background_color", background_color, true);
+	config->set("config/estudio/background_color", background_color, false);
 	// Set background color.
-	palbuf[3 * 255]     = (background_color >> 18) & 0x3f;
-	palbuf[3 * 255 + 1] = (background_color >> 10) & 0x3f;
-	palbuf[3 * 255 + 2] = (background_color >> 2) & 0x3f;
-	// Xform loading uses background colour so reload them
+	palbuf[3 * 255]                 = (background_color >> 18) & 0x3f;
+	palbuf[3 * 255 + 1]             = (background_color >> 10) & 0x3f;
+	palbuf[3 * 255 + 2]             = (background_color >> 2) & 0x3f;
+	translucent_drawing             = get_toggle("prefs_transl");
+	palette_cycling                 = get_toggle("prefs_palcyc");
+	const bool was_animating_shapes = animating_shapes;
+	animating_shapes                = get_toggle("prefs_animsh");
+	config->set("config/estudio/translucent_drawing", translucent_drawing ? "yes" : "no", false);
+	config->set("config/estudio/palette_cycling", palette_cycling ? "yes" : "no", false);
+	config->set("config/estudio/animating_shapes", animating_shapes ? "yes" : "no", false);
+	config->write_back();
+
+	// Xform loading uses background colour and translucent rendering options so reload them
 	load_xforms();
 	if (browser) {    // Repaint browser.
 		browser->set_background_color(background_color);
@@ -3228,6 +3259,11 @@ void ExultStudio::save_preferences() {
 	// Update background colour of all Shape_draws
 	for (auto draw : Shape_draw::iteratable) {
 		draw->set_background_color(background_color);
+		auto* chooser = dynamic_cast<Shape_chooser*>(draw);
+		// animating_shapes setting changed so call setup_info on Shape_chooser to resize animated shapes to match the setting change
+		if (was_animating_shapes != animating_shapes && chooser) {
+			chooser->setup_info();
+		}
 	}
 }
 

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -467,8 +467,8 @@ gboolean ExultStudio::on_animation_timeout(gpointer) {
 
 	for (auto draw : Shape_draw::iteratable) {
 		if (auto b = dynamic_cast<Object_browser*>(draw)) {
-			// If its a browser and not current do nothing
-			if (b != self->browser) {
+			// If its a browser and doesn't have a parent do nothing
+			if (!gtk_widget_get_parent(b->get_widget())) {
 				continue;
 			}
 		}

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -440,6 +440,19 @@ void ExultStudio::on_play_button_toggled(GtkToggleButton* button, gpointer user_
 	studio->update_play_button(playing);
 }
 
+gboolean ExultStudio::on_animation_timeout(gpointer ) {
+
+	// call animate on all shapedraws
+
+	for (auto draw : Shape_draw::iteratable)
+	{
+		draw->animate();
+	}
+
+	return G_SOURCE_CONTINUE;
+	
+}
+
 C_EXPORT void on_tile_grid_button_toggled(GtkToggleButton* button, gpointer user_data) {
 	ignore_unused_variable_warning(user_data);
 	ExultStudio::get_instance()->set_tile_grid(gtk_toggle_button_get_active(button));
@@ -900,6 +913,9 @@ ExultStudio::ExultStudio(int argc, char** argv)
 				= g_signal_connect(G_OBJECT(play_button), "toggled", G_CALLBACK(ExultStudio::on_play_button_toggled), this);
 		play_button_signal_id = g_signal_lookup("toggled", GTK_TYPE_TOGGLE_BUTTON);
 	}
+	// start antimation timer
+	animation_timeout_id = g_timeout_add(ANIMATION_TIMEOUT_MS, on_animation_timeout, nullptr);
+	
 	// Set initial state for menus and toolbar - disconnected
 	update_menu_items(false);
 	int w;

--- a/mapedit/studio.cc
+++ b/mapedit/studio.cc
@@ -3179,6 +3179,10 @@ void ExultStudio::save_preferences() {
 	if (browser) {    // Repaint browser.
 		browser->set_background_color(background_color);
 	}
+	// Update background colour of all Shape_draws
+	for (auto draw : Shape_draw::iteratable) {
+		draw->set_background_color(background_color);
+	}
 }
 
 /*

--- a/mapedit/studio.h
+++ b/mapedit/studio.h
@@ -142,6 +142,7 @@ private:
 	Shape_file_info*                 paperdolfile;        // 'paperdol.vga'.
 	Object_browser*                  browser;
 	std::unique_ptr<unsigned char[]> palbuf;    // 3*256 rgb's, each 0-63.
+	std::vector<Xform_palette>       xforms;    // 'xform.tbl'
 	// Barge editor:
 	GtkWidget* bargewin;    // Barge window.
 	int        barge_ctx;
@@ -344,6 +345,10 @@ public:
 		waiting_client     = client;
 	}
 
+	const auto& GetXform() const {
+		return xforms;
+	}
+
 	Shape_group_file* get_cur_groups();
 
 	Shape_preset_file* get_cur_presets() {
@@ -380,6 +385,7 @@ public:
 	void            set_edit_terrain(gboolean terrain);
 	void            set_edit_mode(int md);
 	void            show_unused_shapes(const unsigned char* data, int datalen);
+	void            load_xforms();
 	// Open/create shape files:
 	Shape_file_info* open_shape_file(const char* basename);
 	void             new_shape_file(bool single);

--- a/mapedit/studio.h
+++ b/mapedit/studio.h
@@ -332,6 +332,10 @@ public:
 		return vgafile;
 	}
 
+	auto get_spritefile() {
+		return spritefile;
+	}
+
 	Combo_editor* get_combowin() {
 		return combowin;
 	}

--- a/mapedit/studio.h
+++ b/mapedit/studio.h
@@ -239,16 +239,16 @@ private:
 	int h_at_close;
 
 	// Widgets, Callbacks, HandlerIDs of the main_window
-	GtkWidget*  connect_button;
-	gulong      connect_button_handler_id;
-	gulong      connect_button_signal_id;
-	static void on_connect_button_toggled(GtkToggleButton* button, gpointer user_data);
-	GtkWidget*  play_button;
-	gulong      play_button_handler_id;
-	gulong      play_button_signal_id;
-	static void on_play_button_toggled(GtkToggleButton* button, gpointer user_data);
+	GtkWidget*      connect_button;
+	gulong          connect_button_handler_id;
+	gulong          connect_button_signal_id;
+	static void     on_connect_button_toggled(GtkToggleButton* button, gpointer user_data);
+	GtkWidget*      play_button;
+	gulong          play_button_handler_id;
+	gulong          play_button_signal_id;
+	static void     on_play_button_toggled(GtkToggleButton* button, gpointer user_data);
 	static gboolean on_animation_timeout(gpointer user_data);
-	gulong      animation_timeout_id;
+	gulong          animation_timeout_id;
 
 	constexpr static int ANIMATION_TIMEOUT_MS = 100;
 
@@ -471,7 +471,7 @@ public:
 	static void schedule_btn_clicked(GtkWidget* btn, gpointer data);
 	// Shapes:
 	GdkPixbuf* shape_image(    // The GdkPixbuf should be g_object_unrefed.
-			Vga_file* shpfile, int shnum, int frnum, bool transparent);
+			Vga_file* shpfile, int shnum, int frnum, bool transparent, bool translucent);
 	void       init_equip_window(int recnum);
 	void       save_equip_window();
 	void       open_equip_window(int recnum);

--- a/mapedit/studio.h
+++ b/mapedit/studio.h
@@ -336,10 +336,6 @@ public:
 		return vgafile;
 	}
 
-	auto get_spritefile() {
-		return spritefile;
-	}
-
 	Combo_editor* get_combowin() {
 		return combowin;
 	}

--- a/mapedit/studio.h
+++ b/mapedit/studio.h
@@ -247,6 +247,10 @@ private:
 	gulong      play_button_handler_id;
 	gulong      play_button_signal_id;
 	static void on_play_button_toggled(GtkToggleButton* button, gpointer user_data);
+	static gboolean on_animation_timeout(gpointer user_data);
+	gulong      animation_timeout_id;
+
+	constexpr static int ANIMATION_TIMEOUT_MS = 100;
 
 public:
 	Shape_info* temp_shape_info;    // Backup for preset undo

--- a/mapedit/studio.h
+++ b/mapedit/studio.h
@@ -252,6 +252,10 @@ private:
 
 	constexpr static int ANIMATION_TIMEOUT_MS = 100;
 
+	bool animating_shapes    = true;
+	bool palette_cycling     = true;
+	bool translucent_drawing = true;
+
 public:
 	Shape_info* temp_shape_info;    // Backup for preset undo
 
@@ -670,6 +674,10 @@ public:
 	}
 
 	BaseGameInfo* get_game() const;
+
+	static bool IsShapeAnimationEnabled() {
+		return self->animating_shapes;
+	}
 };
 
 // Utilities:


### PR DESCRIPTION
closes #1013
Only originally meant to implement Translucency but decided to implement palette cycling and then Animation too

Not really much to say about this but I will anyway

Palette cycling and Animation is controlled by a 100 ms g_timeout in the ExultStudio class

The ShapeDraw class now maintains an iterable linked list for every ShapeDraw object. I use this to update the palette and animation for Each ShapeDraw and queue a draw  or perform a render. I also use this to fix a problem where changing the background colour in preference would only affect the current chooser and would not affect any other shape draws that has been created like shape singles in the shape info dialog or  choosers that were viewed and are now inactive 

Shapes from shapes.vga will render translucent based on shape info, other shapes (eg faces and sprites) are generally always painted as translucent because it seems to be more correct. Shape info editor paints the current shape as transparent based on the checkbox state

All three new capabilities have settings to control them. They are all enabled by default. Disabling all three settings should make things act identically to how they were before these changes

Shape Info is now aways loaded.  This shouldn't really have any impact but I thought I should note it

Xform tables are now loaded if Translucency is enabled, When loading xforms I modify the tables so the value  for the background colour (index FF) in each table  is set to the value of the closest colour in the palette. This generally looks fine with the expected quality that xforms give for 8 bit palettized translucency. If the background colour is equally unlike every colour in the palette it may not look great but I have no idea what colour that would even be like. A basic grey background has no problem because there are lots of grey and near grey colours. The xform loading doesn't try to auto generate xform tables if they are missing like Exult does. If someone needs Exult Studio to generate xform tables, IMO, it should be a Tools menu option perhaps with a dialog that would allow setting the RGBA blend parameters to create custom tables

Shape animation is not entirely identical to how things are in exult. Hour based Frame animation is set to advance frame every 10 real seconds instead of the 1 in game hour exult users which would be about 2 and a half real minutes, It seemed a bit slow to replicate it exactly. Random pause on first frame of generic loop animations is not implemented. The way I'm doing things pretty much synchronizes all animations and random pause would require me to do things differently. While not perfect it should be good enough. Changing thins that could affect shape animation will reset the animation and pause it for 2 seconds. Setting a shape chooser to Frames mode disables animation for the chooser.

Shape Browsers will size animated shapes to the maximum size of all frames if animation is enabled.This prevents horrible overlapping of shapes that change size when animating

I added a nested class to ShapeSingle to automate connecting to the changed singals from widgets. To reduce the amoun of boiler plate code needed to do this. Connecting to the signal with my class is as simple as declaring a field in a ShapeSingle class like this:
`	WidgetChangedConnect shape_3d_x    = {"shinfo_xtiles", "changed", on_widget_changed, this};`  The constructor parameters are the widget's id, the signal to listen too, the call back function and the user_data. The object helpfully keeps a pointer to the  widget. Using the example above, you can get the widget with `shape_3d_x.widget` which replaces `shape_3d_x_widget` that we had before

I set the table in the preferences window to be row-homogeneous so my new rows ere the same size as the existing ones. My checkboxes are just so much smaller than the other controls

Video showing all these changes. Everything is disabled at the start showing how things are now and then I enable all settings and the differences can plainly be seen. The Energy field shape is animated and translucent. Enabling animation causes it to be sized to its maximum size and the rest of the row is affected by the change. With the settings off I have it set to frame 15 that causes it to overlap with other shapes


https://github.com/user-attachments/assets/b640cdbf-519e-482b-98c5-6f8f981fdde9

