### PR TITLE
Scaler, surface and layer changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,6 +98,8 @@ EXULTSOURCES =	\
 	palette.h	\
 	party.cc	\
 	party.h		\
+	perf.cc		\
+	perf.h		\
 	paths.cc	\
 	paths.h		\
 	headers/pent_include.h	\

--- a/Makefile.common
+++ b/Makefile.common
@@ -30,6 +30,7 @@ MAIN_OBJS:=actions.o \
 	npctime.o \
 	palette.o \
 	party.o \
+	perf.o \
 	paths.o \
 	playscene.o \
 	readnpcs.o \

--- a/cheat.cc
+++ b/cheat.cc
@@ -1256,7 +1256,7 @@ public:
 			return;
 		}
 		if (layer < 0) {
-			layer = gwin->create_layer(w, h, 255, 0, display_map_layer_z);
+			layer = gwin->create_layer("map", w, h, 255, 0, display_map_layer_z);
 			if (layer < 0) {
 				return;
 			}

--- a/data/bg/defaultkeys.txt
+++ b/data/bg/defaultkeys.txt
@@ -63,6 +63,7 @@ Shift-F3	write_minimap
 Alt-F4		quit
 Alt-Enter	toggle_fullscreen
 Alt-1		sound_tester
+Alt-2       perf_metrics
 Ctrl-Alt-B		toggle_bboxes
 Ctrl-B		shape_browser
 B		useitem			761	# Show spellbook

--- a/data/si/defaultkeys.txt
+++ b/data/si/defaultkeys.txt
@@ -64,6 +64,7 @@ Shift-F3	write_minimap
 Alt-F4		quit
 Alt-Enter	toggle_fullscreen
 Alt-1		sound_tester
+Alt-2       perf_metrics
 Ctrl-Alt-B		toggle_bboxes
 Ctrl-B		shape_browser
 B		useitem			761	# Show spellbook

--- a/drag.cc
+++ b/drag.cc
@@ -333,7 +333,7 @@ void Dragging_info::paint_obj_to_layer() {
 			gwin->destroy_layer(item_layer);
 			item_layer = -1;
 		}
-		item_layer = gwin->create_layer(w, h, 255, 0, item_layer_z);
+		item_layer = gwin->create_layer("item", w, h, 255, 0, item_layer_z);
 		if (item_layer < 0) {
 			return;
 		}

--- a/effects.cc
+++ b/effects.cc
@@ -1176,7 +1176,7 @@ void Text_effect::paint_to_layer() {
 			gwin->destroy_layer(text_layer);
 			text_layer = -1;
 		}
-		text_layer = gwin->create_layer(w, h, 255, 0, text_effect_layer_z);
+		text_layer = gwin->create_layer("Text effect", w, h, 255, 0, text_effect_layer_z);
 		if (text_layer < 0) {
 			return;
 		}

--- a/exult.cc
+++ b/exult.cc
@@ -3116,6 +3116,8 @@ static void apply_ui_layer_config() {
 	apply_named_layer(Image_window::UiLayerModalGumps, "modal_gumps");
 	apply_named_layer(Image_window::UiLayerDisplayMap, "display_map");
 	apply_named_layer(Image_window::UiLayerTextEffects, "text_effect");
+	gwin->set_ui_layer_config(
+			Image_window::UiLayerFullScreenNoScaler, 320, 200, Image_window::NoScaler, Image_window::Fill, Image_window::bilinear,true);
 }
 
 /*

--- a/exult.cc
+++ b/exult.cc
@@ -3116,8 +3116,6 @@ static void apply_ui_layer_config() {
 	apply_named_layer(Image_window::UiLayerModalGumps, "modal_gumps");
 	apply_named_layer(Image_window::UiLayerDisplayMap, "display_map");
 	apply_named_layer(Image_window::UiLayerTextEffects, "text_effect");
-	gwin->set_ui_layer_config(
-			Image_window::UiLayerFullScreenNoScaler, 320, 200, Image_window::NoScaler, Image_window::Fill, Image_window::bilinear,true);
 }
 
 /*

--- a/gamerend.cc
+++ b/gamerend.cc
@@ -32,11 +32,13 @@
 #include "chunks.h"
 #include "drag.h"
 #include "effects.h"
+#include "font.h"
 #include "gameclk.h"
 #include "gamemap.h"
 #include "gamewin.h"
 #include "ignore_unused_variable_warning.h"
 #include "objiter.h"
+#include "perf.h"
 
 #include <algorithm>
 #include <cstdio>
@@ -326,6 +328,8 @@ void Game_render::increment_bbox_index() {
 void Game_window::paint(
 		int x, int y, int w, int h    // Rectangle to cover.
 ) {
+	auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__);
+
 	if (!win->ready()) {
 		return;
 	}

--- a/gamewin.h
+++ b/gamewin.h
@@ -427,8 +427,8 @@ public:
 		return win;
 	}
 
-	int create_layer(int w, int h, unsigned char transparent = 255, int fixed_scale = 0, int z = 0) {
-		return win->create_layer(w, h, transparent, fixed_scale, z);
+	int create_layer(std::string&& name, int w, int h, unsigned char transparent = 255, int fixed_scale = 0, int z = 0) {
+		return win->create_layer(std::move(name), w, h, transparent, fixed_scale, z);
 	}
 
 	void destroy_layer(int handle) {

--- a/gamewin.h
+++ b/gamewin.h
@@ -459,8 +459,8 @@ public:
 		win->layer_set_z(handle, z);
 	}
 
-	void layer_set_dest(int handle, int x, int y, int w, int h) {
-		win->layer_set_dest(handle, x, y, w, h);
+	void layer_set_dest(int handle, int x, int y, int w, int h, bool add = false) {
+		win->layer_set_dest(handle, x, y, w, h, add);
 	}
 
 	void layer_clear_dest(int handle) {
@@ -485,8 +485,9 @@ public:
 	}
 
 	void set_ui_layer_config(
-			Image_window::UiLayerKind kind, int width, int height, int scaler, Image_window::FillMode fmode, int fill_scaler,bool protect=false) {
-		win->set_ui_layer_config(kind, width, height, scaler, fmode, fill_scaler,protect);
+			Image_window::UiLayerKind kind, int width, int height, int scaler, Image_window::FillMode fmode, int fill_scaler,
+			bool protect = false) {
+		win->set_ui_layer_config(kind, width, height, scaler, fmode, fill_scaler, protect);
 	}
 
 	void set_ui_layer_palette(Image_window::UiLayerKind kind, int mode) {

--- a/gamewin.h
+++ b/gamewin.h
@@ -485,8 +485,8 @@ public:
 	}
 
 	void set_ui_layer_config(
-			Image_window::UiLayerKind kind, int width, int height, int scaler, Image_window::FillMode fmode, int fill_scaler) {
-		win->set_ui_layer_config(kind, width, height, scaler, fmode, fill_scaler);
+			Image_window::UiLayerKind kind, int width, int height, int scaler, Image_window::FillMode fmode, int fill_scaler,bool protect=false) {
+		win->set_ui_layer_config(kind, width, height, scaler, fmode, fill_scaler,protect);
 	}
 
 	void set_ui_layer_palette(Image_window::UiLayerKind kind, int mode) {

--- a/gumps/Book_gump.cc
+++ b/gumps/Book_gump.cc
@@ -27,73 +27,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include <typeinfo>
 
-namespace {
-	// Above normal/hud gumps, below modal gumps.
-	constexpr int text_gump_layer_z = (1 << 18) + (1 << 16) + 1;
-
-	bool begin_text_layer_paint(Gump* g, int drawx, int drawy, int& ox, int& oy, int& w, int& h, Image_buffer8*& prev_target) {
-		if (!g) {
-			return false;
-		}
-		Game_window* gwin = Game_window::get_instance();
-		if (!gwin) {
-			return false;
-		}
-		const TileRect r = g->get_rect();
-		w                = r.w;
-		h                = r.h;
-		if (w <= 0 || h <= 0) {
-			return false;
-		}
-		if (g->render_layer < 0 || g->layer_bounds.w != w || g->layer_bounds.h != h) {
-			if (g->render_layer >= 0) {
-				gwin->destroy_layer(g->render_layer);
-				g->render_layer = -1;
-			}
-
-			g->render_layer = gwin->create_layer(typeid(*g).name(), w, h, 255, 0, text_gump_layer_z);
-			if (g->render_layer < 0) {
-				return false;
-			}
-			gwin->layer_set_ui_kind(g->render_layer, Image_window::UiLayerTextGumps);
-		}
-		g->layer_bounds = TileRect(0, 0, w, h);
-		gwin->layer_set_z(g->render_layer, text_gump_layer_z);
-
-		auto* lbuf = gwin->get_layer_ibuf(g->render_layer);
-		if (!lbuf) {
-			return false;
-		}
-		lbuf->clear_clip();
-		lbuf->fill8(255);
-		prev_target = gwin->push_render_target(lbuf);
-		ox          = drawx - r.x;
-		oy          = drawy - r.y;
-		return true;
-	}
-
-	void end_text_layer_paint(Gump* g, int w, int h, Image_buffer8* prev_target) {
-		if (!g) {
-			return;
-		}
-		Game_window* gwin = Game_window::get_instance();
-		if (!gwin || g->render_layer < 0) {
-			return;
-		}
-		gwin->pop_render_target(prev_target);
-		Image_window* iwin = gwin->get_win();
-		const float   f    = iwin->get_ui_scale_factor(Image_window::UiLayerTextGumps);
-		const float   dw   = static_cast<float>(w) * f;
-		const float   dh   = static_cast<float>(h) * f;
-		const float   dx   = (static_cast<float>(iwin->get_display_width()) - dw) / 2.0f;
-		const float   dy   = (static_cast<float>(iwin->get_display_height()) - dh) / 2.0f;
-		gwin->layer_set_dest(
-				g->render_layer, static_cast<int>(dx), static_cast<int>(dy), static_cast<int>(dw), static_cast<int>(dh));
-		gwin->layer_set_visible(g->render_layer, true);
-		gwin->layer_set_dirty(g->render_layer);
-	}
-}    // namespace
-
 /*
  *  Create book display.
  */
@@ -116,7 +49,7 @@ void Book_gump::paint() {
 	int            oy   = 0;
 	int            w    = 0;
 	int            h    = 0;
-	if (!begin_text_layer_paint(this, oldx, oldy, ox, oy, w, h, prev)) {
+	if (!begin_layer_paint(oldx, oldy, ox, oy, w, h, prev)) {
 		return;
 	}
 
@@ -130,5 +63,5 @@ void Book_gump::paint() {
 	x      = oldx;
 	y      = oldy;
 
-	end_text_layer_paint(this, w, h, prev);
+	end_layer_paint(w, h, prev);
 }

--- a/gumps/Book_gump.cc
+++ b/gumps/Book_gump.cc
@@ -25,6 +25,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "game.h"
 #include "gamewin.h"
 
+#include <typeinfo>
+
 namespace {
 	// Above normal/hud gumps, below modal gumps.
 	constexpr int text_gump_layer_z = (1 << 18) + (1 << 16) + 1;
@@ -48,7 +50,8 @@ namespace {
 				gwin->destroy_layer(g->render_layer);
 				g->render_layer = -1;
 			}
-			g->render_layer = gwin->create_layer(w, h, 255, 0, text_gump_layer_z);
+
+			g->render_layer = gwin->create_layer(typeid(*g).name(), w, h, 255, 0, text_gump_layer_z);
 			if (g->render_layer < 0) {
 				return false;
 			}

--- a/gumps/Gump_manager.cc
+++ b/gumps/Gump_manager.cc
@@ -170,7 +170,15 @@ void Gump_manager::render_gump_part_to_layer(Gump* g, int z, int part, bool is_h
 			gwin->destroy_layer(layer);
 			layer = -1;
 		}
-		layer = gwin->create_layer(b.w, b.h, 255, 0, z);
+		std::string layer_name;
+		layer_name.reserve(32);
+		layer_name = typeid(*g).name();
+		if (auto cont = g->get_container()) {
+			layer_name += ":";
+			layer_name += cont->get_name();
+		}
+
+		layer = gwin->create_layer(std::move(layer_name), b.w, b.h, 255, 0, z);
 		if (layer < 0) {
 			return;
 		}

--- a/gumps/Scroll_gump.cc
+++ b/gumps/Scroll_gump.cc
@@ -48,7 +48,7 @@ namespace {
 				gwin->destroy_layer(g->render_layer);
 				g->render_layer = -1;
 			}
-			g->render_layer = gwin->create_layer(w, h, 255, 0, text_gump_layer_z);
+			g->render_layer = gwin->create_layer(typeid(*g).name(), w, h, 255, 0, text_gump_layer_z);
 			if (g->render_layer < 0) {
 				return false;
 			}

--- a/gumps/Scroll_gump.cc
+++ b/gumps/Scroll_gump.cc
@@ -25,72 +25,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "game.h"
 #include "gamewin.h"
 
-namespace {
-	// Above normal/hud gumps, below modal gumps.
-	constexpr int text_gump_layer_z = (1 << 18) + (1 << 16) + 1;
-
-	bool begin_text_layer_paint(Gump* g, int drawx, int drawy, int& ox, int& oy, int& w, int& h, Image_buffer8*& prev_target) {
-		if (!g) {
-			return false;
-		}
-		Game_window* gwin = Game_window::get_instance();
-		if (!gwin) {
-			return false;
-		}
-		const TileRect r = g->get_rect();
-		w                = r.w;
-		h                = r.h;
-		if (w <= 0 || h <= 0) {
-			return false;
-		}
-		if (g->render_layer < 0 || g->layer_bounds.w != w || g->layer_bounds.h != h) {
-			if (g->render_layer >= 0) {
-				gwin->destroy_layer(g->render_layer);
-				g->render_layer = -1;
-			}
-			g->render_layer = gwin->create_layer(typeid(*g).name(), w, h, 255, 0, text_gump_layer_z);
-			if (g->render_layer < 0) {
-				return false;
-			}
-			gwin->layer_set_ui_kind(g->render_layer, Image_window::UiLayerTextGumps);
-		}
-		g->layer_bounds = TileRect(0, 0, w, h);
-		gwin->layer_set_z(g->render_layer, text_gump_layer_z);
-
-		auto* lbuf = gwin->get_layer_ibuf(g->render_layer);
-		if (!lbuf) {
-			return false;
-		}
-		lbuf->clear_clip();
-		lbuf->fill8(255);
-		prev_target = gwin->push_render_target(lbuf);
-		ox          = drawx - r.x;
-		oy          = drawy - r.y;
-		return true;
-	}
-
-	void end_text_layer_paint(Gump* g, int w, int h, Image_buffer8* prev_target) {
-		if (!g) {
-			return;
-		}
-		Game_window* gwin = Game_window::get_instance();
-		if (!gwin || g->render_layer < 0) {
-			return;
-		}
-		gwin->pop_render_target(prev_target);
-		Image_window* iwin = gwin->get_win();
-		const float   f    = iwin->get_ui_scale_factor(Image_window::UiLayerTextGumps);
-		const float   dw   = static_cast<float>(w) * f;
-		const float   dh   = static_cast<float>(h) * f;
-		const float   dx   = (static_cast<float>(iwin->get_display_width()) - dw) / 2.0f;
-		const float   dy   = (static_cast<float>(iwin->get_display_height()) - dh) / 2.0f;
-		gwin->layer_set_dest(
-				g->render_layer, static_cast<int>(dx), static_cast<int>(dy), static_cast<int>(dw), static_cast<int>(dh));
-		gwin->layer_set_visible(g->render_layer, true);
-		gwin->layer_set_dirty(g->render_layer);
-	}
-}    // namespace
-
 /*
  *  Create scroll display.
  */
@@ -113,7 +47,7 @@ void Scroll_gump::paint() {
 	int            oy   = 0;
 	int            w    = 0;
 	int            h    = 0;
-	if (!begin_text_layer_paint(this, oldx, oldy, ox, oy, w, h, prev)) {
+	if (!begin_layer_paint(oldx, oldy, ox, oy, w, h, prev)) {
 		return;
 	}
 
@@ -124,5 +58,5 @@ void Scroll_gump::paint() {
 	x      = oldx;
 	y      = oldy;
 
-	end_text_layer_paint(this, w, h, prev);
+	end_layer_paint(w, h, prev);
 }

--- a/gumps/Sign_gump.cc
+++ b/gumps/Sign_gump.cc
@@ -26,72 +26,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "game.h"
 #include "gamewin.h"
 
-namespace {
-	// Above normal/hud gumps, below modal gumps.
-	constexpr int text_gump_layer_z = (1 << 18) + (1 << 16) + 1;
-
-	bool begin_text_layer_paint(Gump* g, int drawx, int drawy, int& ox, int& oy, int& w, int& h, Image_buffer8*& prev_target) {
-		if (!g) {
-			return false;
-		}
-		Game_window* gwin = Game_window::get_instance();
-		if (!gwin) {
-			return false;
-		}
-		const TileRect r = g->get_rect();
-		w                = r.w;
-		h                = r.h;
-		if (w <= 0 || h <= 0) {
-			return false;
-		}
-		if (g->render_layer < 0 || g->layer_bounds.w != w || g->layer_bounds.h != h) {
-			if (g->render_layer >= 0) {
-				gwin->destroy_layer(g->render_layer);
-				g->render_layer = -1;
-			}
-			g->render_layer = gwin->create_layer(typeid(*g).name(), w, h, 255, 0, text_gump_layer_z);
-			if (g->render_layer < 0) {
-				return false;
-			}
-			gwin->layer_set_ui_kind(g->render_layer, Image_window::UiLayerTextGumps);
-		}
-		g->layer_bounds = TileRect(0, 0, w, h);
-		gwin->layer_set_z(g->render_layer, text_gump_layer_z);
-
-		auto* lbuf = gwin->get_layer_ibuf(g->render_layer);
-		if (!lbuf) {
-			return false;
-		}
-		lbuf->clear_clip();
-		lbuf->fill8(255);
-		prev_target = gwin->push_render_target(lbuf);
-		ox          = drawx - r.x;
-		oy          = drawy - r.y;
-		return true;
-	}
-
-	void end_text_layer_paint(Gump* g, int w, int h, Image_buffer8* prev_target) {
-		if (!g) {
-			return;
-		}
-		Game_window* gwin = Game_window::get_instance();
-		if (!gwin || g->render_layer < 0) {
-			return;
-		}
-		gwin->pop_render_target(prev_target);
-		Image_window* iwin = gwin->get_win();
-		const float   f    = iwin->get_ui_scale_factor(Image_window::UiLayerTextGumps);
-		const float   dw   = static_cast<float>(w) * f;
-		const float   dh   = static_cast<float>(h) * f;
-		const float   dx   = (static_cast<float>(iwin->get_display_width()) - dw) / 2.0f;
-		const float   dy   = (static_cast<float>(iwin->get_display_height()) - dh) / 2.0f;
-		gwin->layer_set_dest(
-				g->render_layer, static_cast<int>(dx), static_cast<int>(dy), static_cast<int>(dw), static_cast<int>(dh));
-		gwin->layer_set_visible(g->render_layer, true);
-		gwin->layer_set_dirty(g->render_layer);
-	}
-}    // namespace
-
 /*
  *  Create a sign gump.
  */
@@ -100,7 +34,7 @@ Sign_gump::Sign_gump(
 		int shapenum,
 		int nlines    // # of text lines.
 		)
-		: Gump(nullptr, shapenum), num_lines(nlines), serpentine(false) {
+		: Text_gump(shapenum), num_lines(nlines), serpentine(false) {
 	// THIS IS A HACK, but don't ask me why this is like this,
 	if (Game::get_game_type() == SERPENT_ISLE && shapenum == 49) {
 		// check for avatar read here
@@ -190,7 +124,7 @@ void Sign_gump::paint() {
 	int            oy   = 0;
 	int            w    = 0;
 	int            h    = 0;
-	if (!begin_text_layer_paint(this, oldx, oldy, ox, oy, w, h, prev)) {
+	if (!begin_layer_paint(oldx, oldy, ox, oy, w, h, prev)) {
 		return;
 	}
 
@@ -229,6 +163,6 @@ void Sign_gump::paint() {
 	x = oldx;
 	y = oldy;
 
-	end_text_layer_paint(this, w, h, prev);
+	end_layer_paint(w, h, prev);
 	gwin->set_painted();
 }

--- a/gumps/Sign_gump.cc
+++ b/gumps/Sign_gump.cc
@@ -49,7 +49,7 @@ namespace {
 				gwin->destroy_layer(g->render_layer);
 				g->render_layer = -1;
 			}
-			g->render_layer = gwin->create_layer(w, h, 255, 0, text_gump_layer_z);
+			g->render_layer = gwin->create_layer(typeid(*g).name(), w, h, 255, 0, text_gump_layer_z);
 			if (g->render_layer < 0) {
 				return false;
 			}

--- a/gumps/Sign_gump.h
+++ b/gumps/Sign_gump.h
@@ -19,14 +19,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifndef SIGN_GUMP_H
 #define SIGN_GUMP_H
 
-#include "Gump.h"
+#include "Text_gump.h"
 
 #include <string>
 
 /*
  *  A sign showing runes.
  */
-class Sign_gump : public Gump {
+class Sign_gump : public Text_gump {
 protected:
 	std::string* lines;    // Lines of text.
 	int          num_lines;

--- a/gumps/Text_gump.cc
+++ b/gumps/Text_gump.cc
@@ -30,6 +30,60 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 using std::strchr;
 
+bool Text_gump::begin_layer_paint(int drawx, int drawy, int& ox, int& oy, int& w, int& h, Image_buffer8*& prev_target) {
+	Game_window* gwin = Game_window::get_instance();
+	if (!gwin) {
+		return false;
+	}
+	const TileRect r = get_rect();
+	w                = r.w;
+	h                = r.h;
+	if (w <= 0 || h <= 0) {
+		return false;
+	}
+	if (render_layer < 0 || layer_bounds.w != w || layer_bounds.h != h) {
+		if (render_layer >= 0) {
+			gwin->destroy_layer(render_layer);
+			render_layer = -1;
+		}
+		render_layer = gwin->create_layer(typeid(*this).name(), w, h, 255, 0, text_gump_layer_z);
+		if (render_layer < 0) {
+			return false;
+		}
+		gwin->layer_set_ui_kind(render_layer, Image_window::UiLayerTextGumps);
+	}
+	layer_bounds = TileRect(0, 0, w, h);
+	gwin->layer_set_z(render_layer, text_gump_layer_z);
+
+	auto* lbuf = gwin->get_layer_ibuf(render_layer);
+	if (!lbuf) {
+		return false;
+	}
+	lbuf->clear_clip();
+	lbuf->fill8(255);
+	prev_target = gwin->push_render_target(lbuf);
+	ox          = drawx - r.x;
+	oy          = drawy - r.y;
+	return true;
+}
+
+void Text_gump::end_layer_paint(int w, int h, Image_buffer8* prev_target) {
+	Game_window* gwin = Game_window::get_instance();
+	if (!gwin || render_layer < 0) {
+		return;
+	}
+	gwin->pop_render_target(prev_target);
+	Image_window* iwin = gwin->get_win();
+	const float   f    = iwin->get_ui_scale_factor(Image_window::UiLayerTextGumps);
+	const float   dw   = static_cast<float>(w) * f;
+	const float   dh   = static_cast<float>(h) * f;
+	const float   dx   = (static_cast<float>(iwin->get_display_width()) - dw) / 2.0f;
+	const float   dy   = (static_cast<float>(iwin->get_display_height()) - dh) / 2.0f;
+	gwin->layer_set_dest(render_layer, static_cast<int>(dx), static_cast<int>(dy), static_cast<int>(dw), static_cast<int>(dh));
+	gwin->layer_set_visible(render_layer, true);
+	gwin->layer_set_dirty(render_layer);
+}
+
 Text_gump::~Text_gump() {
 	delete[] text;
 	free_render_layer();

--- a/gumps/Text_gump.h
+++ b/gumps/Text_gump.h
@@ -47,6 +47,12 @@ public:
 	int  paint_page(const TileRect& box, int start);
 	// Next page of book/scroll.
 	int show_next_page();
-};
 
+protected:
+	bool begin_layer_paint(int drawx, int drawy, int& ox, int& oy, int& w, int& h, class Image_buffer8*& prev_target);
+
+	void end_layer_paint(int w, int h, class Image_buffer8* prev_target);
+	// Above normal/hud gumps, below modal gumps.
+	constexpr static int text_gump_layer_z = (1 << 18) + (1 << 16) + 1;
+};
 #endif

--- a/gumps/UIOptions_gump.cc
+++ b/gumps/UIOptions_gump.cc
@@ -544,7 +544,10 @@ Gump_button* UIOptions_gump::on_button(int mx, int my) {
 
 void UIOptions_gump::build_buttons() {
 	for (int i = id_first_setting; i < id_count; ++i) {
-		buttons[i].reset();
+		// Don't kill the universal button as it may have called us
+		if (i != id_universal) {
+			buttons[i].reset();
+		}
 	}
 
 	std::vector<std::string> size_text = {Strings::Full320x200_(), Strings::Medium420x263_(), Strings::Auto0x0_()};
@@ -581,9 +584,15 @@ void UIOptions_gump::build_buttons() {
 			get_button_pos_for_label(Strings::Fillscaler_()), yForRow(row_fill_scl), 108);
 
 	const std::vector<std::string> yes_no = {Strings::No(), Strings::Yes()};
-	buttons[id_universal]                 = std::make_unique<UIOptions_toggle>(
-            this, &UIOptions_gump::toggle_universal, yes_no, universal ? 1 : 0, get_button_pos_for_label(Strings::AllLayers_()),
-            yForRow(row_universal), 44);
+	// Only create the button if it doesn't exist
+	// If it does exist just change the frame
+	if (auto button = dynamic_cast<UIOptions_toggle*>(buttons[id_universal].get())) {
+		button->set_frame(universal ? 1 : 0);
+	} else {
+		buttons[id_universal] = std::make_unique<UIOptions_toggle>(
+				this, &UIOptions_gump::toggle_universal, yes_no, universal ? 1 : 0, get_button_pos_for_label(Strings::AllLayers_()),
+				yForRow(row_universal), 44);
+	}
 
 	buttons[id_palette] = std::make_unique<UIOptions_toggle>(
 			this, &UIOptions_gump::toggle_palette, palette_options(), palette_to_selection(global_cfg.palette),

--- a/imagewin/ibuf8.h
+++ b/imagewin/ibuf8.h
@@ -28,14 +28,29 @@
  *  An 8-bit image buffer:
  */
 class Image_buffer8 : public Image_buffer {
+	bool bits_owned;
+
 	// Private ctor. for Image_window8.
-	Image_buffer8(unsigned int w, unsigned int h, Image_buffer*) : Image_buffer(w, h, 8) {}
+	Image_buffer8(unsigned int w, unsigned int h, Image_buffer*) : Image_buffer(w, h, 8), bits_owned(false) {}
 
 public:
-	Image_buffer8(unsigned int w, unsigned int h) : Image_buffer(w, h, 8) {
+	Image_buffer8(unsigned int w, unsigned int h) : Image_buffer(w, h, 8), bits_owned(true) {
 		bits = new unsigned char[w * h];
 	}
 	friend class Image_window8;
+
+	// for Image_window::Layer to create a buffer backed by a SDL_Surface with a guard band
+	Image_buffer8(unsigned int w, unsigned int h, unsigned int pitch, unsigned char* bits, int guard_band)
+			: Image_buffer(w - guard_band * 2, h - guard_band * 2, 8), bits_owned(false) {
+		this->line_width = pitch;
+		this->bits       = bits + guard_band + pitch * guard_band;
+	}
+
+	~Image_buffer8() {
+		if (!bits_owned) {
+			bits = nullptr;
+		}
+	}
 
 	/*
 	 *  Depth-independent methods:

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -1638,23 +1638,26 @@ void Image_window::layer_set_alpha(int handle, unsigned char a) {
 	layers[handle]->alpha = a;
 }
 
-void Image_window::layer_set_dest(int handle, int x, int y, int w, int h) {
+void Image_window::layer_set_dest(int handle, int x, int y, int w, int h, bool add) {
 	if (handle < 0 || handle >= static_cast<int>(layers.size()) || !layers[handle]) {
 		return;
 	}
-	Layer& layer   = *layers[handle];
-	layer.has_dest = true;
-	layer.dest.x   = static_cast<float>(x);
-	layer.dest.y   = static_cast<float>(y);
-	layer.dest.w   = static_cast<float>(w);
-	layer.dest.h   = static_cast<float>(h);
+	Layer& layer = *layers[handle];
+	if (layer.dest.empty() || add) {
+		layer.dest.emplace_back();
+	}
+
+	layer.dest.back().x = float(x);
+	layer.dest.back().y = float(y);
+	layer.dest.back().w = float(w);
+	layer.dest.back().h = float(h);
 }
 
 void Image_window::layer_clear_dest(int handle) {
 	if (handle < 0 || handle >= static_cast<int>(layers.size()) || !layers[handle]) {
 		return;
 	}
-	layers[handle]->has_dest = false;
+	layers[handle]->dest.clear();
 }
 
 void Image_window::layer_set_ui_kind(int handle, UiLayerKind kind) {
@@ -1770,12 +1773,16 @@ SDL_Surface* Image_window::get_layer_dst32_surface(unsigned index, int w, int h)
 	return surface;
 }
 
-void Image_window::get_layer_dest(const Layer& layer, SDL_FRect& dst) {
-	if (layer.has_dest) {    // Explicit placement (e.g. the mouse cursor).
-		dst = layer.dest;
-		return;
+bool Image_window::get_layer_dest(const Layer& layer, SDL_FRect& dst, int num) {
+	if (num >= 0 && size_t(num) < layer.dest.size()) {    // Explicit placement (e.g. the mouse cursor).
+		dst = layer.dest[num];
+	} else if (num <= 0) {
+		compute_layer_fill_dest(layer.logw, layer.logh, dst, layer.ui_kind);
+	} else {
+		dst = {0, 0, 0, 0};
+		return false;
 	}
-	compute_layer_fill_dest(layer.logw, layer.logh, dst, layer.ui_kind);
+	return true;
 }
 
 void Image_window::set_ui_config(int width, int height, int scaler_, FillMode fmode, int fill_scaler_) {
@@ -2115,9 +2122,16 @@ void Image_window::composite_layers() {
 		SDL_SetTextureAlphaMod(layer.texture, layer.alpha);
 		SDL_FRect dst, src = {float(guard_band * render_scale), float(guard_band * render_scale), float(layer.logw * render_scale),
 							  float(layer.logh * render_scale)};
-		get_layer_dest(layer, dst);
 
-		SDL_RenderTexture(screen_renderer, layer.texture, &src, &dst);
+		for (int i = 0;; i++) {
+			if (!get_layer_dest(layer, dst, i)) {
+				break;
+			}
+			// Only draw if dest rect is valid
+			if (dst.w > 0 && dst.h > 0) {
+				SDL_RenderTexture(screen_renderer, layer.texture, &src, &dst);
+			}
+		}
 	}
 }
 

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -673,7 +673,6 @@ bool Image_window::create_scale_surfaces(int w, int h, int bpp) {
 	SDL_SetRenderDrawColor(screen_renderer, 0, 0, 0, 255);
 	SDL_RenderClear(screen_renderer);
 	SDL_RenderPresent(screen_renderer);
-
 	int    sbpp;
 	Uint32 sRmask;
 	Uint32 sGmask;
@@ -894,7 +893,7 @@ void Image_window::show(int x, int y, int w, int h) {
 	// Create temporary display_surface from screen_texture;
 	SDL_Surface* display_surface;
 	{
-		auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_LockTextureToSurface");
+		auto perftimer_sltts = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_LockTextureToSurface");
 		SDL_LockTextureToSurface(screen_texture, nullptr, &display_surface);
 	}
 
@@ -905,8 +904,8 @@ void Image_window::show(int x, int y, int w, int h) {
 	if (ibuf->width + 2 * guard_band == draw_surface->w && ibuf->height + 2 * guard_band == draw_surface->h) {
 		// Phase 1 blit from draw_surface to inter_surface
 		if (draw_surface != inter_surface) {
-			auto              perftimer  = PerformanceTimer::GetScopedPerfTimer(__func__, " scaler");
-			const ScalerInfo& sel_scaler = Scalers[scaler];
+			auto              perftimer_s = PerformanceTimer::GetScopedPerfTimer(__func__, " scaler");
+			const ScalerInfo& sel_scaler  = Scalers[scaler];
 
 			const SDL_PixelFormatDetails* inter_surface_format = SDL_GetPixelFormatDetails(inter_surface->format);
 
@@ -947,8 +946,8 @@ void Image_window::show(int x, int y, int w, int h) {
 
 		// Phase 2 blit from inter_surface to display_surface
 		if (inter_surface != display_surface && fill_scaler != SDLScaler) {
-			auto              perftimer  = PerformanceTimer::GetScopedPerfTimer(__func__, " fill scaler");
-			const ScalerInfo& sel_scaler = Scalers[fill_scaler];
+			auto              perftimer_fs = PerformanceTimer::GetScopedPerfTimer(__func__, " fill scaler");
+			const ScalerInfo& sel_scaler   = Scalers[fill_scaler];
 
 			// Just scale entire surfaces
 			if (inter_surface == draw_surface) {
@@ -978,7 +977,7 @@ void Image_window::show(int x, int y, int w, int h) {
 
 		// Just blit the inter surface including guardband to the display surface with no scaling here.
 		else if (fill_scaler == SDLScaler && inter_surface != display_surface) {
-			auto perfcounter = PerformanceTimer::GetScopedPerfTimer(__func__, " sdl fill scaler");
+			auto perfcounter_sfs = PerformanceTimer::GetScopedPerfTimer(__func__, " sdl fill scaler");
 			// display_surface is always as big as or bigger than inter_surface so we copy the entire inter_surface to
 			// display_surface So the scaling can be done when rendering the texture in UpdateRect
 
@@ -2014,13 +2013,13 @@ void Image_window::UpdateRect(SDL_FRect* srcRect) {
 	// Seem to get flicker like crazy or some other ill effect no matter
 	// what I try. -Lanica 08/28/2013
 	{
-		auto perfcounter = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_RenderTexture");
+		auto perfcounter_srt = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_RenderTexture");
 		SDL_RenderTexture(screen_renderer, screen_texture, srcRect, nullptr);
 	}
 	// Draw overlay layers on top of the main image, before presenting.
 	composite_layers();
 	{
-		auto perfcounter = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_RenderPresent");
+		auto perfcounter_srp = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_RenderPresent");
 		SDL_RenderPresent(screen_renderer);
 	}
 }

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -34,6 +34,8 @@ Boston, MA  02111-1307, USA.
 #include "Configuration.h"
 #include "PointScaler.h"
 #include "common_types.h"
+#include "exceptions.h"
+#include "gamewin.h"
 #include "istring.h"
 #include "items.h"
 #include "manip.h"
@@ -553,102 +555,16 @@ void Image_window::create_surface(unsigned int w, unsigned int h) {
 		// Try fallback to point scaler if it failed, if it doesn't work, we
 		// probably can't run
 		scaler = point;
-		try_scaler(w, h);
-	}
-
-	if (!paletted_surface && !force_bpp) {    // No scaling, or failed?
-		uint32 flags = SDL_WINDOW_HIGH_PIXEL_DENSITY;
-		if (screen_window != nullptr) {
-			SDL_SetWindowSize(screen_window, w / scale, h / scale);
-#if 0
-			{
-				SDL_DisplayMode closest_mode;
-				// This does not appear to have any effect
-				if (SDL_GetClosestFullscreenDisplayMode(
-							SDL_GetPrimaryDisplay(), w / scale, h / scale, 0.0,
-							true, &closest_mode)) {
-					SDL_SetWindowFullscreenMode(screen_window, &closest_mode);
-				}
-			}
-#endif
-			SDL_SetWindowFullscreen(screen_window, fullscreen);
-		} else {
-			screen_window = SDL_CreateWindow("", w / scale, h / scale, flags);
-#if 0
-			{
-				SDL_DisplayMode closest_mode;
-				// This does not appear to have any effect
-				if (SDL_GetClosestFullscreenDisplayMode(
-							SDL_GetPrimaryDisplay(), w / scale, h / scale, 0.0,
-							true, &closest_mode)) {
-					SDL_SetWindowFullscreenMode(screen_window, &closest_mode);
-				}
-			}
-#endif
-			SDL_SetWindowFullscreen(screen_window, fullscreen);
-		}
-		if (screen_window == nullptr) {
-			cout << "Couldn't create window: " << SDL_GetError() << std::endl;
-		}
-
-		if (screen_renderer == nullptr) {
-			screen_renderer = SDL_CreateRenderer(screen_window, nullptr);
-		}
-		if (screen_renderer == nullptr) {
-			cout << "Couldn't create renderer: " << SDL_GetError() << std::endl;
-		}
-		int vsync = 1;
-		config->value("config/video/vsync", vsync, vsync);
-		SDL_SetRenderVSync(screen_renderer, vsync);
-		// Do an initial draw/fill
-		SDL_SetRenderDrawColor(screen_renderer, 0, 0, 0, 255);
-		SDL_RenderClear(screen_renderer);
-		SDL_RenderPresent(screen_renderer);
-
-		int    sbpp;
-		Uint32 sRmask;
-		Uint32 sGmask;
-		Uint32 sBmask;
-		Uint32 sAmask;
-		SDL_GetMasksForPixelFormat(desktop_displaymode.format, &sbpp, &sRmask, &sGmask, &sBmask, &sAmask);
-		display_surface
-				= SDL_CreateSurface((w / scale), (h / scale), SDL_GetPixelFormatForMasks(sbpp, sRmask, sGmask, sBmask, sAmask));
-		if (display_surface == nullptr) {
-			cout << "Couldn't create display surface: " << SDL_GetError() << std::endl;
-		}
-		if (screen_texture == nullptr) {
-			screen_texture = SDL_CreateTexture(
-					screen_renderer, desktop_displaymode.format, SDL_TEXTUREACCESS_STREAMING, (w / scale), (h / scale));
-		}
-		if (screen_texture == nullptr) {
-			cout << "Couldn't create texture: " << SDL_GetError() << std::endl;
-		}
-		SDL_SetTextureBlendMode(screen_texture, SDL_BLENDMODE_NONE);
-		inter_surface = draw_surface = paletted_surface = display_surface;
-		inter_width                                     = w / scale;
-		inter_height                                    = h / scale;
-		scale                                           = 1;
-	}
-	if (!paletted_surface) {
-		cerr << "Couldn't set video mode (" << w << ", " << h << ") at " << ibuf->depth
-			 << " bpp depth: " << (force_bpp ? "" : SDL_GetError()) << endl;
-		if (w == 640 && h == 480) {
-			exit(-1);
-		} else {
-			cerr << "Attempting fallback to 640x480. Good luck..." << endl;
-			scale = 2;
-			create_surface(640, 480);
-			return;
+		if (!try_scaler(w, h)) {
+			throw exult_exception("Failed to creat Display Sorfaces");
 		}
 	}
 
 	ibuf->width  = draw_surface->w;
 	ibuf->height = draw_surface->h;
 
-	if (draw_surface != display_surface) {
-		ibuf->width -= guard_band * 2;
-		ibuf->height -= guard_band * 2;
-	}
+	ibuf->width -= guard_band * 2;
+	ibuf->height -= guard_band * 2;
 
 	// Update line size in words.
 	ibuf->line_width = draw_surface->pitch / ibuf->pixel_size;
@@ -657,9 +573,7 @@ void Image_window::create_surface(unsigned int w, unsigned int h) {
 	ibuf->offset_y = (get_full_height() - get_game_height()) / 2;
 	ibuf->bits     = static_cast<unsigned char*>(draw_surface->pixels) - get_start_x() - get_start_y() * ibuf->line_width;
 	// Scaler guardband is in effect
-	if (draw_surface != display_surface) {
-		ibuf->bits += guard_band + ibuf->line_width * guard_band;
-	}
+	ibuf->bits += guard_band + ibuf->line_width * guard_band;
 }
 
 /*
@@ -767,22 +681,15 @@ bool Image_window::create_scale_surfaces(int w, int h, int bpp) {
 	Uint32 sAmask;
 	SDL_GetMasksForPixelFormat(desktop_displaymode.format, &sbpp, &sRmask, &sGmask, &sBmask, &sAmask);
 
-	display_surface = SDL_CreateSurface(w, h, SDL_GetPixelFormatForMasks(sbpp, sRmask, sGmask, sBmask, sAmask));
-	if (display_surface == nullptr) {
-		cout << "Couldn't create display surface: " << SDL_GetError() << std::endl;
-	}
 	if (screen_texture == nullptr) {
-		screen_texture = SDL_CreateTexture(screen_renderer, desktop_displaymode.format, SDL_TEXTUREACCESS_STREAMING, w, h);
+		screen_texture = SDL_CreateTexture(
+				screen_renderer, desktop_displaymode.format, SDL_TEXTUREACCESS_STREAMING,
+				std::max(inter_width, w) + 2 * guard_band * scale, std::max(inter_height, h) + 2 * guard_band * scale);
 	}
 	if (screen_texture == nullptr) {
 		cout << "Couldn't create texture: " << SDL_GetError() << std::endl;
 	}
 	SDL_SetTextureBlendMode(screen_texture, SDL_BLENDMODE_NONE);
-	if (!display_surface) {
-		cerr << "Unable to set video mode to" << w << "x" << h << " " << hwdepth << " bpp" << endl;
-		free_surface();
-		return false;
-	}
 
 	int draw_width  = inter_width / scale + 2 * guard_band;
 	int draw_height = inter_height / scale + 2 * guard_band;
@@ -798,17 +705,12 @@ bool Image_window::create_scale_surfaces(int w, int h, int bpp) {
 	}
 
 	// Scale using 'fill_scaler' only
-	if (fill_scaler != SDLScaler && (scaler == fill_scaler || scale == 1)) {
+	if (scaler == fill_scaler || scale == 1 || (fill_scaler == SDLScaler && scaler == bilinear)) {
 		inter_surface = draw_surface;
 	} else if (inter_width != w || inter_height != h) {
-		const SDL_PixelFormatDetails* display_surface_format = SDL_GetPixelFormatDetails(display_surface->format);
-		int                           i_width                = inter_width + 2 * scale * guard_band;
-		int                           i_height               = inter_height + 2 * scale * guard_band;
-		if (!(inter_surface = SDL_CreateSurface(
-					  i_width, i_height,
-					  SDL_GetPixelFormatForMasks(
-							  hwdepth, display_surface_format->Rmask, display_surface_format->Gmask, display_surface_format->Bmask,
-							  display_surface_format->Amask)))) {
+		int i_width  = inter_width + 2 * scale * guard_band;
+		int i_height = inter_height + 2 * scale * guard_band;
+		if (!(inter_surface = SDL_CreateSurface(i_width, i_height, desktop_displaymode.format))) {
 			cerr << "Couldn't create inter surface: " << SDL_GetError() << endl;
 			free_surface();
 			return false;
@@ -816,14 +718,10 @@ bool Image_window::create_scale_surfaces(int w, int h, int bpp) {
 	}
 	// Scale using 'scaler' only
 	else {
-		inter_surface = display_surface;
+		inter_surface = nullptr;
 	}
 
-	if ((uses_palette = (bpp == 8))) {
-		paletted_surface = display_surface;
-	} else {
-		paletted_surface = draw_surface;
-	}
+	paletted_surface = draw_surface;
 
 	return true;
 }
@@ -846,35 +744,21 @@ bool Image_window::try_scaler(int w, int h) {
 		return false;
 	}
 
-	bool has8  = ibuf->depth == 8 && info->fun8to8 && (force_bpp == 0 || force_bpp == 8);
 	bool has16 = ibuf->depth == 8 && info->fun8to16 && (force_bpp == 0 || force_bpp == 16);
 	bool has32 = ibuf->depth == 8 && info->fun8to32 && (force_bpp == 0 || force_bpp == 32);
 
 	if (info->arb) {
-		has8 |= (force_bpp == 0 || force_bpp == 8) && info->arb->Support8bpp(ibuf->depth);
 		has16 |= (force_bpp == 0 || force_bpp == 16) && info->arb->Support16bpp(ibuf->depth);
 		has32 |= (force_bpp == 0 || force_bpp == 32) && info->arb->Support32bpp(ibuf->depth);
 	}
 
-	// First try best of 16 bit/32 bit scaler
-	if (has16 && has32 && create_scale_surfaces(w, h, 0)) {
-		return true;
+	// 16 and 32 bit both un supported means this scaler is unuusable so bail
+	if (!has16 && !has32) {
+		return false;
 	}
-
-	if (has16 && create_scale_surfaces(w, h, 16)) {
-		return true;
-	}
-
-	if (has32 && create_scale_surfaces(w, h, 32)) {
-		return true;
-	}
-
-	// 8bit display output is mostly deprecated!
-	if (has8 && create_scale_surfaces(w, h, 8)) {
-		return true;
-	}
-
-	return false;
+	// If both 16 and 32 bit supported allow create_scale_surfaces to select bpp
+	// otherwise try 16 or 32 as suppoprted by the scaler
+	return create_scale_surfaces(w, h, has16 && has32 ? 0 : has16 ? 16 : 32);
 }
 
 /*
@@ -882,11 +766,8 @@ bool Image_window::try_scaler(int w, int h) {
  */
 
 void Image_window::free_surface() {
-	if (inter_surface != nullptr && inter_surface != display_surface && inter_surface != draw_surface) {
+	if (inter_surface != nullptr && inter_surface != draw_surface) {
 		SDL_DestroySurface(inter_surface);
-	}
-	if (display_surface != nullptr && display_surface != draw_surface) {
-		SDL_DestroySurface(display_surface);
 	}
 	if (draw_surface != nullptr) {
 		SDL_DestroySurface(draw_surface);
@@ -898,7 +779,6 @@ void Image_window::free_surface() {
 	paletted_surface = nullptr;
 	inter_surface    = nullptr;
 	draw_surface     = nullptr;
-	display_surface  = nullptr;
 	ibuf->bits       = nullptr;
 	free_layer_textures();
 	if (screen_renderer != nullptr) {
@@ -970,10 +850,10 @@ void Image_window::show(int x, int y, int w, int h) {
 	x -= get_start_x();
 	y -= get_start_y();
 
-	// we can only include guard band in the buffersize if inter_surface is not
-	// display_surface otherwise scalers will write out of bounds. A separate
-	// inter_surface has a guardband but display_surface does not
-	int gb = (inter_surface != display_surface) ? guard_band : 0;
+	// we can only include guard band in the buffersize if inter_surface is being used
+	// otherwise scalers will write out of bounds. A separate
+	// inter_surface has a guardband but screen_texture does not
+	int gb = guard_band;
 	//  Include guardband when comparing to width and height so the whole buffer
 	//  can still be used if it is not a muliple of 4
 	int buffer_w = get_full_width() + gb;
@@ -1007,6 +887,15 @@ void Image_window::show(int x, int y, int w, int h) {
 	if (h + y > buffer_h) {
 		h = buffer_h - y;
 	}
+	// Create temporary display_surface from screen_texture;
+	SDL_Surface* display_surface;
+	{
+		auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_LockTextureToSurface");
+		SDL_LockTextureToSurface(screen_texture, nullptr, &display_surface);
+	}
+
+	// inter_surface is not null use that, otherwise set it to the temporary display_surface
+	inter_surface = inter_surface ? inter_surface : display_surface;
 
 	// No scaling if ibuf and draw_surface are not the same size
 	if (ibuf->width + 2 * guard_band == draw_surface->w && ibuf->height + 2 * guard_band == draw_surface->h) {
@@ -1016,11 +905,6 @@ void Image_window::show(int x, int y, int w, int h) {
 			const ScalerInfo& sel_scaler = Scalers[scaler];
 
 			const SDL_PixelFormatDetails* inter_surface_format = SDL_GetPixelFormatDetails(inter_surface->format);
-			// Need to apply an offset to compensate for the guard_band
-			if (inter_surface == display_surface) {
-				inter_surface->pixels = static_cast<uint8*>(inter_surface->pixels) - inter_surface->pitch * guard_band * scale
-										- inter_surface_format->bytes_per_pixel * guard_band * scale;
-			}
 
 			if (sel_scaler.arb) {
 				if (!sel_scaler.arb->Scale(
@@ -1051,12 +935,6 @@ void Image_window::show(int x, int y, int w, int h) {
 				(this->*show_scaled)(x, y, w, h);
 			}
 
-			// Undo guard_band offset
-			if (inter_surface == display_surface) {
-				inter_surface->pixels = static_cast<uint8*>(inter_surface->pixels) + inter_surface->pitch * guard_band * scale
-										+ inter_surface_format->bytes_per_pixel * guard_band * scale;
-			}
-
 			x *= scale;
 			y *= scale;
 			w *= scale;
@@ -1081,51 +959,53 @@ void Image_window::show(int x, int y, int w, int h) {
 				h = inter_height;
 			}
 
-			if (!sel_scaler.arb
-				|| !sel_scaler.arb->Scale(
-						inter_surface, x, y, w, h, display_surface, 0, 0, display_surface->w, display_surface->h, false)) {
-				Scalers[point].arb->Scale(
-						inter_surface, x, y, w, h, display_surface, 0, 0, display_surface->w, display_surface->h, false);
+			int dw = display_surface->w - 2 * guard_band * scale;
+			int dh = display_surface->h - 2 * guard_band * scale;
+
+			if (!sel_scaler.arb || !sel_scaler.arb->Scale(inter_surface, x, y, w, h, display_surface, 0, 0, dw, dh, false)) {
+				Scalers[point].arb->Scale(inter_surface, x, y, w, h, display_surface, 0, 0, dw, dh, false);
 			}
 
 			x = 0;
 			y = 0;
-			w = display_surface->w;
-			h = display_surface->h;
+			w = dw;
+			h = dh;
 		}
-	}
-	// When using the fill scaler path, 'inter_surface' may differ from the
-	// display size (e.g. AspectCorrectCentre), so uploading it directly may not
-	// match the display texture dimensions. Resolve to display_surface first.
-	if (fill_scaler == SDLScaler && inter_surface != display_surface) {
-		auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__, " sdl fill scaler");
-		int  sx;
-		int  sy;
-		int  sw;
-		int  sh;
-		if (inter_surface == draw_surface) {
-			sx = guard_band;
-			sy = guard_band;
-			sw = get_full_width();
-			sh = get_full_height();
-		} else {
-			sx = guard_band * scale;
-			sy = guard_band * scale;
-			sw = inter_width;
-			sh = inter_height;
-		}
-		if (!Scalers[fill_scaler].arb
-			|| !Scalers[fill_scaler].arb->Scale(
-					inter_surface, sx, sy, sw, sh, display_surface, 0, 0, display_surface->w, display_surface->h, false)) {
-			const SDL_Rect src = {sx, sy, sw, sh};
-			const SDL_Rect dst = {0, 0, display_surface->w, display_surface->h};
-			SDL_BlitSurfaceScaled(inter_surface, &src, display_surface, &dst, SDL_SCALEMODE_LINEAR);
+
+		// Just blit the inter surface including guardband to the display surface with no scaling here.
+		else if (fill_scaler == SDLScaler && inter_surface != display_surface) {
+			auto perfcounter = PerformanceTimer::GetScopedPerfTimer(__func__, " sdl fill scaler");
+			// display_surface is always as big as or bigger than inter_surface so we copy the entire inter_surface to
+			// display_surface So the scaling can be done when rendering the texture in UpdateRect
+
+			if (inter_surface == draw_surface) {
+				x = guard_band;
+				y = guard_band;
+				w = get_full_width();
+				h = get_full_height();
+			} else {
+				x = guard_band * scale;
+				y = guard_band * scale;
+				w = inter_width;
+				h = inter_height;
+			}
+			// Copy everything
+			SDL_BlitSurface(inter_surface, nullptr, display_surface, nullptr);
 		}
 	}
 
-	// Phase 3 blit high res draw surface on top of display_surface
-	// Phase 4 notify SDL
-	UpdateRect(display_surface);
+	// Phase 3 call UpdateRect to render screen_texture
+	SDL_FRect toupdate;
+	toupdate.x = x;
+	toupdate.y = y;
+	toupdate.w = w;
+	toupdate.h = h;
+	// reset inter_surface back to nullptr if it was set to the temporary display_surface that is about to be destroyed
+	if (inter_surface == display_surface) {
+		inter_surface = nullptr;
+	}
+	SDL_UnlockTexture(screen_texture);
+	UpdateRect(&toupdate);
 }
 
 /*
@@ -1135,8 +1015,8 @@ void Image_window::toggle_fullscreen() {
 	int w;
 	int h;
 
-	w = display_surface->w;
-	h = display_surface->h;
+	w = screen_texture->w;
+	h = screen_texture->h;
 
 	if (fullscreen) {
 		cout << "Switching to windowed mode." << endl;
@@ -1278,11 +1158,11 @@ void Image_window::set_title(const char* title) {
 }
 
 int Image_window::get_display_width() {
-	return display_surface->w;
+	return screen_texture->w - 2 * guard_band * scale;
 }
 
 int Image_window::get_display_height() {
-	return display_surface->h;
+	return screen_texture->h - 2 * guard_band * scale;
 }
 
 void Image_window::screen_to_game(int sx, int sy, bool fast, int& gx, int& gy) {
@@ -1912,8 +1792,8 @@ int Image_window::get_ui_height(UiLayerKind kind) const {
 }
 
 void Image_window::compute_fill_dest(int logw, int logh, FillMode fmode, int escl, SDL_FRect& dst) const {
-	const int dw = display_surface ? display_surface->w : logw;
-	const int dh = display_surface ? display_surface->h : logh;
+	const int dw = screen_texture ? screen_texture->w : logw;
+	const int dh = screen_texture ? screen_texture->h : logh;
 	double    cw;
 	double    ch;
 	if (logw <= 0 || logh <= 0) {
@@ -2124,28 +2004,19 @@ void Image_window::composite_layers() {
 	}
 }
 
-void Image_window::UpdateRect(SDL_Surface* surf) {
-	auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__);
+void Image_window::UpdateRect(SDL_FRect* srcRect) {
+	auto perfcounter = PerformanceTimer::GetScopedPerfTimer(__func__);
 	// TODO: Only update the necessary portion of the screen.
 	// Seem to get flicker like crazy or some other ill effect no matter
 	// what I try. -Lanica 08/28/2013
 	{
-		auto                          perftimer   = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_UpdateTexture");
-		const SDL_PixelFormatDetails* surf_format = SDL_GetPixelFormatDetails(surf->format);
-		uint8*                        pixels
-				= (surf == display_surface ? static_cast<uint8*>(surf->pixels)
-										   : static_cast<uint8*>(surf->pixels) + guard_band * scale * surf_format->bytes_per_pixel
-													 + guard_band * scale * surf->pitch);
-		SDL_UpdateTexture(screen_texture, nullptr, pixels, surf->pitch);
-	}
-	{
-		auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_RenderTexture");
-		SDL_RenderTexture(screen_renderer, screen_texture, nullptr, nullptr);
+		auto perfcounter = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_RenderTexture");
+		SDL_RenderTexture(screen_renderer, screen_texture, srcRect, nullptr);
 	}
 	// Draw overlay layers on top of the main image, before presenting.
 	composite_layers();
 	{
-		auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_RenderPresent");
+		auto perfcounter = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_RenderPresent");
 		SDL_RenderPresent(screen_renderer);
 	}
 }
@@ -2167,7 +2038,7 @@ int Image_window::VideoModeOK(int width, int height, bool fullscreen, int bpp) {
 		Uint32                 Bmask;
 		Uint32                 Amask;
 		if (SDL_GetMasksForPixelFormat(mode->format, &nbpp, &Rmask, &Gmask, &Bmask, &Amask) && mode->w >= width && mode->h >= height
-			&& ((bpp == nbpp) || (bpp == 0 && (nbpp == 8 || nbpp == 16 || nbpp == 32)))) {
+			&& ((bpp == nbpp) || (bpp == 0 && (nbpp == 16 || nbpp == 32)))) {
 			return nbpp;
 		}
 		return 0;
@@ -2181,7 +2052,7 @@ int Image_window::VideoModeOK(int width, int height, bool fullscreen, int bpp) {
 		Uint32 Bmask;
 		Uint32 Amask;
 		if (SDL_GetMasksForPixelFormat(modes[j]->format, &nbpp, &Rmask, &Gmask, &Bmask, &Amask) && modes[j]->w == width
-			&& modes[j]->h == height && ((bpp == nbpp) || (bpp == 0 && (nbpp == 8 || nbpp == 16 || nbpp == 32)))) {
+			&& modes[j]->h == height && ((bpp == nbpp) || (bpp == 0 && (nbpp == 16 || nbpp == 32)))) {
 			SDL_free(modes);
 			return nbpp;
 		}

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -36,6 +36,7 @@ Boston, MA  02111-1307, USA.
 #include "common_types.h"
 #include "exceptions.h"
 #include "gamewin.h"
+#include "ibuf8.h"
 #include "istring.h"
 #include "items.h"
 #include "manip.h"
@@ -1543,12 +1544,17 @@ int Image_window::create_layer(std::string&& name, int w, int h, unsigned char t
 	if (w <= 0 || h <= 0) {
 		return -1;
 	}
-	std::unique_ptr<Image_buffer> buf = create_buffer(w, h);
-	if (!buf) {
+	auto surface = SDL_CreateSurface(w + 2 * guard_band, h + 2 * guard_band, SDL_PIXELFORMAT_INDEX8);
+	if (!surface) {
 		return -1;
 	}
-	buf->fill8(transparent);    // Start fully transparent.
-	auto layer = std::make_unique<Layer>(std::move(buf), w, h, transparent, fixed_scale, z, std::move(name));
+	// Make sure the surface has a palette
+	if (!SDL_CreateSurfacePalette(surface)) {
+		return -1;
+	}
+
+	auto layer = std::make_unique<Layer>(surface, w, h, transparent, fixed_scale, z, std::move(name));
+	layer->get_ibuf()->fill8(transparent);    // Start fully transparent.
 	// Reuse a freed slot if there is one, so handles stay stable.
 	for (size_t i = 0; i < layers.size(); i++) {
 		if (!layers[i]) {
@@ -1563,9 +1569,6 @@ int Image_window::create_layer(std::string&& name, int w, int h, unsigned char t
 void Image_window::destroy_layer(int handle) {
 	if (handle < 0 || handle >= static_cast<int>(layers.size()) || !layers[handle]) {
 		return;
-	}
-	if (layers[handle]->texture) {
-		SDL_DestroyTexture(layers[handle]->texture);
 	}
 	layers[handle].reset();
 }
@@ -1782,6 +1785,7 @@ void Image_window::set_ui_config(int width, int height, int scaler_, FillMode fm
 	cfg.scaler      = scaler_;
 	cfg.fill_mode   = fmode;
 	cfg.fill_scaler = fill_scaler_;
+	cfg.protect     = false;
 	for (int i = 0; i < NumUiLayerKinds; ++i) {
 		if (!ui_cfgs[i].protect) {
 			ui_cfgs[i] = cfg;
@@ -1791,7 +1795,8 @@ void Image_window::set_ui_config(int width, int height, int scaler_, FillMode fm
 	mark_all_layers_dirty();
 }
 
-void Image_window::set_ui_layer_config(UiLayerKind kind, int width, int height, int scaler_, FillMode fmode, int fill_scaler_, bool protect) {
+void Image_window::set_ui_layer_config(
+		UiLayerKind kind, int width, int height, int scaler_, FillMode fmode, int fill_scaler_, bool protect) {
 	if (kind < UiLayerDefault || kind >= NumUiLayerKinds) {
 		return;
 	}
@@ -1801,12 +1806,12 @@ void Image_window::set_ui_layer_config(UiLayerKind kind, int width, int height, 
 	if (cfg.protect && !protect) {
 		return;
 	}
-	cfg.width          = width;
-	cfg.height         = height;
-	cfg.scaler         = scaler_;
-	cfg.fill_mode      = fmode;
-	cfg.fill_scaler    = fill_scaler_;
-	cfg.protect        = protect;
+	cfg.width       = width;
+	cfg.height      = height;
+	cfg.scaler      = scaler_;
+	cfg.fill_mode   = fmode;
+	cfg.fill_scaler = fill_scaler_;
+	cfg.protect     = protect;
 	mark_all_layers_dirty();
 }
 
@@ -2093,12 +2098,13 @@ void Image_window::composite_layers() {
 		layer.render_scale = render_scale;
 		if (layer.texture == nullptr) {    // Lazily (re)create the GPU texture.
 			layer.texture = SDL_CreateTexture(
-					screen_renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, layer.logw * render_scale,
-					layer.logh * render_scale);
+					screen_renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING,
+					(layer.logw + 2 * guard_band + 2) * render_scale, (layer.logh + 2 * guard_band) * render_scale);
 			if (layer.texture == nullptr) {
 				continue;
 			}
-			SDL_SetTextureBlendMode(layer.texture, SDL_BLENDMODE_BLEND);
+
+			SDL_SetTextureBlendMode(layer.texture, layer.is_opaque() ? SDL_BLENDMODE_NONE : SDL_BLENDMODE_BLEND);
 			layer.dirty = true;
 		}
 		SDL_SetTextureScaleMode(layer.texture, smode);
@@ -2107,9 +2113,12 @@ void Image_window::composite_layers() {
 			layer.dirty = false;
 		}
 		SDL_SetTextureAlphaMod(layer.texture, layer.alpha);
-		SDL_FRect dst;
+		SDL_FRect dst, src = {float(guard_band * render_scale), float(guard_band * render_scale), float(layer.logw * render_scale),
+							  float(layer.logh * render_scale)};
 		get_layer_dest(layer, dst);
-		SDL_RenderTexture(screen_renderer, layer.texture, nullptr, &dst);
+
+		// SDL_RenderTexture(screen_renderer, layer.texture, nullptr, &dst);
+		SDL_RenderTexture(screen_renderer, layer.texture, &src, &dst);
 	}
 }
 
@@ -2198,3 +2207,18 @@ int Image_window::VideoModeOK(int width, int height, bool fullscreen, int bpp) {
 }
 
 SDL_DisplayMode Image_window::desktop_displaymode;
+
+Image_window::Layer::~Layer() {
+	if (texture) {
+		SDL_DestroyTexture(texture);
+	}
+	if (surface) {
+		SDL_DestroySurface(surface);
+	}
+}
+
+Image_window::Layer::Layer(SDL_Surface* surface, int w, int h, unsigned char transp, int fscale, int zorder, std::string&& name)
+		: surface(surface),
+		  buf(std::make_unique<Image_buffer8>(
+				  surface->w, surface->h, surface->pitch, reinterpret_cast<unsigned char*>(surface->pixels), guard_band)),
+		  logw(w), logh(h), fixed_scale(fscale), transparent(transp), z(zorder), name(std::move(name)) {}

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -746,6 +746,11 @@ bool Image_window::create_scale_surfaces(int w, int h, int bpp) {
 
 	paletted_surface = draw_surface;
 
+	// Set UI config for UiLayerGameWorldCoords
+
+	set_ui_layer_config(UiLayerFullScreenBilinear, w, h, NoScaler, Fill, bilinear, true);
+	set_ui_layer_config(UiLayerFullScreenPoint, w, h, NoScaler, Fill, point, true);
+
 	return true;
 }
 

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -811,6 +811,13 @@ void Image_window::free_surface() {
 		SDL_DestroyRenderer(screen_renderer);
 	}
 	screen_renderer = nullptr;
+
+	for (auto& surf : layer_dst32_surfaces) {
+		if (surf) {
+			SDL_DestroySurface(surf);
+			surf = nullptr;
+		}
+	}
 }
 
 /*
@@ -1733,6 +1740,31 @@ bool Image_window::scale_layer_color(const Layer& layer, SDL_Surface* src8, int 
 	ibuf->height     = save_height;
 	scale            = save_scale;
 	return true;
+}
+
+SDL_Surface* Image_window::get_layer_dst32_surface(unsigned index, int w, int h) {
+	if (index >= std::size(layer_dst32_surfaces)) {
+		return nullptr;
+	}
+
+	SDL_Surface*& surface = layer_dst32_surfaces[index];
+
+	if (surface && (surface->w < w || surface->h < h)) {
+		SDL_DestroySurface(surface);
+		surface = nullptr;
+	}
+
+	// Create a new surface
+	if (!surface) {
+		surface = SDL_CreateSurface(w, h, SDL_PIXELFORMAT_ARGB8888);
+	}
+
+	if (surface) {
+		// zero fill the surface
+		SDL_FillSurfaceRect(surface, nullptr, 0);
+	}
+
+	return surface;
 }
 
 void Image_window::get_layer_dest(const Layer& layer, SDL_FRect& dst) {

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -668,10 +668,16 @@ bool Image_window::create_scale_surfaces(int w, int h, int bpp) {
 				SDL_WINDOWPOS_CENTERED_DISPLAY(original_displayID));
 		SDL_SetRenderLogicalPresentation(screen_renderer, w, h, SDL_LOGICAL_PRESENTATION_LETTERBOX);
 	}
+	display_width  = w;
+	display_height = h;
 
 	// Do an initial draw/fill
 	SDL_SetRenderDrawColor(screen_renderer, 0, 0, 0, 255);
 	SDL_RenderClear(screen_renderer);
+	// Clear screen_texture_a too
+	SDL_SetRenderTarget(screen_renderer, screen_texture_a);
+	SDL_RenderClear(screen_renderer);
+	SDL_SetRenderTarget(screen_renderer, nullptr);
 	SDL_RenderPresent(screen_renderer);
 	int    sbpp;
 	Uint32 sRmask;
@@ -686,9 +692,20 @@ bool Image_window::create_scale_surfaces(int w, int h, int bpp) {
 				std::max(inter_width, w) + 2 * guard_band * scale, std::max(inter_height, h) + 2 * guard_band * scale);
 	}
 	if (screen_texture == nullptr) {
-		cout << "Couldn't create texture: " << SDL_GetError() << std::endl;
+		cout << "Couldn't create screen_texture: " << SDL_GetError() << std::endl;
+	}
+	// This is just to make sure that rects in screen_texture get copied exactly to screen_texture_a
+	SDL_SetTextureScaleMode(screen_texture, SDL_SCALEMODE_NEAREST);
+
+	if (screen_texture_a == nullptr) {
+		screen_texture_a = SDL_CreateTexture(
+				screen_renderer, desktop_displaymode.format, SDL_TEXTUREACCESS_TARGET, screen_texture->w, screen_texture->h);
+	}
+	if (screen_texture_a == nullptr) {
+		cout << "Couldn't create screen_texture_a: " << SDL_GetError() << std::endl;
 	}
 	SDL_SetTextureBlendMode(screen_texture, SDL_BLENDMODE_NONE);
+	SDL_SetTextureBlendMode(screen_texture_a, SDL_BLENDMODE_NONE);
 
 	int draw_width  = inter_width / scale + 2 * guard_band;
 	int draw_height = inter_height / scale + 2 * guard_band;
@@ -705,15 +722,14 @@ bool Image_window::create_scale_surfaces(int w, int h, int bpp) {
 
 	// Scale using 'fill_scaler' only
 	if (scaler == fill_scaler || scale == 1 || (fill_scaler == SDLScaler && (scaler == point || scaler == bilinear))) {
-		// Use nearest scale mode if the scaler is point
-		if (fill_scaler == SDLScaler && scaler == point) {
-			SDL_SetTextureScaleMode(screen_texture, SDL_SCALEMODE_NEAREST);
-		}
+		// Use nearest scale mode if the scaler is point otherwise use linear
+		SDL_SetTextureScaleMode(
+				screen_texture_a, (fill_scaler == SDLScaler && scaler == point) ? SDL_SCALEMODE_NEAREST : SDL_SCALEMODE_LINEAR);
 		inter_surface = draw_surface;
 	} else if (inter_width != w || inter_height != h) {
 		int i_width  = inter_width + 2 * scale * guard_band;
 		int i_height = inter_height + 2 * scale * guard_band;
-		if (!(inter_surface = SDL_CreateSurface(i_width, i_height, desktop_displaymode.format))) {
+		if (!(inter_surface = SDL_CreateSurface(i_width, i_height, SDL_PIXELFORMAT_ARGB8888))) {
 			cerr << "Couldn't create inter surface: " << SDL_GetError() << endl;
 			free_surface();
 			return false;
@@ -781,7 +797,11 @@ void Image_window::free_surface() {
 	if (screen_texture != nullptr) {
 		SDL_DestroyTexture(screen_texture);
 	}
+	if (screen_texture_a != nullptr) {
+		SDL_DestroyTexture(screen_texture_a);
+	}
 	screen_texture   = nullptr;
+	screen_texture_a = nullptr;
 	paletted_surface = nullptr;
 	inter_surface    = nullptr;
 	draw_surface     = nullptr;
@@ -833,6 +853,8 @@ void Image_window::resized(
 
 void Image_window::show(int x, int y, int w, int h) {
 	PerformanceTimer::paintPerfMetrics();
+	SDL_ClearError();
+
 	auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__);
 	if (!ready()) {
 		return;
@@ -895,9 +917,20 @@ void Image_window::show(int x, int y, int w, int h) {
 	}
 	// Create temporary display_surface from screen_texture;
 	SDL_Surface* display_surface;
+
+	// The region of screen_texture that was changed
+	SDL_FRect dirtyrect = {0, 0, 0, 0};
+	// The Region of the screen_texture that needs to be rendered to the screen
+	SDL_FRect fullrect = {0, 0, 0, 0};
 	{
-		auto perftimer_sltts = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_LockTextureToSurface");
-		SDL_LockTextureToSurface(screen_texture, nullptr, &display_surface);
+		auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_LockTextureToSurface");
+
+		// Lock the texture as a surface so we can draw to it. The Lock operation imvalidates anything already in the texture
+		if (!SDL_LockTextureToSurface(screen_texture, nullptr, &display_surface)) {
+			const char* err = SDL_GetError();
+			std::cerr << "SDL_LockTextureToSurface failed: " << (err ? err : "") << std::endl;
+			SDL_ClearError();
+		}
 	}
 
 	// inter_surface is not null use that, otherwise set it to the temporary display_surface
@@ -940,14 +973,20 @@ void Image_window::show(int x, int y, int w, int h) {
 
 				(this->*show_scaled)(x, y, w, h);
 			}
-
+			x += guard_band;
+			y += guard_band;
 			x *= scale;
 			y *= scale;
 			w *= scale;
 			h *= scale;
+
+			fullrect.x = guard_band * scale;
+			fullrect.y = guard_band * scale;
+			fullrect.w = (draw_surface->w - 2 * guard_band) * scale;
+			fullrect.h = (draw_surface->h - 2 * guard_band) * scale;
 		}
 
-		// Phase 2 blit from inter_surface to display_surface
+		// Phase 2 blit from inter_surface to display_surface (this scales the entire surface)
 		if (inter_surface != display_surface && fill_scaler != SDLScaler) {
 			auto              perftimer_fs = PerformanceTimer::GetScopedPerfTimer(__func__, " fill scaler");
 			const ScalerInfo& sel_scaler   = Scalers[fill_scaler];
@@ -964,7 +1003,6 @@ void Image_window::show(int x, int y, int w, int h) {
 				w = inter_width;
 				h = inter_height;
 			}
-
 			int dw = display_surface->w - 2 * guard_band * scale;
 			int dh = display_surface->h - 2 * guard_band * scale;
 
@@ -972,13 +1010,17 @@ void Image_window::show(int x, int y, int w, int h) {
 				Scalers[point].arb->Scale(inter_surface, x, y, w, h, display_surface, 0, 0, dw, dh, false);
 			}
 
-			x = 0;
-			y = 0;
-			w = dw;
-			h = dh;
+			x          = 0;
+			y          = 0;
+			w          = dw;
+			h          = dh;
+			fullrect.x = x;
+			fullrect.y = y;
+			fullrect.w = w;
+			fullrect.h = h;
 		}
 
-		// Just blit the inter surface including guardband to the display surface with no scaling here.
+		// Copy the entire inter surface including guardband to the display surface with no scaling here.
 		else if (fill_scaler == SDLScaler && inter_surface != display_surface) {
 			auto perfcounter_sfs = PerformanceTimer::GetScopedPerfTimer(__func__, " sdl fill scaler");
 			// display_surface is always as big as or bigger than inter_surface so we copy the entire inter_surface to
@@ -997,10 +1039,11 @@ void Image_window::show(int x, int y, int w, int h) {
 			}
 			// Copy everything using memcpy if the surfaces have the same format
 			if (inter_surface->format == display_surface->format) {
-				char* src = reinterpret_cast<char*>(inter_surface->pixels) + x * inter_bytes_per_pixel + y * size_t(inter_surface->pitch);
+				char* src = reinterpret_cast<char*>(inter_surface->pixels) + x * inter_bytes_per_pixel
+							+ y * size_t(inter_surface->pitch);
 				char* end = src + h * inter_surface->pitch;
-				char* dst
-						= reinterpret_cast<char*>(display_surface->pixels) + x * inter_bytes_per_pixel + y * size_t(display_surface->pitch);
+				char* dst = reinterpret_cast<char*>(display_surface->pixels) + x * inter_bytes_per_pixel
+							+ y * size_t(display_surface->pitch);
 
 				while (src != end) {
 					memcpy(dst, src, w * inter_bytes_per_pixel);
@@ -1015,21 +1058,31 @@ void Image_window::show(int x, int y, int w, int h) {
 					SDL_ClearError();
 				}
 			}
+			fullrect.x = x;
+			fullrect.y = y;
+			fullrect.w = w;
+			fullrect.h = h;
 		}
 	}
+	dirtyrect.x = x;
+	dirtyrect.y = y;
+	dirtyrect.w = w;
+	dirtyrect.h = h;
 
 	// Phase 3 call UpdateRect to render screen_texture
-	SDL_FRect toupdate;
-	toupdate.x = x;
-	toupdate.y = y;
-	toupdate.w = w;
-	toupdate.h = h;
+
 	// reset inter_surface back to nullptr if it was set to the temporary display_surface that is about to be destroyed
 	if (inter_surface == display_surface) {
 		inter_surface = nullptr;
 	}
+	// Unlocking the texture destroys display_surface
 	SDL_UnlockTexture(screen_texture);
-	UpdateRect(&toupdate);
+	UpdateRect(&dirtyrect, &fullrect);
+
+	const char* err = SDL_GetError();
+	if (err && *err) {
+		std::cerr << "A SDL error occurred: " << err << std::endl;
+	}
 }
 
 /*
@@ -1039,8 +1092,8 @@ void Image_window::toggle_fullscreen() {
 	int w;
 	int h;
 
-	w = screen_texture->w;
-	h = screen_texture->h;
+	w = display_height;
+	h = display_height;
 
 	if (fullscreen) {
 		cout << "Switching to windowed mode." << endl;
@@ -1179,14 +1232,6 @@ bool Image_window::screenshot(SDL_IOStream* dst) {
 
 void Image_window::set_title(const char* title) {
 	SDL_SetWindowTitle(screen_window, title);
-}
-
-int Image_window::get_display_width() {
-	return screen_texture->w - 2 * guard_band * scale;
-}
-
-int Image_window::get_display_height() {
-	return screen_texture->h - 2 * guard_band * scale;
 }
 
 void Image_window::screen_to_game(int sx, int sy, bool fast, int& gx, int& gy) {
@@ -1816,8 +1861,8 @@ int Image_window::get_ui_height(UiLayerKind kind) const {
 }
 
 void Image_window::compute_fill_dest(int logw, int logh, FillMode fmode, int escl, SDL_FRect& dst) const {
-	const int dw = screen_texture ? screen_texture->w : logw;
-	const int dh = screen_texture ? screen_texture->h : logh;
+	const int dw = display_width;
+	const int dh = display_height;
 	double    cw;
 	double    ch;
 	if (logw <= 0 || logh <= 0) {
@@ -2028,20 +2073,47 @@ void Image_window::composite_layers() {
 	}
 }
 
-void Image_window::UpdateRect(SDL_FRect* srcRect) {
+void Image_window::UpdateRect(SDL_FRect* dirtyRect, SDL_FRect* fullRect) {
 	auto perfcounter = PerformanceTimer::GetScopedPerfTimer(__func__);
-	// TODO: Only update the necessary portion of the screen.
-	// Seem to get flicker like crazy or some other ill effect no matter
-	// what I try. -Lanica 08/28/2013
+
 	{
-		auto perfcounter_srt = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_RenderTexture");
-		SDL_RenderTexture(screen_renderer, screen_texture, srcRect, nullptr);
+		auto perfcounter = PerformanceTimer::GetScopedPerfTimer(__func__, " Rendering Textures");
+		if (!SDL_SetRenderTarget(screen_renderer, screen_texture_a)) {
+			const char* err = SDL_GetError();
+			std::cerr << "SDL_SetRenderTarget(screen_renderer, screen_texture_a) failed: " << (err ? err : "") << std::endl;
+			SDL_ClearError();
+		}
+
+		if (!SDL_RenderTexture(screen_renderer, screen_texture, dirtyRect, dirtyRect)) {
+			const char* err = SDL_GetError();
+			std::cerr << "SDL_RenderTexture(screen_renderer, screen_texture, srcRect, srcRect) failed: " << (err ? err : "")
+					  << std::endl;
+			SDL_ClearError();
+		}
+
+		if (!SDL_SetRenderTarget(screen_renderer, nullptr)) {
+			const char* err = SDL_GetError();
+			std::cerr << "SDL_SetRenderTarget(screen_renderer, screen_texture_a) failed: " << (err ? err : "") << std::endl;
+			SDL_ClearError();
+		}
+		SDL_RenderClear(screen_renderer);
+		if (!SDL_RenderTexture(screen_renderer, screen_texture_a, fullRect, nullptr)) {
+			const char* err = SDL_GetError();
+			std::cerr << "SDL_RenderTexture(screen_renderer, screen_texture_a, srcRect, nullptr) failed: " << (err ? err : "")
+					  << std::endl;
+			SDL_ClearError();
+		}
 	}
+
 	// Draw overlay layers on top of the main image, before presenting.
 	composite_layers();
 	{
 		auto perfcounter_srp = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_RenderPresent");
-		SDL_RenderPresent(screen_renderer);
+		if (!SDL_RenderPresent(screen_renderer)) {
+			const char* err = SDL_GetError();
+			std::cerr << "SDL_RenderPresent failed: " << (err ? err : "") << std::endl;
+			SDL_ClearError();
+		}
 	}
 }
 

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -718,6 +718,9 @@ bool Image_window::create_scale_surfaces(int w, int h, int bpp) {
 			free_surface();
 			return false;
 		}
+		// inter_surface could have an alpha channel but we don't want blending
+		// so disable it
+		SDL_SetSurfaceBlendMode(inter_surface, SDL_BLENDMODE_NONE);
 	}
 	// Scale using 'scaler' only
 	else {
@@ -902,12 +905,12 @@ void Image_window::show(int x, int y, int w, int h) {
 
 	// No scaling if ibuf and draw_surface are not the same size
 	if (ibuf->width + 2 * guard_band == draw_surface->w && ibuf->height + 2 * guard_band == draw_surface->h) {
-		// Phase 1 blit from draw_surface to inter_surface
+		// Phase 1 blit from draw_surface to inter_surface. This only scales the input rectangle
+		const SDL_PixelFormatDetails* inter_surface_format  = SDL_GetPixelFormatDetails(inter_surface->format);
+		const size_t                  inter_bytes_per_pixel = inter_surface_format->bits_per_pixel / 8;
 		if (draw_surface != inter_surface) {
 			auto              perftimer_s = PerformanceTimer::GetScopedPerfTimer(__func__, " scaler");
 			const ScalerInfo& sel_scaler  = Scalers[scaler];
-
-			const SDL_PixelFormatDetails* inter_surface_format = SDL_GetPixelFormatDetails(inter_surface->format);
 
 			if (sel_scaler.arb) {
 				if (!sel_scaler.arb->Scale(
@@ -992,8 +995,26 @@ void Image_window::show(int x, int y, int w, int h) {
 				w = inter_width;
 				h = inter_height;
 			}
-			// Copy everything
-			SDL_BlitSurface(inter_surface, nullptr, display_surface, nullptr);
+			// Copy everything using memcpy if the surfaces have the same format
+			if (inter_surface->format == display_surface->format) {
+				char* src = reinterpret_cast<char*>(inter_surface->pixels) + x * inter_bytes_per_pixel + y * size_t(inter_surface->pitch);
+				char* end = src + h * inter_surface->pitch;
+				char* dst
+						= reinterpret_cast<char*>(display_surface->pixels) + x * inter_bytes_per_pixel + y * size_t(display_surface->pitch);
+
+				while (src != end) {
+					memcpy(dst, src, w * inter_bytes_per_pixel);
+					src += inter_surface->pitch;
+					dst += display_surface->pitch;
+				}
+			} else {
+				// Fallback to SDL if pixel format conversion is needed
+				if (!SDL_BlitSurface(inter_surface, nullptr, display_surface, nullptr)) {
+					const char* err = SDL_GetError();
+					std::cerr << "SDL_BlitSurface failed: " << (err ? err : "") << std::endl;
+					SDL_ClearError();
+				}
+			}
 		}
 	}
 

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -38,6 +38,7 @@ Boston, MA  02111-1307, USA.
 #include "items.h"
 #include "manip.h"
 #include "mouse.h"
+#include "perf.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -941,6 +942,8 @@ void Image_window::resized(
  */
 
 void Image_window::show(int x, int y, int w, int h) {
+	PerformanceTimer::paintPerfMetrics();
+	auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__);
 	if (!ready()) {
 		return;
 	}
@@ -1005,6 +1008,7 @@ void Image_window::show(int x, int y, int w, int h) {
 	if (ibuf->width + 2 * guard_band == draw_surface->w && ibuf->height + 2 * guard_band == draw_surface->h) {
 		// Phase 1 blit from draw_surface to inter_surface
 		if (draw_surface != inter_surface) {
+			auto              perftimer  = PerformanceTimer::GetScopedPerfTimer(__func__, " scaler");
 			const ScalerInfo& sel_scaler = Scalers[scaler];
 
 			const SDL_PixelFormatDetails* inter_surface_format = SDL_GetPixelFormatDetails(inter_surface->format);
@@ -1057,6 +1061,7 @@ void Image_window::show(int x, int y, int w, int h) {
 
 		// Phase 2 blit from inter_surface to display_surface
 		if (inter_surface != display_surface && fill_scaler != SDLScaler) {
+			auto              perftimer  = PerformanceTimer::GetScopedPerfTimer(__func__, " fill scaler");
 			const ScalerInfo& sel_scaler = Scalers[fill_scaler];
 
 			// Just scale entire surfaces
@@ -1089,10 +1094,11 @@ void Image_window::show(int x, int y, int w, int h) {
 	// display size (e.g. AspectCorrectCentre), so uploading it directly may not
 	// match the display texture dimensions. Resolve to display_surface first.
 	if (fill_scaler == SDLScaler && inter_surface != display_surface) {
-		int sx;
-		int sy;
-		int sw;
-		int sh;
+		auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__, " sdl fill scaler");
+		int  sx;
+		int  sy;
+		int  sw;
+		int  sh;
 		if (inter_surface == draw_surface) {
 			sx = guard_band;
 			sy = guard_band;
@@ -1573,7 +1579,7 @@ bool Image_window::fillmode_to_string(FillMode fmode, std::string& str) {
  *  Layers.
  */
 
-int Image_window::create_layer(int w, int h, unsigned char transparent, int fixed_scale, int z) {
+int Image_window::create_layer(std::string&& name, int w, int h, unsigned char transparent, int fixed_scale, int z) {
 	if (w <= 0 || h <= 0) {
 		return -1;
 	}
@@ -1582,7 +1588,7 @@ int Image_window::create_layer(int w, int h, unsigned char transparent, int fixe
 		return -1;
 	}
 	buf->fill8(transparent);    // Start fully transparent.
-	auto layer = std::make_unique<Layer>(std::move(buf), w, h, transparent, fixed_scale, z);
+	auto layer = std::make_unique<Layer>(std::move(buf), w, h, transparent, fixed_scale, z, std::move(name));
 	// Reuse a freed slot if there is one, so handles stay stable.
 	for (size_t i = 0; i < layers.size(); i++) {
 		if (!layers[i]) {
@@ -2049,6 +2055,7 @@ void Image_window::composite_layers() {
 	if (layers.empty() || screen_renderer == nullptr) {
 		return;
 	}
+	auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__);
 	// Gather the visible layers and composite them from lowest to highest z.
 	std::vector<Layer*> ordered;
 	ordered.reserve(layers.size());
@@ -2073,8 +2080,10 @@ void Image_window::composite_layers() {
 		return a->z < b->z;
 	});
 	for (Layer* lptr : ordered) {
-		Layer&               layer = *lptr;
-		const UiLayerConfig& cfg   = get_ui_cfg(layer.ui_kind);
+		Layer& layer     = *lptr;
+		auto   perftimer = PerformanceTimer::GetScopedPerfTimer("Composite_Layer:", layer.get_name(), true);
+
+		const UiLayerConfig& cfg = get_ui_cfg(layer.ui_kind);
 		// Match filtering to this layer's scaler/fill scaler.
 		const bool smooth = (eff_ui_scaler(cfg) == bilinear) || (eff_ui_scaler(cfg) == SDLScaler)
 							|| (eff_ui_fill_scaler(cfg) == bilinear) || (eff_ui_fill_scaler(cfg) == SDLScaler);
@@ -2112,19 +2121,29 @@ void Image_window::composite_layers() {
 }
 
 void Image_window::UpdateRect(SDL_Surface* surf) {
+	auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__);
 	// TODO: Only update the necessary portion of the screen.
 	// Seem to get flicker like crazy or some other ill effect no matter
 	// what I try. -Lanica 08/28/2013
-	const SDL_PixelFormatDetails* surf_format = SDL_GetPixelFormatDetails(surf->format);
-	uint8*                        pixels
-			= (surf == display_surface ? static_cast<uint8*>(surf->pixels)
-									   : static_cast<uint8*>(surf->pixels) + guard_band * scale * surf_format->bytes_per_pixel
-												 + guard_band * scale * surf->pitch);
-	SDL_UpdateTexture(screen_texture, nullptr, pixels, surf->pitch);
-	SDL_RenderTexture(screen_renderer, screen_texture, nullptr, nullptr);
+	{
+		auto                          perftimer   = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_UpdateTexture");
+		const SDL_PixelFormatDetails* surf_format = SDL_GetPixelFormatDetails(surf->format);
+		uint8*                        pixels
+				= (surf == display_surface ? static_cast<uint8*>(surf->pixels)
+										   : static_cast<uint8*>(surf->pixels) + guard_band * scale * surf_format->bytes_per_pixel
+													 + guard_band * scale * surf->pitch);
+		SDL_UpdateTexture(screen_texture, nullptr, pixels, surf->pitch);
+	}
+	{
+		auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_RenderTexture");
+		SDL_RenderTexture(screen_renderer, screen_texture, nullptr, nullptr);
+	}
 	// Draw overlay layers on top of the main image, before presenting.
 	composite_layers();
-	SDL_RenderPresent(screen_renderer);
+	{
+		auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_RenderPresent");
+		SDL_RenderPresent(screen_renderer);
+	}
 }
 
 int Image_window::VideoModeOK(int width, int height, bool fullscreen, int bpp) {

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -1751,22 +1751,30 @@ void Image_window::set_ui_config(int width, int height, int scaler_, FillMode fm
 	cfg.fill_mode   = fmode;
 	cfg.fill_scaler = fill_scaler_;
 	for (int i = 0; i < NumUiLayerKinds; ++i) {
-		ui_cfgs[i] = cfg;
+		if (!ui_cfgs[i].protect) {
+			ui_cfgs[i] = cfg;
+		}
 	}
 	// Sizes/scale may have changed; force layer textures to rebuild.
 	mark_all_layers_dirty();
 }
 
-void Image_window::set_ui_layer_config(UiLayerKind kind, int width, int height, int scaler_, FillMode fmode, int fill_scaler_) {
+void Image_window::set_ui_layer_config(UiLayerKind kind, int width, int height, int scaler_, FillMode fmode, int fill_scaler_, bool protect) {
 	if (kind < UiLayerDefault || kind >= NumUiLayerKinds) {
 		return;
 	}
 	UiLayerConfig& cfg = ui_cfgs[static_cast<int>(kind)];
+	// configs with protectflagset can't be chaged unless protect argument is also set
+	// This is just to prevent ui settings gump from changing this config
+	if (cfg.protect && !protect) {
+		return;
+	}
 	cfg.width          = width;
 	cfg.height         = height;
 	cfg.scaler         = scaler_;
 	cfg.fill_mode      = fmode;
 	cfg.fill_scaler    = fill_scaler_;
+	cfg.protect        = protect;
 	mark_all_layers_dirty();
 }
 

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -2117,7 +2117,6 @@ void Image_window::composite_layers() {
 							  float(layer.logh * render_scale)};
 		get_layer_dest(layer, dst);
 
-		// SDL_RenderTexture(screen_renderer, layer.texture, nullptr, &dst);
 		SDL_RenderTexture(screen_renderer, layer.texture, &src, &dst);
 	}
 }

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -597,7 +597,9 @@ void Image_window::create_surface(unsigned int w, unsigned int h) {
 		if (screen_renderer == nullptr) {
 			cout << "Couldn't create renderer: " << SDL_GetError() << std::endl;
 		}
-		SDL_SetRenderVSync(screen_renderer, 1);
+		int vsync = 1;
+		config->value("config/video/vsync", vsync, vsync);
+		SDL_SetRenderVSync(screen_renderer, vsync);
 		// Do an initial draw/fill
 		SDL_SetRenderDrawColor(screen_renderer, 0, 0, 0, 255);
 		SDL_RenderClear(screen_renderer);
@@ -711,7 +713,9 @@ bool Image_window::create_scale_surfaces(int w, int h, int bpp) {
 	if (screen_renderer == nullptr) {
 		cout << "Couldn't create renderer: " << SDL_GetError() << std::endl;
 	}
-	SDL_SetRenderVSync(screen_renderer, 1);
+	int vsync = 1;
+	config->value("config/video/vsync", vsync, vsync);
+	SDL_SetRenderVSync(screen_renderer, vsync);
 
 	SDL_DisplayID original_displayID = SDL_GetDisplayForWindow(screen_window);
 

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -705,7 +705,11 @@ bool Image_window::create_scale_surfaces(int w, int h, int bpp) {
 	}
 
 	// Scale using 'fill_scaler' only
-	if (scaler == fill_scaler || scale == 1 || (fill_scaler == SDLScaler && scaler == bilinear)) {
+	if (scaler == fill_scaler || scale == 1 || (fill_scaler == SDLScaler && (scaler == point || scaler == bilinear))) {
+		// Use nearest scale mode if the scaler is point
+		if (fill_scaler == SDLScaler && scaler == point) {
+			SDL_SetTextureScaleMode(screen_texture, SDL_SCALEMODE_NEAREST);
+		}
 		inter_surface = draw_surface;
 	} else if (inter_width != w || inter_height != h) {
 		int i_width  = inter_width + 2 * scale * guard_band;

--- a/imagewin/imagewin.cc
+++ b/imagewin/imagewin.cc
@@ -923,7 +923,7 @@ void Image_window::show(int x, int y, int w, int h) {
 	// The Region of the screen_texture that needs to be rendered to the screen
 	SDL_FRect fullrect = {0, 0, 0, 0};
 	{
-		auto perftimer = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_LockTextureToSurface");
+		auto perftimer_s_ltts = PerformanceTimer::GetScopedPerfTimer(__func__, " SDL_LockTextureToSurface");
 
 		// Lock the texture as a surface so we can draw to it. The Lock operation imvalidates anything already in the texture
 		if (!SDL_LockTextureToSurface(screen_texture, nullptr, &display_surface)) {
@@ -2077,7 +2077,7 @@ void Image_window::UpdateRect(SDL_FRect* dirtyRect, SDL_FRect* fullRect) {
 	auto perfcounter = PerformanceTimer::GetScopedPerfTimer(__func__);
 
 	{
-		auto perfcounter = PerformanceTimer::GetScopedPerfTimer(__func__, " Rendering Textures");
+		auto perfcounter_rt = PerformanceTimer::GetScopedPerfTimer(__func__, " Rendering Textures");
 		if (!SDL_SetRenderTarget(screen_renderer, screen_texture_a)) {
 			const char* err = SDL_GetError();
 			std::cerr << "SDL_SetRenderTarget(screen_renderer, screen_texture_a) failed: " << (err ? err : "") << std::endl;

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -399,6 +399,11 @@ protected:
 
 	// Layers composited on top of the main image (see class Layer).
 	std::vector<std::unique_ptr<Layer>> layers;
+	// Scaling layers can need upto 3 dst32 surfaces. Layer dst32 Surfaces aren't persistent and shared between all layers as needed
+	SDL_Surface* layer_dst32_surfaces[3] = {nullptr, nullptr, nullptr};
+
+	// Get one of the 3 layer dst32 surfaces making sure it's size is at least w x h
+	SDL_Surface* get_layer_dst32_surface(unsigned index, int w, int h);
 
 	// Compute a layer's on-screen destination rect (in display coords, which
 	// match the renderer's logical presentation).

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -78,7 +78,11 @@ public:
 		UiLayerDisplayMap,
 		UiLayerTextEffects,
 		UiLayerFullScreenScene,
-		UiLayerFullScreenNoScaler,
+
+		// Layer is drawn fullscreen with bilinear fill scaling.
+		UiLayerFullScreenBilinear,
+		// Layer is drawn fullscreen with point fill scaling
+		UiLayerFullScreenPoint,
 
 		NumUiLayerKinds
 	};

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -375,14 +375,14 @@ protected:
 	static SDL_DisplayMode desktop_displaymode;
 	struct SDL_Window*     screen_window;
 	struct SDL_Renderer*   screen_renderer;
-	struct SDL_Texture*    screen_texture;
-	void                   UpdateRect(SDL_Surface* surf);
+	struct SDL_Texture*    screen_texture; // What gets drawn to the screen by SDL. 
+
+	void                   UpdateRect(SDL_FRect *srcRect); // Draw screen_texture with Screen_renderer
 
 	SDL_Surface* paletted_surface;    // Surface that palette is set on (Example
-									  // res)
-	SDL_Surface* display_surface;     // Final surface that is displayed  (1024x1024)
-	SDL_Surface* inter_surface;       // Post scaled/pre stretch surface  (960x600)
-	SDL_Surface* draw_surface;        // Pre scaled surface               (320x200)
+									  // res) - Never null
+	SDL_Surface* inter_surface;       // Post scaled/pre stretch surface  (960x600) - can be null
+	SDL_Surface* draw_surface;        // Pre scaled surface               (320x200) - Never null
 
 	// Layers composited on top of the main image (see class Layer).
 	std::vector<std::unique_ptr<Layer>> layers;
@@ -547,7 +547,7 @@ public:
 			FillMode fmode = AspectCorrectCentre, int fillsclr = point)
 			: ibuf(ib), scale(scl), scaler(sclr), uses_palette(true), fullscreen(fs), game_width(gamew), game_height(gameh),
 			  saved_game_width(gamew), saved_game_height(gameh), fill_mode(fmode), fill_scaler(fillsclr), screen_window(nullptr),
-			  screen_renderer(nullptr), screen_texture(nullptr), paletted_surface(nullptr), display_surface(nullptr),
+			  screen_renderer(nullptr), screen_texture(nullptr), paletted_surface(nullptr),
 			  inter_surface(nullptr), draw_surface(nullptr) {
 		static_init();
 		create_surface(w, h);
@@ -776,7 +776,7 @@ public:
 			return false;
 		}
 		// Only if actually scaling
-		if (draw_surface == display_surface) {
+		if (draw_surface->w == screen_texture->w && draw_surface->h == screen_texture->h) {
 			return false;
 		}
 
@@ -786,9 +786,9 @@ public:
 			return false;
 		}
 
-		// if inter is the same as display the scaling is only being done by
+		// if no inter surface the scaling is only being done by
 		// scaler and if is point we don't need to do this
-		if (display_surface == inter_surface && point == scaler) {
+		if (!inter_surface && point == scaler) {
 			return false;
 		}
 

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -78,6 +78,8 @@ public:
 		UiLayerDisplayMap,
 		UiLayerTextEffects,
 		UiLayerFullScreenScene,
+		UiLayerFullScreenNoScaler,
+
 		NumUiLayerKinds
 	};
 
@@ -142,6 +144,7 @@ public:
 		int      scaler      = 0;
 		FillMode fill_mode   = Fit;
 		int      fill_scaler = 0;
+		bool     protect = false; // Protect flag is used to prevent this config from being changed by set_ui_config and set_ui_layer_config
 		// Optional fixed palette for the layer (see UiPaletteMode).
 		int                        ui_palette = UiPaletteDisabled;
 		std::vector<unsigned char> ui_palette_colors;    // 768 gamma RGB, empty = none.
@@ -189,6 +192,10 @@ public:
 		// entry is used verbatim (with its own alpha) instead of the opaque
 		// palette colour, letting a layer draw translucent pixels.
 		std::vector<uint32> index_argb;
+		std::vector<uint32> gamma_argb;
+		double              gamma_r = 0;
+		double              gamma_g = 0;
+		double              gamma_b = 0;
 
 		std::string name;
 
@@ -232,7 +239,7 @@ public:
 			return visible;
 		}
 
-		const std::string& get_name() {
+		const std::string& get_name() const {
 			return name;
 		}
 	};
@@ -709,7 +716,7 @@ public:
 	// placed. width/height set a fixed UI layout size in game pixels. A value
 	// of 0,0 means Auto (use game area size).
 	void set_ui_config(int width, int height, int scaler, FillMode fmode, int fill_scaler);
-	void set_ui_layer_config(UiLayerKind kind, int width, int height, int scaler, FillMode fmode, int fill_scaler);
+	void set_ui_layer_config(UiLayerKind kind, int width, int height, int scaler, FillMode fmode, int fill_scaler, bool protect=false);
 	// -------- Layer fixed palette --------
 	// Which fixed palette (if any) a layer uses when the game's live
 	// palette is not the day palette. Values are UiPaletteMode; the mapping to

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -190,9 +190,11 @@ public:
 		// palette colour, letting a layer draw translucent pixels.
 		std::vector<uint32> index_argb;
 
+		std::string name;
+
 	public:
-		Layer(std::unique_ptr<Image_buffer> b, int w, int h, unsigned char transp, int fscale, int zorder)
-				: buf(std::move(b)), logw(w), logh(h), fixed_scale(fscale), transparent(transp), z(zorder) {}
+		Layer(std::unique_ptr<Image_buffer> b, int w, int h, unsigned char transp, int fscale, int zorder, std::string&& name)
+				: buf(std::move(b)), logw(w), logh(h), fixed_scale(fscale), transparent(transp), z(zorder), name(std::move(name)) {}
 
 		Image_buffer* get_ibuf() const {
 			return buf.get();
@@ -228,6 +230,10 @@ public:
 
 		bool is_visible() const {
 			return visible;
+		}
+
+		const std::string& get_name() {
+			return name;
 		}
 	};
 
@@ -663,7 +669,7 @@ public:
 	// constant on-screen size independent of the world scaling), otherwise it
 	// is drawn at the given integer scale.  'z' orders layers: higher values
 	// are composited on top.
-	int           create_layer(int w, int h, unsigned char transparent = 255, int fixed_scale = 0, int z = 0);
+	int           create_layer(std::string&& name, int w, int h, unsigned char transparent = 255, int fixed_scale = 0, int z = 0);
 	void          destroy_layer(int handle);
 	Image_buffer* get_layer_ibuf(int handle);
 	// Mark a layer's buffer as changed so it is re-uploaded before the next

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -335,6 +335,8 @@ protected:
 	int active_scene_layer = -1;
 	int inter_width;
 	int inter_height;
+	int display_width;
+	int display_height;
 	// Guardband around the edge of the draw surface to allow scalers to run
 	// without per pixel bounds checking and to allow rounding up to
 	// multiples of 4. It should  not be less than 4 and there is no reason for
@@ -375,14 +377,18 @@ protected:
 	static SDL_DisplayMode desktop_displaymode;
 	struct SDL_Window*     screen_window;
 	struct SDL_Renderer*   screen_renderer;
-	struct SDL_Texture*    screen_texture; // What gets drawn to the screen by SDL. 
+	struct SDL_Texture*
+			screen_texture;    // Output of scalers gets drawn here. This may contain partial frames if there is no inter_surface
+	struct SDL_Texture* screen_texture_a;    // What gets drawn to the screen by SDL. The is the accumulation of all updates to
+											 // screen_texture and contains the current full frame being displayed
 
-	void                   UpdateRect(SDL_FRect *srcRect); // Draw screen_texture with Screen_renderer
+	// Update screen_texture_a with the dirtyRect changes made to screen_texture and render fullRect of screen_texture_a
+	void UpdateRect(SDL_FRect* dirtyRect, SDL_FRect* fullRect);
 
 	SDL_Surface* paletted_surface;    // Surface that palette is set on (Example
 									  // res) - Never null
-	SDL_Surface* inter_surface;       // Post scaled/pre stretch surface  (960x600) - can be null
-	SDL_Surface* draw_surface;        // Pre scaled surface               (320x200) - Never null
+	SDL_Surface* inter_surface;    // Post scaled/pre stretch surface  (960x600) - can be null if there is no stretching being dome
+	SDL_Surface* draw_surface;     // Pre scaled surface               (320x200) - Never null
 
 	// Layers composited on top of the main image (see class Layer).
 	std::vector<std::unique_ptr<Layer>> layers;
@@ -547,7 +553,7 @@ public:
 			FillMode fmode = AspectCorrectCentre, int fillsclr = point)
 			: ibuf(ib), scale(scl), scaler(sclr), uses_palette(true), fullscreen(fs), game_width(gamew), game_height(gameh),
 			  saved_game_width(gamew), saved_game_height(gameh), fill_mode(fmode), fill_scaler(fillsclr), screen_window(nullptr),
-			  screen_renderer(nullptr), screen_texture(nullptr), paletted_surface(nullptr),
+			  screen_renderer(nullptr), screen_texture(nullptr), screen_texture_a(nullptr), paletted_surface(nullptr),
 			  inter_surface(nullptr), draw_surface(nullptr) {
 		static_init();
 		create_surface(w, h);
@@ -561,8 +567,13 @@ public:
 		return scale;
 	}
 
-	int get_display_width();
-	int get_display_height();
+	int get_display_width() {
+		return display_width;
+	}
+
+	int get_display_height() {
+		return display_height;
+	}
 
 	void screen_to_game(int sx, int sy, bool fast, int& gx, int& gy);
 

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -181,11 +181,11 @@ public:
 		bool                          opaque = false;       // If set, NO index is transparent (a
 															// full-screen opaque scene: every pixel
 															// is drawn, even the 'transparent' index).
-		bool        visible  = true;
-		bool        dirty    = true;     // Buffer changed => re-upload.
-		int         z        = 0;        // Composite order (higher = on top).
-		bool        has_dest = false;    // Explicit destination override?
-		SDL_FRect   dest{};              // Destination rect (display coords).
+		bool                   visible = true;
+		bool                   dirty   = true;    // Buffer changed => re-upload.
+		int                    z       = 0;       // Composite order (higher = on top).
+		std::vector<SDL_FRect> dest    = {};      // Destination rects to paint layer. If more than 1 the layer is painted multiple
+												  // tines, if 0 default foe UIConfog is used
 		UiLayerKind ui_kind      = UiLayerDefault;
 		int         render_scale = 1;    // 1 = 1:1 upload; >1 = pre-scaled by
 										 // the game's scaler at this factor.
@@ -409,7 +409,7 @@ protected:
 
 	// Compute a layer's on-screen destination rect (in display coords, which
 	// match the renderer's logical presentation).
-	void get_layer_dest(const Layer& layer, struct SDL_FRect& dst);
+	bool get_layer_dest(const Layer& layer, struct SDL_FRect& dst, int num = 0);
 	// Place a logw x logh layer on the display using the UI fill mode / scale.
 	void compute_layer_fill_dest(int logw, int logh, struct SDL_FRect& dst) const;
 	void compute_layer_fill_dest(int logw, int logh, struct SDL_FRect& dst, UiLayerKind kind) const;
@@ -707,7 +707,7 @@ public:
 	// Give a layer an explicit destination rectangle (in display coords),
 	// overriding the centred auto-fit placement.  Used to position a layer
 	// (e.g. the mouse cursor) freely. layer_clear_dest() restores auto-fit.
-	void layer_set_dest(int handle, int x, int y, int w, int h);
+	void layer_set_dest(int handle, int x, int y, int w, int h, bool add = false);
 	void layer_clear_dest(int handle);
 	void layer_set_ui_kind(int handle, UiLayerKind kind);
 	// Set (or clear, with nullptr) a layer's 256-entry ARGB override table.

--- a/imagewin/imagewin.h
+++ b/imagewin/imagewin.h
@@ -144,7 +144,8 @@ public:
 		int      scaler      = 0;
 		FillMode fill_mode   = Fit;
 		int      fill_scaler = 0;
-		bool     protect = false; // Protect flag is used to prevent this config from being changed by set_ui_config and set_ui_layer_config
+		bool     protect     = false;    // Protect flag is used to prevent this config from being changed by set_ui_config and
+										 // set_ui_layer_config
 		// Optional fixed palette for the layer (see UiPaletteMode).
 		int                        ui_palette = UiPaletteDisabled;
 		std::vector<unsigned char> ui_palette_colors;    // 768 gamma RGB, empty = none.
@@ -170,6 +171,7 @@ public:
 	class Layer {
 		friend class Image_window;
 		friend class Image_window8;
+		SDL_Surface*                  surface = nullptr;    // SDL Surface for buf
 		std::unique_ptr<Image_buffer> buf;                  // 8-bit drawing buffer.
 		struct SDL_Texture*           texture = nullptr;    // GPU cache (rebuilt on resize).
 		int                           logw;                 // Logical (game-pixel) width.
@@ -200,8 +202,8 @@ public:
 		std::string name;
 
 	public:
-		Layer(std::unique_ptr<Image_buffer> b, int w, int h, unsigned char transp, int fscale, int zorder, std::string&& name)
-				: buf(std::move(b)), logw(w), logh(h), fixed_scale(fscale), transparent(transp), z(zorder), name(std::move(name)) {}
+		~Layer();
+		Layer(SDL_Surface* surface, int w, int h, unsigned char transp, int fscale, int zorder, std::string&& name);
 
 		Image_buffer* get_ibuf() const {
 			return buf.get();
@@ -348,7 +350,7 @@ protected:
 	// without per pixel bounds checking and to allow rounding up to
 	// multiples of 4. It should  not be less than 4 and there is no reason for
 	// it to be bigger.
-	const int guard_band = 4;
+	constexpr static int guard_band = 4;
 
 	FillMode fill_mode;
 	int      fill_scaler;
@@ -721,7 +723,8 @@ public:
 	// placed. width/height set a fixed UI layout size in game pixels. A value
 	// of 0,0 means Auto (use game area size).
 	void set_ui_config(int width, int height, int scaler, FillMode fmode, int fill_scaler);
-	void set_ui_layer_config(UiLayerKind kind, int width, int height, int scaler, FillMode fmode, int fill_scaler, bool protect=false);
+	void set_ui_layer_config(
+			UiLayerKind kind, int width, int height, int scaler, FillMode fmode, int fill_scaler, bool protect = false);
 	// -------- Layer fixed palette --------
 	// Which fixed palette (if any) a layer uses when the game's live
 	// palette is not the day palette. Values are UiPaletteMode; the mapping to

--- a/imagewin/iwin8.cc
+++ b/imagewin/iwin8.cc
@@ -326,8 +326,20 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 		const int    ossw  = ((logw + 3) & ~3) + 2 * gb;
 		const int    ossh  = logh + 2 * gb;
 		SDL_Surface* osrc8 = SDL_CreateSurface(ossw, ossh, SDL_PIXELFORMAT_INDEX8);
-		SDL_Surface* odst  = SDL_CreateSurface(ossw * factor, ossh * factor, SDL_PIXELFORMAT_ARGB8888);
-		bool         done  = false;
+		SDL_Surface* odst;
+		if (!SDL_LockTextureToSurface(layer.texture, nullptr, &odst)) {
+			const char* err = SDL_GetError();
+			std::cerr << "SDL_LockTextureToSurface failed trying to lock texture for layer " << layer.get_name() << ":"
+					  << (err ? err : "") << std::endl;
+
+			return false;
+		}
+		if (odst->w < ossw * factor || odst->h < ossh * factor) {
+			std::cerr << " odst surface size too small after locking texture for layer '" << layer.get_name() << "' expected "
+					  << (ossw * factor) << "x" << (ossh * factor) << " got " << odst->w << "x" << odst->h << std::endl;
+			return false;
+		}
+		bool done = false;
 		if (osrc8 && odst) {
 			SDL_Palette* sdl_pal = SDL_CreateSurfacePalette(osrc8);
 			if (sdl_pal) {
@@ -368,14 +380,12 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 							trow[x] = 0xff000000u | (row[x] & 0x00ffffffu);
 						}
 					}
-					SDL_UpdateTexture(layer.texture, nullptr, texpix.get(), tex_w * static_cast<int>(sizeof(uint32)));
+					SDL_UnlockTexture(layer.texture);
 					done = true;
 				}
 			}
 		}
-		if (odst) {
-			SDL_DestroySurface(odst);
-		}
+
 		if (osrc8) {
 			SDL_DestroySurface(osrc8);
 		}

--- a/imagewin/iwin8.cc
+++ b/imagewin/iwin8.cc
@@ -48,6 +48,7 @@ Boston, MA  02111-1307, USA.
 #include <algorithm>
 #include <climits>
 #include <cstring>
+#include <iostream>
 
 using std::make_unique;
 using std::rotate;
@@ -260,28 +261,37 @@ void Image_window8::refresh_layer(Layer& layer) {
 	if (layer.render_scale > 1 && refresh_layer_scaled(layer, layer.render_scale)) {
 		return;
 	}
-	const int            w      = layer.get_width();
-	const int            h      = layer.get_height();
-	Image_buffer*        b      = layer.get_ibuf();
-	const unsigned char* src    = b->get_bits();
-	const int            pitch  = static_cast<int>(b->get_line_width());
-	auto                 pixels = make_unique<uint32[]>(static_cast<size_t>(w) * h);
-	uint32               palette[256];
+	const int            w     = layer.get_width();
+	const int            h     = layer.get_height();
+	Image_buffer*        b     = layer.get_ibuf();
+	const unsigned char* src   = b->get_bits();
+	const int            pitch = static_cast<int>(b->get_line_width());
 
+	char* pixels       = nullptr;
+	int   pixels_pitch = 0;
+
+	if (!SDL_LockTexture(layer.texture, nullptr, reinterpret_cast<void**>(&pixels), &pixels_pitch)) {
+		const char* err = SDL_GetError();
+		std::cerr << "SDL_LockTexture failed trying to lock texture for layer " << layer.get_name() << ":" << (err ? err : "")
+				  << std::endl;
+		return;
+	}
+
+	uint32 palette[256];
 	for (int i = 0; i < 256; i++) {
 		palette[i] = layer_argb_pixel(layer, i);
 	}
 
 	for (int y = 0; y < h; y++) {
 		const unsigned char* srow = src + static_cast<size_t>(y) * pitch;
-		uint32*              drow = pixels.get() + static_cast<size_t>(y) * w;
+		uint32*              drow = reinterpret_cast<uint32*>(pixels + static_cast<size_t>(y) * pixels_pitch);
 		uint32*              end  = drow + w;
 
 		while (drow != end) {
 			*drow++ = palette[*srow++];
 		}
 	}
-	SDL_UpdateTexture(layer.texture, nullptr, pixels.get(), w * static_cast<int>(sizeof(uint32)));
+	SDL_UnlockTexture(layer.texture);
 }
 
 /*

--- a/imagewin/iwin8.cc
+++ b/imagewin/iwin8.cc
@@ -492,7 +492,16 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 		}
 	}
 
-	auto texpix = make_unique<uint32[]>(static_cast<size_t>(tex_w) * tex_h);
+	int     texpix_pitch;
+	char *texpix=nullptr;
+	if (!SDL_LockTexture(layer.texture, nullptr, reinterpret_cast<void**>(&texpix), &texpix_pitch)) {
+		const char* err = SDL_GetError();
+		std::cerr << "SDL_LockTexture failed trying to lock texture for layer " << layer.get_name() << ":"
+					<< (err ? err : "") << std::endl;
+
+		return false;
+	}
+
 	if (ok) {
 		const uint32* pix1             = static_cast<const uint32*>(dst32->pixels);
 		const uint32* pix2             = static_cast<const uint32*>(dst32b->pixels);
@@ -506,7 +515,7 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 			const uint32*        row2 = pix2 + roff;
 			const uint32*        row3 = have3 ? pix3 + roff : nullptr;
 			const unsigned char* srow = src + static_cast<size_t>(sy) * spitch;
-			uint32*              trow = texpix.get() + static_cast<size_t>(y) * tex_w;
+			uint32*              trow = reinterpret_cast<uint32*>(texpix + static_cast<size_t>(y) * texpix_pitch);
 			for (int x = 0; x < tex_w; x++) {
 				const unsigned char idx = srow[x / factor];
 				const uint32        p1  = row1[x];
@@ -595,13 +604,13 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 		// Fallback: nearest-neighbour upscale of the 1:1 conversion.
 		for (int y = 0; y < tex_h; y++) {
 			const unsigned char* srow = src + static_cast<size_t>(y / factor) * spitch;
-			uint32*              trow = texpix.get() + static_cast<size_t>(y) * tex_w;
+			uint32*              trow = reinterpret_cast<uint32*>(texpix + static_cast<size_t>(y) * texpix_pitch);
 			for (int x = 0; x < tex_w; x++) {
 				trow[x] = layer_argb_pixel(layer, srow[x / factor]);
 			}
 		}
 	}
-	SDL_UpdateTexture(layer.texture, nullptr, texpix.get(), tex_w * static_cast<int>(sizeof(uint32)));
+	SDL_UnlockTexture(layer.texture);
 	if (dst32c) {
 		SDL_DestroySurface(dst32c);
 	}

--- a/imagewin/iwin8.cc
+++ b/imagewin/iwin8.cc
@@ -266,11 +266,19 @@ void Image_window8::refresh_layer(Layer& layer) {
 	const unsigned char* src    = b->get_bits();
 	const int            pitch  = static_cast<int>(b->get_line_width());
 	auto                 pixels = make_unique<uint32[]>(static_cast<size_t>(w) * h);
+	uint32               palette[256];
+
+	for (int i = 0; i < 256; i++) {
+		palette[i] = layer_argb_pixel(layer, i);
+	}
+
 	for (int y = 0; y < h; y++) {
 		const unsigned char* srow = src + static_cast<size_t>(y) * pitch;
 		uint32*              drow = pixels.get() + static_cast<size_t>(y) * w;
-		for (int x = 0; x < w; x++) {
-			drow[x] = layer_argb_pixel(layer, srow[x]);
+		uint32*              end  = drow + w;
+
+		while (drow != end) {
+			*drow++ = palette[*srow++];
 		}
 	}
 	SDL_UpdateTexture(layer.texture, nullptr, pixels.get(), w * static_cast<int>(sizeof(uint32)));

--- a/imagewin/iwin8.cc
+++ b/imagewin/iwin8.cc
@@ -249,6 +249,30 @@ uint32 Image_window8::layer_argb_pixel(const Layer& layer, unsigned char p) cons
 		   | static_cast<uint32>(pal[3 * p + 2]);
 }
 
+static void fill_guardband(void* buffer, int width, int height, int pitch, int gbsize, uint32 val) {
+	uint8* buffer8 = reinterpret_cast<uint8*>(buffer);
+	if (gbsize < 0) {
+		buffer8 += gbsize + pitch * gbsize;
+		gbsize = -gbsize;
+	}
+
+	// left and right guardbands
+	for (int y = 0; y < height; y++) {
+		uint32* row = reinterpret_cast<uint32*>(buffer8 + y * pitch);
+		std::fill_n(row, gbsize, val);
+		std::fill_n(row + width + gbsize, gbsize, val);
+	}
+	// top and bottom guardbands
+	for (int y = 0; y < gbsize; y++) {
+		// Top guardband
+		uint32* row = reinterpret_cast<uint32*>(buffer8 + y * pitch);
+		std::fill_n(row, width + gbsize * 2, val);
+		// Bottom guardband
+		row = reinterpret_cast<uint32*>(buffer8 + (gbsize + height + y) * pitch);
+		std::fill_n(row, width + gbsize * 2, val);
+	}
+}
+
 /*
  *  Convert a layer's 8-bit paletted pixels into its ARGB texture,
  *  using the current palette.  The layer's transparent index is written as
@@ -261,14 +285,13 @@ void Image_window8::refresh_layer(Layer& layer) {
 	if (layer.render_scale > 1 && refresh_layer_scaled(layer, layer.render_scale)) {
 		return;
 	}
-	const int            w     = layer.get_width();
-	const int            h     = layer.get_height();
-	SDL_Surface*         s     = layer.surface;
-	const unsigned char* src   = reinterpret_cast<unsigned char*>(s->pixels);
-	const int            pitch = s->pitch;
-
-	char* pixels       = nullptr;
-	int   pixels_pitch = 0;
+	const int            w            = layer.get_width();
+	const int            h            = layer.get_height();
+	SDL_Surface*         s            = layer.surface;
+	const unsigned char* src          = reinterpret_cast<unsigned char*>(s->pixels);
+	const int            pitch        = s->pitch;
+	char*                pixels       = nullptr;
+	int                  pixels_pitch = 0;
 
 	if (!SDL_LockTexture(layer.texture, nullptr, reinterpret_cast<void**>(&pixels), &pixels_pitch)) {
 		const char* err = SDL_GetError();
@@ -276,6 +299,7 @@ void Image_window8::refresh_layer(Layer& layer) {
 				  << (err ? err : "") << std::endl;
 		return;
 	}
+	fill_guardband(pixels, w, h, pixels_pitch, guard_band, 0);
 
 	uint32 palette[256];
 	for (int i = 0; i < 256; i++) {
@@ -379,6 +403,7 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 			SDL_UnlockTexture(layer.texture);
 			return false;
 		}
+		fill_guardband(odst->pixels, tex_w, tex_h, odst->pitch, guard_band * factor, 0);
 		bool done = false;
 		if (odst) {
 			if (scale_layer_color(layer, lsurf, logw, logh, odst)) {
@@ -470,6 +495,7 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 
 		return false;
 	}
+	fill_guardband(texpix, tex_w, tex_h, texpix_pitch, guard_band * factor, 0);
 
 	if (ok) {
 		const uint32* pix1    = static_cast<const uint32*>(dst32->pixels);
@@ -584,7 +610,6 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 			}
 		}
 	}
-
 	SDL_UnlockTexture(layer.texture);
 
 	return true;

--- a/imagewin/iwin8.cc
+++ b/imagewin/iwin8.cc
@@ -288,8 +288,8 @@ void Image_window8::refresh_layer(Layer& layer) {
 	const int            w            = layer.get_width();
 	const int            h            = layer.get_height();
 	SDL_Surface*         s            = layer.surface;
-	const unsigned char* src          = reinterpret_cast<unsigned char*>(s->pixels);
-	const int            pitch        = s->pitch;
+	const size_t         spitch       = s->pitch;
+	const unsigned char* src          = reinterpret_cast<unsigned char*>(s->pixels) + spitch * guard_band + guard_band;
 	char*                pixels       = nullptr;
 	int                  pixels_pitch = 0;
 
@@ -299,6 +299,7 @@ void Image_window8::refresh_layer(Layer& layer) {
 				  << (err ? err : "") << std::endl;
 		return;
 	}
+
 	fill_guardband(pixels, w, h, pixels_pitch, guard_band, 0);
 
 	uint32 palette[256];
@@ -306,9 +307,11 @@ void Image_window8::refresh_layer(Layer& layer) {
 		palette[i] = layer_argb_pixel(layer, i);
 	}
 
+	const size_t ppitch = pixels_pitch;
+	pixels += ppitch * guard_band + guard_band * sizeof(uint32);
 	for (int y = 0; y < h; y++) {
-		const unsigned char* srow = src + static_cast<size_t>(y) * pitch;
-		uint32*              drow = reinterpret_cast<uint32*>(pixels + static_cast<size_t>(y) * pixels_pitch);
+		const unsigned char* srow = src + y * spitch;
+		uint32*              drow = reinterpret_cast<uint32*>(pixels + y * ppitch);
 		uint32*              end  = drow + w;
 
 		while (drow != end) {

--- a/imagewin/iwin8.cc
+++ b/imagewin/iwin8.cc
@@ -263,17 +263,17 @@ void Image_window8::refresh_layer(Layer& layer) {
 	}
 	const int            w     = layer.get_width();
 	const int            h     = layer.get_height();
-	Image_buffer*        b     = layer.get_ibuf();
-	const unsigned char* src   = b->get_bits();
-	const int            pitch = static_cast<int>(b->get_line_width());
+	SDL_Surface*         s     = layer.surface;
+	const unsigned char* src   = reinterpret_cast<unsigned char*>(s->pixels);
+	const int            pitch = s->pitch;
 
 	char* pixels       = nullptr;
 	int   pixels_pitch = 0;
 
 	if (!SDL_LockTexture(layer.texture, nullptr, reinterpret_cast<void**>(&pixels), &pixels_pitch)) {
 		const char* err = SDL_GetError();
-		std::cerr << "SDL_LockTexture failed trying to lock texture for layer " << layer.get_name() << ":" << (err ? err : "")
-				  << std::endl;
+		std::cerr << "refresh_layer: SDL_LockTexture failed trying to lock texture for layer " << layer.get_name() << ":"
+				  << (err ? err : "") << std::endl;
 		return;
 	}
 
@@ -302,20 +302,62 @@ void Image_window8::refresh_layer(Layer& layer) {
  *  source so it stays crisp and masks any colour bleed at transparent edges.
  */
 bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
-	const int            gb     = guard_band;    // Scaler reads a padded border.
 	const int            logw   = layer.get_width();
 	const int            logh   = layer.get_height();
-	Image_buffer*        b      = layer.get_ibuf();
-	const unsigned char* src    = b->get_bits();
-	const int            spitch = static_cast<int>(b->get_line_width());
-	const unsigned char  transp = layer.get_transparent();
-	const bool           has_ov = !layer.index_argb.empty();
-	const uint32*        ov     = has_ov ? layer.index_argb.data() : nullptr;
-	const int            tex_w  = logw * factor;
-	const int            tex_h  = logh * factor;
+	SDL_Surface*         lsurf  = layer.surface;
+	const size_t         spitch = static_cast<size_t>(lsurf->pitch);
+	unsigned char* const src    = reinterpret_cast<unsigned char*>(lsurf->pixels) + guard_band + guard_band * spitch;
+
+	const unsigned char transp = layer.get_transparent();
+	const bool          has_ov = !layer.index_argb.empty();
+	const uint32*       ov     = has_ov ? layer.index_argb.data() : nullptr;
+	const int           tex_w  = logw * factor;
+	const int           tex_h  = logh * factor;
+	const int           ssw    = ((logw + 3) & ~3) + 2 * guard_band;
+	const int           ssh    = logh + 2 * guard_band;
+
+	// Copy edge pixels into Source surface guardband
+
+	// left and right guardbands
+	for (int y = 0; y < logh; y++) {
+		uint8* row = src + y * spitch;
+		memset(row - guard_band, *row, guard_band);
+		memset(row + logw, row[logw - 1], guard_band);
+	}
+	// top and bottom guardbands
+	for (int y = 0; y < guard_band; y++) {
+		// Top guardband
+		uint8* drow = reinterpret_cast<unsigned char*>(lsurf->pixels) + y * spitch;
+		uint8* srow = reinterpret_cast<unsigned char*>(lsurf->pixels) + guard_band * spitch;
+		memcpy(drow, srow, lsurf->w);
+		// Bottom guardband
+		srow = reinterpret_cast<unsigned char*>(lsurf->pixels) + (guard_band + logh - 1) * spitch;
+		drow = reinterpret_cast<unsigned char*>(lsurf->pixels) + (guard_band + logh + y) * spitch;
+		memcpy(drow, srow, lsurf->w);
+	}
+
 	// Fixed-palette override for this layer, if any (else the live palette).
 	const std::vector<unsigned char>& pal_ov      = get_ui_cfg(layer.ui_kind).ui_palette_colors;
 	const unsigned char*              palette_rgb = pal_ov.empty() ? colors : pal_ov.data();
+
+	SDL_Palette* sdl_pal = SDL_GetSurfacePalette(lsurf);
+	if (!sdl_pal) {
+		return false;
+	}
+	SDL_Color cols[256];
+	for (int i = 0; i < 256; i++) {
+		if (has_ov && ov[i] != 0) {    // Translucent slot -> blend colour.
+			cols[i].r = GammaRed[(ov[i] >> 16) & 0xff];
+			cols[i].g = GammaGreen[(ov[i] >> 8) & 0xff];
+			cols[i].b = GammaBlue[ov[i] & 0xff];
+		} else {
+			cols[i].r = palette_rgb[3 * i];
+			cols[i].g = palette_rgb[3 * i + 1];
+			cols[i].b = palette_rgb[3 * i + 2];
+		}
+		cols[i].a = 255;
+	}
+	SDL_SetPaletteColors(sdl_pal, cols, 0, 256);
 
 	// A fully opaque layer (a full-screen scene) has no transparent index and no
 	// translucency, so skip the transparency matting entirely: scale the colours
@@ -323,9 +365,6 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 	// scene's legitimate use of the 'transparent' index (e.g. index 255 in an
 	// FLI frame) would be matted away to see-through.
 	if (layer.is_opaque()) {
-		const int    ossw  = ((logw + 3) & ~3) + 2 * gb;
-		const int    ossh  = logh + 2 * gb;
-		SDL_Surface* osrc8 = SDL_CreateSurface(ossw, ossh, SDL_PIXELFORMAT_INDEX8);
 		SDL_Surface* odst;
 		if (!SDL_LockTextureToSurface(layer.texture, nullptr, &odst)) {
 			const char* err = SDL_GetError();
@@ -334,198 +373,133 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 
 			return false;
 		}
-		if (odst->w < ossw * factor || odst->h < ossh * factor) {
+		if (odst->w < ssw * factor || odst->h < ssh * factor) {
 			std::cerr << " odst surface size too small after locking texture for layer '" << layer.get_name() << "' expected "
-					  << (ossw * factor) << "x" << (ossh * factor) << " got " << odst->w << "x" << odst->h << std::endl;
+					  << (ssw * factor) << "x" << (ssh * factor) << " got " << odst->w << "x" << odst->h << std::endl;
+			SDL_UnlockTexture(layer.texture);
 			return false;
 		}
 		bool done = false;
-		if (osrc8 && odst) {
-			SDL_Palette* sdl_pal = SDL_CreateSurfacePalette(osrc8);
-			if (sdl_pal) {
-				SDL_Color cols[256];
-				for (int i = 0; i < 256; i++) {
-					cols[i].r = palette_rgb[3 * i];
-					cols[i].g = palette_rgb[3 * i + 1];
-					cols[i].b = palette_rgb[3 * i + 2];
-					cols[i].a = 255;
-				}
-				SDL_SetPaletteColors(sdl_pal, cols, 0, 256);
-				uint8*    sp       = static_cast<uint8*>(osrc8->pixels);
-				const int sp_pitch = osrc8->pitch;
-				// Copy content at (gb,gb), replicating edge pixels into the guard
-				// band so the scaler does not bleed a stray colour at the border.
-				for (int y = 0; y < logh; y++) {
-					uint8*               drow = sp + static_cast<size_t>(y + gb) * sp_pitch;
-					const unsigned char* srow = src + static_cast<size_t>(y) * spitch;
-					memset(drow, srow[0], gb);
-					memcpy(drow + gb, srow, logw);
-					memset(drow + gb + logw, srow[logw - 1], ossw - gb - logw);
-				}
-				for (int y = 0; y < gb; y++) {
-					memcpy(sp + static_cast<size_t>(y) * sp_pitch, sp + static_cast<size_t>(gb) * sp_pitch, ossw);
-				}
-				for (int y = logh + gb; y < ossh; y++) {
-					memcpy(sp + static_cast<size_t>(y) * sp_pitch, sp + static_cast<size_t>(logh + gb - 1) * sp_pitch, ossw);
-				}
-				if (scale_layer_color(layer, osrc8, logw, logh, odst)) {
-					auto          texpix = make_unique<uint32[]>(static_cast<size_t>(tex_w) * tex_h);
-					const uint32* pix    = static_cast<const uint32*>(odst->pixels);
-					const size_t  dpitch = static_cast<size_t>(odst->pitch) / sizeof(uint32);
-					const size_t  sgb    = static_cast<size_t>(factor) * gb;
-					for (int y = 0; y < tex_h; y++) {
-						const uint32* row  = pix + (static_cast<size_t>(y) + sgb) * dpitch + sgb;
-						uint32*       trow = texpix.get() + static_cast<size_t>(y) * tex_w;
-						for (int x = 0; x < tex_w; x++) {
-							trow[x] = 0xff000000u | (row[x] & 0x00ffffffu);
-						}
-					}
-					SDL_UnlockTexture(layer.texture);
-					done = true;
-				}
+		if (odst) {
+			if (scale_layer_color(layer, lsurf, logw, logh, odst)) {
+				auto texpix = make_unique<uint32[]>(static_cast<size_t>(tex_w) * tex_h);
+
+				done = true;
 			}
 		}
 
-		if (osrc8) {
-			SDL_DestroySurface(osrc8);
-		}
+		SDL_UnlockTexture(layer.texture);
 		if (done) {
 			return true;
 		}
 		// If the fast path failed, fall through to the normal (matting) path.
 	}
 
-	// Guard-banded 8-bit source (content at (gb,gb)) and a scaled 32-bit dest.
-	const int    ssw    = ((logw + 3) & ~3) + 2 * gb;
-	const int    ssh    = logh + 2 * gb;
-	SDL_Surface* src8   = SDL_CreateSurface(ssw, ssh, SDL_PIXELFORMAT_INDEX8);
 	SDL_Surface* dst32  = get_layer_dst32_surface(0, ssw * factor, ssh * factor);
 	SDL_Surface* dst32b = get_layer_dst32_surface(1, ssw * factor, ssh * factor);
 	SDL_Surface* dst32c = nullptr;
 	bool         ok     = false;
 	bool         have3  = false;
-	if (src8 && dst32 && dst32b) {
-		SDL_Palette* sdl_pal = SDL_CreateSurfacePalette(src8);
-		if (sdl_pal) {
-			SDL_Color cols[256];
-			for (int i = 0; i < 256; i++) {
-				if (has_ov && ov[i] != 0) {    // Translucent slot -> blend colour.
-					cols[i].r = GammaRed[(ov[i] >> 16) & 0xff];
-					cols[i].g = GammaGreen[(ov[i] >> 8) & 0xff];
-					cols[i].b = GammaBlue[ov[i] & 0xff];
-				} else {
-					cols[i].r = palette_rgb[3 * i];
-					cols[i].g = palette_rgb[3 * i + 1];
-					cols[i].b = palette_rgb[3 * i + 2];
-				}
-				cols[i].a = 255;
-			}
-			SDL_SetPaletteColors(sdl_pal, cols, 0, 256);
-			// Pad with the transparent index, then copy the content.
-			uint8*    sp       = static_cast<uint8*>(src8->pixels);
-			const int sp_pitch = src8->pitch;
-			for (int y = 0; y < ssh; y++) {
-				memset(sp + static_cast<size_t>(y) * sp_pitch, transp, ssw);
-			}
-			for (int y = 0; y < logh; y++) {
-				memcpy(sp + static_cast<size_t>(y + gb) * sp_pitch + gb, src + static_cast<size_t>(y) * spitch, logw);
-			}
-			// CONSENSUS DIFFERENCE MATTING: run the colour scaler with a pure
-			// red, then a pure green fill under the transparent index. Wherever
-			// the two outputs differ, the difference measures how much
-			// transparent colour the scaler mixed into that pixel; from that we
-			// recover the TRUE un-bled colour and the scaler's own smooth edge
-			// coverage. Two passes are enough when they agree everywhere; only
-			// if some pixel disagrees (the shape contains a colour close to red
-			// or green, making the edge-directed scalers branch differently in
-			// that pass) do we run a THIRD pass with a blue fill, and each
-			// pixel then picks whichever PAIR of passes agrees best. So the
-			// common case costs two scaler runs, and tricky shapes three.
-			SDL_Color fill;
-			fill.a = 255;
-			fill.r = 255;
-			fill.g = 0;
-			fill.b = 0;    // Pass 1: red under transparency.
-			SDL_SetPaletteColors(sdl_pal, &fill, transp, 1);
-			const bool ok1 = scale_layer_color(layer, src8, logw, logh, dst32);
-			fill.r         = 0;
-			fill.g         = 255;
-			fill.b         = 0;    // Pass 2: green under transparency.
-			SDL_SetPaletteColors(sdl_pal, &fill, transp, 1);
-			const bool ok2 = scale_layer_color(layer, src8, logw, logh, dst32b);
-			ok             = ok1 && ok2;
-			if (ok) {
-				// Pre-scan: do the red/green passes disagree anywhere? (Early
-				// exit on the first such pixel; this is far cheaper than an
-				// unconditional third scaler run.)
-				const uint32* pix1             = static_cast<const uint32*>(dst32->pixels);
-				const uint32* pix2             = static_cast<const uint32*>(dst32b->pixels);
-				const size_t  dpitch           = static_cast<size_t>(dst32->pitch) / sizeof(uint32);
-				const size_t  scaled_guardband = static_cast<size_t>(factor) * static_cast<size_t>(gb);
-				bool          needs3           = false;
-				for (int y = 0; y < tex_h && !needs3; y++) {
-					const size_t  roff = (static_cast<size_t>(y) + scaled_guardband) * dpitch + scaled_guardband;
-					const uint32* row1 = pix1 + roff;
-					const uint32* row2 = pix2 + roff;
-					for (int x = 0; x < tex_w; x++) {
-						const uint32 p1   = row1[x];
-						const uint32 p2   = row2[x];
-						const int    t12a = static_cast<int>((p1 >> 16) & 0xff) - static_cast<int>((p2 >> 16) & 0xff);
-						const int    t12b = static_cast<int>((p2 >> 8) & 0xff) - static_cast<int>((p1 >> 8) & 0xff);
-						if (std::abs(t12a - t12b) > 96) {
-							needs3 = true;
-							break;
-						}
+	if (dst32 && dst32b) {
+		// CONSENSUS DIFFERENCE MATTING: run the colour scaler with a pure
+		// red, then a pure green fill under the transparent index. Wherever
+		// the two outputs differ, the difference measures how much
+		// transparent colour the scaler mixed into that pixel; from that we
+		// recover the TRUE un-bled colour and the scaler's own smooth edge
+		// coverage. Two passes are enough when they agree everywhere; only
+		// if some pixel disagrees (the shape contains a colour close to red
+		// or green, making the edge-directed scalers branch differently in
+		// that pass) do we run a THIRD pass with a blue fill, and each
+		// pixel then picks whichever PAIR of passes agrees best. So the
+		// common case costs two scaler runs, and tricky shapes three.
+		SDL_Color fill;
+		fill.a = 255;
+		fill.r = 255;
+		fill.g = 0;
+		fill.b = 0;    // Pass 1: red under transparency.
+		SDL_SetPaletteColors(sdl_pal, &fill, transp, 1);
+		const bool ok1 = scale_layer_color(layer, lsurf, logw, logh, dst32);
+		fill.r         = 0;
+		fill.g         = 255;
+		fill.b         = 0;    // Pass 2: green under transparency.
+		SDL_SetPaletteColors(sdl_pal, &fill, transp, 1);
+		const bool ok2 = scale_layer_color(layer, lsurf, logw, logh, dst32b);
+		ok             = ok1 && ok2;
+		if (ok) {
+			// Pre-scan: do the red/green passes disagree anywhere? (Early
+			// exit on the first such pixel; this is far cheaper than an
+			// unconditional third scaler run.)
+			const uint32* pix1   = static_cast<const uint32*>(dst32->pixels);
+			const uint32* pix2   = static_cast<const uint32*>(dst32b->pixels);
+			const size_t  dpitch = static_cast<size_t>(dst32->pitch) / sizeof(uint32);
+			bool          needs3 = false;
+			for (int y = 0; y < tex_h && !needs3; y++) {
+				const size_t  roff = (static_cast<size_t>(y)) * dpitch;
+				const uint32* row1 = pix1 + roff;
+				const uint32* row2 = pix2 + roff;
+				for (int x = 0; x < tex_w; x++) {
+					const uint32 p1   = row1[x];
+					const uint32 p2   = row2[x];
+					const int    t12a = static_cast<int>((p1 >> 16) & 0xff) - static_cast<int>((p2 >> 16) & 0xff);
+					const int    t12b = static_cast<int>((p2 >> 8) & 0xff) - static_cast<int>((p1 >> 8) & 0xff);
+					if (std::abs(t12a - t12b) > 96) {
+						needs3 = true;
+						break;
 					}
 				}
-				if (needs3) {
-					dst32c = get_layer_dst32_surface(2, ssw * factor, ssh * factor);
-					if (dst32c) {
-						fill.r = 0;
-						fill.g = 0;
-						fill.b = 255;    // Pass 3: blue under transparency.
-						SDL_SetPaletteColors(sdl_pal, &fill, transp, 1);
-						have3 = scale_layer_color(layer, src8, logw, logh, dst32c);
-					}
+			}
+			if (needs3) {
+				dst32c = get_layer_dst32_surface(2, ssw * factor, ssh * factor);
+				if (dst32c) {
+					fill.r = 0;
+					fill.g = 0;
+					fill.b = 255;    // Pass 3: blue under transparency.
+					SDL_SetPaletteColors(sdl_pal, &fill, transp, 1);
+					have3 = scale_layer_color(layer, lsurf, logw, logh, dst32c);
 				}
 			}
 		}
 	}
 
-	int     texpix_pitch;
-	char *texpix=nullptr;
+	int   texpix_pitch;
+	char* texpix = nullptr;
 	if (!SDL_LockTexture(layer.texture, nullptr, reinterpret_cast<void**>(&texpix), &texpix_pitch)) {
 		const char* err = SDL_GetError();
-		std::cerr << "SDL_LockTexture failed trying to lock texture for layer " << layer.get_name() << ":"
-					<< (err ? err : "") << std::endl;
+		std::cerr << "SDL_LockTexture failed trying to lock texture for layer " << layer.get_name() << ":" << (err ? err : "")
+				  << std::endl;
 
 		return false;
 	}
 
 	if (ok) {
-		const uint32* pix1             = static_cast<const uint32*>(dst32->pixels);
-		const uint32* pix2             = static_cast<const uint32*>(dst32b->pixels);
-		const uint32* pix3             = have3 ? static_cast<const uint32*>(dst32c->pixels) : nullptr;
-		const size_t  dpitch           = static_cast<size_t>(dst32->pitch) / sizeof(uint32);
-		const size_t  scaled_guardband = static_cast<size_t>(factor) * static_cast<size_t>(gb);
+		const uint32* pix1    = static_cast<const uint32*>(dst32->pixels);
+		const uint32* pix2    = static_cast<const uint32*>(dst32b->pixels);
+		const uint32* pix3    = have3 ? static_cast<const uint32*>(dst32c->pixels) : nullptr;
+		const size_t  dpitch  = static_cast<size_t>(dst32->pitch) / sizeof(uint32);
+		const size_t  dpitchb = static_cast<size_t>(dst32b->pitch) / sizeof(uint32);
+		const size_t  dpitchc = have3 ? static_cast<size_t>(dst32c->pitch) / sizeof(uint32) : 0;
 		for (int y = 0; y < tex_h; y++) {
-			const int            sy   = y / factor;
-			const size_t         roff = (static_cast<size_t>(y) + scaled_guardband) * dpitch + scaled_guardband;
-			const uint32*        row1 = pix1 + roff;
-			const uint32*        row2 = pix2 + roff;
-			const uint32*        row3 = have3 ? pix3 + roff : nullptr;
-			const unsigned char* srow = src + static_cast<size_t>(sy) * spitch;
-			uint32*              trow = reinterpret_cast<uint32*>(texpix + static_cast<size_t>(y) * texpix_pitch);
+			int                  realy = y + factor * guard_band;
+			const int            sy    = y / factor;
+			const size_t         roff1 = (static_cast<size_t>(realy)) * dpitch;
+			const size_t         roff2 = (static_cast<size_t>(realy)) * dpitchb;
+			const size_t         roff3 = (static_cast<size_t>(realy)) * dpitchc;
+			const uint32*        row1  = pix1 + roff1;
+			const uint32*        row2  = pix2 + roff2;
+			const uint32*        row3  = have3 ? pix3 + roff3 : nullptr;
+			const unsigned char* srow  = src + static_cast<size_t>(sy) * spitch;
+			uint32*              trow  = reinterpret_cast<uint32*>(texpix + static_cast<size_t>(realy) * texpix_pitch);
 			for (int x = 0; x < tex_w; x++) {
-				const unsigned char idx = srow[x / factor];
-				const uint32        p1  = row1[x];
-				const uint32        p2  = row2[x];
-				const int           r1  = (p1 >> 16) & 0xff;
-				const int           g1  = (p1 >> 8) & 0xff;
-				const int           b1  = p1 & 0xff;
-				const int           r2  = (p2 >> 16) & 0xff;
-				const int           g2  = (p2 >> 8) & 0xff;
-				const int           b2  = p2 & 0xff;
+				int                 realx = x + factor * guard_band;
+				const unsigned char idx   = srow[x / factor];
+				const uint32        p1    = row1[realx];
+				const uint32        p2    = row2[realx];
+				const int           r1    = (p1 >> 16) & 0xff;
+				const int           g1    = (p1 >> 8) & 0xff;
+				const int           b1    = p1 & 0xff;
+				const int           r2    = (p2 >> 16) & 0xff;
+				const int           g2    = (p2 >> 8) & 0xff;
+				const int           b2    = p2 & 0xff;
 				// For each pair of passes, two independent estimates of the
 				// transparent fraction t (0..255) from the channels where the
 				// fills differ by 255. If a pair's estimates agree, both its
@@ -536,7 +510,7 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 				int       use   = 1;                         // Which pass to un-blend from (1 or 2).
 				int       sbest = std::abs(t12a - t12b);
 				if (have3) {
-					const uint32 p3   = row3[x];
+					const uint32 p3   = row3[realx];
 					const int    r3   = (p3 >> 16) & 0xff;
 					const int    g3   = (p3 >> 8) & 0xff;
 					const int    b3   = p3 & 0xff;
@@ -597,7 +571,7 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 					intrinsic = 255;    // Opaque (or an outer AA pixel).
 				}
 				const uint32 a = static_cast<uint32>(cov * intrinsic / 255);
-				trow[x]        = (a << 24) | rgb;
+				trow[realx]    = (a << 24) | rgb;
 			}
 		}
 	} else {
@@ -610,9 +584,8 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 			}
 		}
 	}
+
 	SDL_UnlockTexture(layer.texture);
-	if (src8) {
-		SDL_DestroySurface(src8);
-	}
+
 	return true;
 }

--- a/imagewin/iwin8.cc
+++ b/imagewin/iwin8.cc
@@ -399,8 +399,8 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 	const int    ssw    = ((logw + 3) & ~3) + 2 * gb;
 	const int    ssh    = logh + 2 * gb;
 	SDL_Surface* src8   = SDL_CreateSurface(ssw, ssh, SDL_PIXELFORMAT_INDEX8);
-	SDL_Surface* dst32  = SDL_CreateSurface(ssw * factor, ssh * factor, SDL_PIXELFORMAT_ARGB8888);
-	SDL_Surface* dst32b = SDL_CreateSurface(ssw * factor, ssh * factor, SDL_PIXELFORMAT_ARGB8888);
+	SDL_Surface* dst32  = get_layer_dst32_surface(0, ssw * factor, ssh * factor);
+	SDL_Surface* dst32b = get_layer_dst32_surface(1, ssw * factor, ssh * factor);
 	SDL_Surface* dst32c = nullptr;
 	bool         ok     = false;
 	bool         have3  = false;
@@ -479,7 +479,7 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 					}
 				}
 				if (needs3) {
-					dst32c = SDL_CreateSurface(ssw * factor, ssh * factor, SDL_PIXELFORMAT_ARGB8888);
+					dst32c = get_layer_dst32_surface(2, ssw * factor, ssh * factor);
 					if (dst32c) {
 						fill.r = 0;
 						fill.g = 0;
@@ -611,15 +611,6 @@ bool Image_window8::refresh_layer_scaled(Layer& layer, int factor) {
 		}
 	}
 	SDL_UnlockTexture(layer.texture);
-	if (dst32c) {
-		SDL_DestroySurface(dst32c);
-	}
-	if (dst32b) {
-		SDL_DestroySurface(dst32b);
-	}
-	if (dst32) {
-		SDL_DestroySurface(dst32);
-	}
 	if (src8) {
 		SDL_DestroySurface(src8);
 	}

--- a/ios/Exult.xcodeproj/project.pbxproj
+++ b/ios/Exult.xcodeproj/project.pbxproj
@@ -1,4 +1,4 @@
-// !$*UTF8*$!
+﻿// !$*UTF8*$!
 {
 	archiveVersion = 1;
 	classes = {
@@ -70,6 +70,7 @@
 		8AE5D3C21D2A0D9601379947 /* cheat_screen_actors.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8ADFFDF825DE791000FC4D3A /* cheat_screen_actors.cc */; };
 		8AE8B9BE2E400B740094DF3C /* SDL3.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AE8B9BC2E400B4F0094DF3C /* SDL3.framework */; };
 		8AE8B9BF2E400B740094DF3C /* SDL3.framework in Embedd SDL3 Framework */ = {isa = PBXBuildFile; fileRef = 8AE8B9BC2E400B4F0094DF3C /* SDL3.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8AEBA98E1475A21C0172E554 /* perf.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8ADFFDFA25DE791000FC4D3A /* perf.cc */; };
 		8AF2AFDF2016708100696E08 /* joypad-glass-southwest.png in Resources */ = {isa = PBXBuildFile; fileRef = 8AF2AFD62016707F00696E08 /* joypad-glass-southwest.png */; };
 		8AF2AFE02016708100696E08 /* joypad-glass-north.png in Resources */ = {isa = PBXBuildFile; fileRef = 8AF2AFD72016708000696E08 /* joypad-glass-north.png */; };
 		8AF2AFE12016708100696E08 /* joypad-glass.png in Resources */ = {isa = PBXBuildFile; fileRef = 8AF2AFD82016708000696E08 /* joypad-glass.png */; };
@@ -430,6 +431,8 @@
 		8ADFFDF525DE791000FC4D3A /* verify.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = verify.h; path = ../verify.h; sourceTree = "<group>"; };
 		8ADFFDF725DE791000FC4D3A /* cheat_screen_strings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cheat_screen_strings.h; path = ../cheat_screen_strings.h; sourceTree = "<group>"; };
 		8ADFFDF825DE791000FC4D3A /* cheat_screen_actors.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cheat_screen_actors.cc; path = ../cheat_screen_actors.cc; sourceTree = "<group>"; };
+		8ADFFDF925DE791000FC4D3A /* perf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = perf.h; path = ../perf.h; sourceTree = "<group>"; };
+		8ADFFDFA25DE791000FC4D3A /* perf.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = perf.cc; path = ../perf.cc; sourceTree = "<group>"; };
 		8AE3D1093001610500BCB1FF /* scene_layer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = scene_layer.h; path = ../scene_layer.h; sourceTree = SOURCE_ROOT; };
 		8AE8B9BC2E400B4F0094DF3C /* SDL3.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SDL3.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AF2AFD62016707F00696E08 /* joypad-glass-southwest.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "joypad-glass-southwest.png"; sourceTree = "<group>"; };
@@ -1119,6 +1122,8 @@
 				8ADFFDF525DE791000FC4D3A /* verify.h */,
 				8ADFFDF725DE791000FC4D3A /* cheat_screen_strings.h */,
 				8ADFFDF825DE791000FC4D3A /* cheat_screen_actors.cc */,
+				8ADFFDF925DE791000FC4D3A /* perf.h */,
+				8ADFFDFA25DE791000FC4D3A /* perf.cc */,
 				E700DC341A6E30A7006C8BE4 /* actions.cc */,
 				E700DC351A6E30A7006C8BE4 /* actions.h */,
 				E700DC361A6E30A7006C8BE4 /* actorio.cc */,
@@ -1970,6 +1975,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8AEBA98E1475A21C0172E554 /* perf.cc in Sources */,
 				8AE5D3C21D2A0D9601379947 /* cheat_screen_actors.cc in Sources */,
 				8AC797C81C8D0E4F001AF014 /* zip.cc in Sources */,
 				E700DF441A6E34C6006C8BE4 /* debugserver.cc in Sources */,

--- a/keyactions.cc
+++ b/keyactions.cc
@@ -51,6 +51,7 @@
 #include "mouse.h"
 #include "palette.h"
 #include "party.h"
+#include "perf.h"
 #include "ucmachine.h"
 #include "version.h"
 
@@ -978,4 +979,8 @@ void ActionTest(const int* params) {
 
 void ActionToggleBBoxes(const int* /*params*/) {
 	Game_window::get_instance()->get_render()->increment_bbox_index();
+}
+
+void ActionPerfMetrics(const int* /*params*/) {
+	PerformanceTimer::IncMode();
 }

--- a/keyactions.h
+++ b/keyactions.h
@@ -115,4 +115,5 @@ void ActionSoundTester(const int* params);
 void ActionTest(const int* params);
 
 void ActionToggleBBoxes(const int* params);
+void ActionPerfMetrics(const int* params);
 #endif

--- a/keys.cc
+++ b/keys.cc
@@ -187,7 +187,8 @@ const struct Action {
 		{       "WRITE_MINIMAP",       ActionWriteMiniMap,           nullptr, 0x854, Action::mapedit_keys,         NONE, false,  true,  true, false},
 		{             "REPAINT",            ActionRepaint,           nullptr, 0x855,    Action::dont_show,         NONE,  true,  true,  true, false},
 		{       "TOGGLE_BBOXES",       ActionToggleBBoxes,           nullptr, 0x856, Action::mapedit_keys,         NONE, false,  true,  true, false},
-		{                    "",                  nullptr,           nullptr,     0,    Action::dont_show,         NONE, false, false, false, false}  //  terminator
+		{       "PERF_METRICS",         ActionPerfMetrics,           nullptr, 0x856, Action::dont_show,            NONE, false,  true,  true, false},
+		{                    "",                  nullptr,           nullptr,     0,    Action::dont_show,         NONE, true,  true,  true, false}  //  terminator
 		// clang-format on
 };
 

--- a/mouse.cc
+++ b/mouse.cc
@@ -202,7 +202,7 @@ bool Mouse::ensure_mouse_layer() {
 	if (layer_w <= 0 || layer_h <= 0) {
 		return false;
 	}
-	mouse_layer = gwin->create_layer(layer_w, layer_h, 255, 0, mouse_layer_z);
+	mouse_layer = gwin->create_layer("mouse", layer_w, layer_h, 255, 0, mouse_layer_z);
 	if (mouse_layer < 0) {
 		return false;
 	}

--- a/msvcstuff/vs2019/Exult.vcxproj
+++ b/msvcstuff/vs2019/Exult.vcxproj
@@ -528,6 +528,7 @@ for /f "tokens=* delims=" %%u in ('git ls-remote --get-url') do echo #define GIT
     <ClCompile Include="..\..\pathfinder\PathFinder.cc" />
     <ClCompile Include="..\..\pathfinder\Zombie.cc" />
     <ClCompile Include="..\..\paths.cc" />
+    <ClCompile Include="..\..\perf.cc" />
     <ClCompile Include="..\..\playscene.cc" />
     <ClCompile Include="..\..\readnpcs.cc" />
     <ClCompile Include="..\..\schedule.cc" />
@@ -774,6 +775,7 @@ for /f "tokens=* delims=" %%u in ('git ls-remote --get-url') do echo #define GIT
     <ClInclude Include="..\..\pathfinder\PathFinder.h" />
     <ClInclude Include="..\..\pathfinder\Zombie.h" />
     <ClInclude Include="..\..\paths.h" />
+    <ClInclude Include="..\..\perf.h" />
     <ClInclude Include="..\..\playscene.h" />
     <ClInclude Include="..\..\rect.h" />
     <ClInclude Include="..\..\schedule.h" />

--- a/msvcstuff/vs2019/Exult.vcxproj.filters
+++ b/msvcstuff/vs2019/Exult.vcxproj.filters
@@ -776,6 +776,9 @@
     <ClCompile Include="..\..\cheat_screen_actors.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\perf.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\actions.h">
@@ -1538,6 +1541,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\cheat_screen_strings.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\perf.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/perf.cc
+++ b/perf.cc
@@ -97,6 +97,7 @@ void PerformanceTimer::paintPerfMetrics() {
 			gwin->layer_set_index_argb(layer_handle, rgba);
 		}
 		gwin->layer_set_dest(layer_handle, 0, 0, int(960 * scale_factor), int(720 * scale_factor));
+		gwin->layer_set_ui_kind(layer_handle, Image_window::UiLayerFullScreenNoScaler);
 	}
 	if (mode == 1) {
 		if (layer_handle_mini == -1) {
@@ -109,6 +110,7 @@ void PerformanceTimer::paintPerfMetrics() {
 			std::memset(rgba, 255, sizeof(rgba));
 			rgba[254] = 0xAf000000;
 			gwin->layer_set_index_argb(layer_handle_mini, rgba);
+			gwin->layer_set_ui_kind(layer_handle_mini, Image_window::UiLayerFullScreenNoScaler);
 		}
 		gwin->layer_set_dest(layer_handle_mini, 0, 0, int(256 * scale_factor), int(20 * scale_factor));
 	}

--- a/perf.cc
+++ b/perf.cc
@@ -97,7 +97,7 @@ void PerformanceTimer::paintPerfMetrics() {
 			gwin->layer_set_index_argb(layer_handle, rgba);
 		}
 		gwin->layer_set_dest(layer_handle, 0, 0, int(960 * scale_factor), int(720 * scale_factor));
-		gwin->layer_set_ui_kind(layer_handle, Image_window::UiLayerFullScreenNoScaler);
+		gwin->layer_set_ui_kind(layer_handle, Image_window::UiLayerFullScreenBilinear);
 	}
 	if (mode == 1) {
 		if (layer_handle_mini == -1) {
@@ -110,7 +110,7 @@ void PerformanceTimer::paintPerfMetrics() {
 			std::memset(rgba, 255, sizeof(rgba));
 			rgba[254] = 0xAf000000;
 			gwin->layer_set_index_argb(layer_handle_mini, rgba);
-			gwin->layer_set_ui_kind(layer_handle_mini, Image_window::UiLayerFullScreenNoScaler);
+			gwin->layer_set_ui_kind(layer_handle_mini, Image_window::UiLayerFullScreenBilinear);
 		}
 		gwin->layer_set_dest(layer_handle_mini, 0, 0, int(256 * scale_factor), int(20 * scale_factor));
 	}

--- a/perf.cc
+++ b/perf.cc
@@ -115,6 +115,10 @@ void PerformanceTimer::paintPerfMetrics() {
 
 	if (font) {
 		ibuf = gwin->get_layer_ibuf(mode == 2 ? layer_handle : layer_handle_mini);
+		if (!ibuf) {
+			// Shouldn't happen but just in case
+			return;
+		}
 		ibuf->fill8(255);
 		Image_buffer8* prev_ibuf = gwin->push_render_target(ibuf);
 		int            y = 0, xlimit = 0;

--- a/perf.cc
+++ b/perf.cc
@@ -1,0 +1,144 @@
+/**
+**  perf.cc - PerformanceTimer class implemenation
+**
+**/
+
+/*
+Copyright (C) 2026 The Exult Team
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with this library; if not, write to the
+Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+Boston, MA  02111-1307, USA.
+*/
+#include "perf.h"
+
+#include "gamewin.h"
+
+#include <SDL3/SDL.h>
+
+PerformanceTimer* PerformanceTimer::all    = nullptr;
+PerformanceTimer* PerformanceTimer::active = nullptr;
+int               PerformanceTimer::mode   = 0;
+
+PerformanceTimer& PerformanceTimer::GetPerfTimer(std::string_view name, std::string_view name2, bool unique) {
+	if (!mode) {
+		static PerformanceTimer none;
+		return none;
+	}
+	PerformanceTimer* node;
+	for (node = all; node; node = node->next) {
+		// Use node with matching name if unique is false or the node hasn't been used this frame
+		std::string_view node_name = node->name;
+		if (node_name.substr(0, name.size()) == name && node_name.substr(name.size()) == name2 && (!unique || !node->used)) {
+			return *node;
+		}
+	}
+	node = new PerformanceTimer();
+	node->name.reserve(name.size() + name2.size());
+	node->name += name;
+	node->name += name2;
+	node->AddToList(all);
+	return *node;
+}
+
+uint64 PerformanceTimer::GetNS() {
+	return SDL_GetTicksNS();
+}
+
+void PerformanceTimer::paintPerfMetrics() {
+	auto       gwin              = Game_window::get_instance();
+	static int layer_handle      = -1;
+	static int layer_handle_mini = -1;
+	if (layer_handle != -1) {
+		gwin->layer_set_visible(layer_handle, mode == 2);
+	}
+	if (layer_handle_mini != -1) {
+		gwin->layer_set_visible(layer_handle_mini, mode == 1);
+	}
+	if (!mode) {
+		return;
+	}
+
+	auto              font = fontManager.get_font("SMALL_BLACK_FONT");
+	Xform_palette     textbg;
+	uint32            rgba[256];
+	PerformanceTimer* node;
+	char              line[80];
+	Image_buffer8*    ibuf;
+
+	for (uint8 i = 0; i < 255; i++) {
+		textbg.colors[i] = i;
+	}
+	textbg.colors[255] = 254;
+	float scale_factor = 1.5f * 960.0f / gwin->get_win()->get_display_width();
+
+	if (mode == 2 && layer_handle == -1) {
+		layer_handle = gwin->create_layer("Perf text", 960, 720, 255, 0, INT_MAX);
+		if (layer_handle == -1) {
+			// Failed, do nothing
+			return;
+		}
+		// layer_set_ui_kind(layer_handle,)
+		gwin->layer_set_opaque(layer_handle, false);
+		std::memset(rgba, 255, sizeof(rgba));
+		rgba[254] = 0xAf000000;
+		gwin->layer_set_index_argb(layer_handle, rgba);
+		gwin->layer_set_dest(layer_handle, 0, 0, int(960 * scale_factor), int(720 * scale_factor));
+	}
+	if (mode == 1 && layer_handle_mini == -1) {
+		layer_handle_mini = gwin->create_layer("Perf text mini", 256, 20, 255, 0, INT_MAX);
+		if (layer_handle_mini == -1) {
+			// Failed, do nothing
+			return;
+		}
+		gwin->layer_set_opaque(layer_handle_mini, false);
+		std::memset(rgba, 255, sizeof(rgba));
+		rgba[254] = 0xAf000000;
+		gwin->layer_set_index_argb(layer_handle_mini, rgba);
+		gwin->layer_set_dest(layer_handle_mini, 0, 0, int(256 * scale_factor), int(20 * scale_factor));
+	}
+
+	auto& frameperf = GetPerfTimer("Frame", "", false);
+
+	frameperf.end_phase();
+
+	if (font) {
+		ibuf = gwin->get_layer_ibuf(mode == 2 ? layer_handle : layer_handle_mini);
+		ibuf->fill8(255);
+		Image_buffer8* prev_ibuf = gwin->push_render_target(ibuf);
+		int            y = 0, xlimit = 0;
+
+		auto frame = frameperf.value / 1000;
+		snprintf(line, 80, "Performance metrics %.02f fps", frame ? 1000000.0 / frame : 0);
+		xlimit = font->paint_text_fixedwidth(ibuf, line, 0, y++ * 9, 8);
+		ibuf->fill_translucent8(0, xlimit + 2, 9, 0, y * 9 - 9, textbg);
+
+		for (node = all; node; node = node->next) {
+			if (node->used && (mode == 2 || node == &frameperf)) {
+				auto time = node->value / 1000;
+				snprintf(line, 80, "%s: %lli us", node->name.c_str(), time);
+				xlimit = font->paint_text_fixedwidth(ibuf, line, 0, y++ * 9, 8);
+				ibuf->fill_translucent8(0, xlimit + 2, 9, 0, y * 9 - 9, textbg);
+			}
+		}
+		gwin->push_render_target(prev_ibuf);
+		gwin->layer_set_dirty(layer_handle);
+		gwin->set_all_dirty();
+	}
+
+	for (node = all; node; node = node->next) {
+		node->start_frame();
+	}
+	frameperf.start_phase(false);
+}

--- a/perf.cc
+++ b/perf.cc
@@ -81,31 +81,35 @@ void PerformanceTimer::paintPerfMetrics() {
 		textbg.colors[i] = i;
 	}
 	textbg.colors[255] = 254;
-	float scale_factor = 1.5f * 960.0f / gwin->get_win()->get_display_width();
+	float scale_factor = std::max(.75f, gwin->get_win()->get_display_width() / 1440.f);
 
-	if (mode == 2 && layer_handle == -1) {
-		layer_handle = gwin->create_layer("Perf text", 960, 720, 255, 0, INT_MAX);
+	if (mode == 2) {
 		if (layer_handle == -1) {
-			// Failed, do nothing
-			return;
+			layer_handle = gwin->create_layer("Perf text", 960, 720, 255, 0, INT_MAX);
+			if (layer_handle == -1) {
+				// Failed, do nothing
+				return;
+			}
+			// layer_set_ui_kind(layer_handle,)
+			gwin->layer_set_opaque(layer_handle, false);
+			std::memset(rgba, 255, sizeof(rgba));
+			rgba[254] = 0xAf000000;
+			gwin->layer_set_index_argb(layer_handle, rgba);
 		}
-		// layer_set_ui_kind(layer_handle,)
-		gwin->layer_set_opaque(layer_handle, false);
-		std::memset(rgba, 255, sizeof(rgba));
-		rgba[254] = 0xAf000000;
-		gwin->layer_set_index_argb(layer_handle, rgba);
 		gwin->layer_set_dest(layer_handle, 0, 0, int(960 * scale_factor), int(720 * scale_factor));
 	}
-	if (mode == 1 && layer_handle_mini == -1) {
-		layer_handle_mini = gwin->create_layer("Perf text mini", 256, 20, 255, 0, INT_MAX);
+	if (mode == 1) {
 		if (layer_handle_mini == -1) {
-			// Failed, do nothing
-			return;
+			layer_handle_mini = gwin->create_layer("Perf text mini", 256, 20, 255, 0, INT_MAX);
+			if (layer_handle_mini == -1) {
+				// Failed, do nothing
+				return;
+			}
+			gwin->layer_set_opaque(layer_handle_mini, false);
+			std::memset(rgba, 255, sizeof(rgba));
+			rgba[254] = 0xAf000000;
+			gwin->layer_set_index_argb(layer_handle_mini, rgba);
 		}
-		gwin->layer_set_opaque(layer_handle_mini, false);
-		std::memset(rgba, 255, sizeof(rgba));
-		rgba[254] = 0xAf000000;
-		gwin->layer_set_index_argb(layer_handle_mini, rgba);
 		gwin->layer_set_dest(layer_handle_mini, 0, 0, int(256 * scale_factor), int(20 * scale_factor));
 	}
 

--- a/perf.h
+++ b/perf.h
@@ -41,6 +41,11 @@ class PerformanceTimer {
 	PerformanceTimer*        next = nullptr;
 	PerformanceTimer*        prev = nullptr;
 
+	// Private default constructor
+	PerformanceTimer() {
+		start_frame();
+	}
+
 	void RemoveFromList(PerformanceTimer*& head) {
 		if (next) {
 			next->prev = prev;
@@ -72,10 +77,6 @@ class PerformanceTimer {
 public:
 	static void IncMode() {
 		mode = (mode + 1) % 3;
-	}
-
-	PerformanceTimer() {
-		start_frame();
 	}
 
 	void start_frame() {

--- a/perf.h
+++ b/perf.h
@@ -1,0 +1,140 @@
+/**
+**  perf.h - PerformanceTimer class to generate per frame Perfomance metrics
+**
+**/
+
+/*
+Copyright (C) 2026 The Exult Team
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with this library; if not, write to the
+Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+Boston, MA  02111-1307, USA.
+*/
+#ifndef PERF_H_INCLUDED
+#define PERF_H_INCLUDED
+
+#include "common_types.h"
+
+#include <string>
+#include <string_view>
+
+class PerformanceTimer {
+	uint64 start_time = 0;
+	uint64 value      = 0;
+	bool   used       = false;
+
+	std::string              name = {};
+	static PerformanceTimer* all;
+	static PerformanceTimer* active;
+	static int               mode;
+	PerformanceTimer*        next = nullptr;
+	PerformanceTimer*        prev = nullptr;
+
+	void RemoveFromList(PerformanceTimer*& head) {
+		if (next) {
+			next->prev = prev;
+		}
+		if (prev) {
+			prev->next = next;
+		}
+		if (this == head) {
+			head = next;
+		}
+		next = nullptr;
+		prev = nullptr;
+	}
+
+	void AddToList(PerformanceTimer*& head) {
+		if (this == head) {
+			return;
+		}
+		next = head;
+		head = this;
+		prev = nullptr;
+		if (next) {
+			next->prev = this;
+		}
+	}
+
+	static uint64 GetNS();
+
+public:
+	static void IncMode() {
+		mode = (mode + 1) % 3;
+	}
+
+	PerformanceTimer() {
+		start_frame();
+	}
+
+	void start_frame() {
+		if (!mode) {
+			return;
+		}
+		start_time = 0;
+		value      = 0;
+		used       = false;
+	}
+
+	void start_phase(bool swaplists = true) {
+		if (!mode) {
+			return;
+		}
+		start_time = GetNS();
+		used       = true;
+
+		if (swaplists) {
+			RemoveFromList(all);
+			AddToList(active);
+		}
+	}
+
+	void end_phase() {
+		if (!mode) {
+			return;
+		}
+		auto delta = GetNS() - start_time;
+		value += delta;
+
+		RemoveFromList(active);
+		AddToList(all);
+
+		// remove our time from the timers that are active
+		for (auto node = active; node; node = node->next) {
+			node->start_time += delta;
+		}
+	}
+
+	struct ScopedPerfTimer {
+		PerformanceTimer& counter;
+
+		ScopedPerfTimer(PerformanceTimer& counter) : counter(counter) {
+			counter.start_phase();
+		}
+
+		~ScopedPerfTimer() {
+			counter.end_phase();
+		}
+	};
+
+	static PerformanceTimer& GetPerfTimer(std::string_view name, std::string_view name2 = {}, bool unique = false);
+
+	static ScopedPerfTimer GetScopedPerfTimer(std::string_view name, std::string_view name2 = {}, bool unique = false) {
+		return GetPerfTimer(name, name2, unique);
+	}
+
+	static void paintPerfMetrics();
+};
+
+#endif    // PERF_H_INCLUDED

--- a/scene_layer.h
+++ b/scene_layer.h
@@ -50,7 +50,7 @@ public:
 		gwin->set_ui_layer_config(
 				Image_window::UiLayerFullScreenScene, scene_w, scene_h, iwin->get_scaler(), Image_window::Fill,
 				iwin->get_fill_scaler());
-		handle = gwin->create_layer(scene_w, scene_h, transparent_index, 0, scene_layer_z);
+		handle = gwin->create_layer("scene", scene_w, scene_h, transparent_index, 0, scene_layer_z);
 		if (handle >= 0) {
 			gwin->layer_set_ui_kind(handle, Image_window::UiLayerFullScreenScene);
 			// A scene is a full-screen opaque takeover: NO palette index is

--- a/usecode/conversation.cc
+++ b/usecode/conversation.cc
@@ -217,7 +217,7 @@ TileRect Conversation::get_conv_rect() const {
  */
 int Conversation::get_conv_layer() {
 	if (conv_layer < 0) {
-		conv_layer = gwin->create_layer(conv_width, conv_height, conv_transparent);
+		conv_layer = gwin->create_layer("conv", conv_width, conv_height, conv_transparent, 0, 0);
 		if (conv_layer >= 0) {
 			gwin->layer_set_ui_kind(conv_layer, Image_window::UiLayerConversations);
 			// Let the layer render translucent (Guardian/serpent) pixels with
@@ -251,7 +251,7 @@ int Conversation::get_conv_layer() {
 
 int Conversation::get_conv_bg_layer() {
 	if (conv_bg_layer < 0) {
-		conv_bg_layer = gwin->create_layer(conv_width, conv_height, conv_transparent, 0, -1);
+		conv_bg_layer = gwin->create_layer("convbg", conv_width, conv_height, conv_transparent, 0, -1);
 		if (conv_bg_layer >= 0) {
 			gwin->layer_set_ui_kind(conv_bg_layer, Image_window::UiLayerConversations);
 			gwin->layer_set_alpha(conv_bg_layer, conv_bg_alpha);

--- a/usecode/intrinsics.cc
+++ b/usecode/intrinsics.cc
@@ -979,7 +979,7 @@ USECODE_INTRINSIC(npc_nearby) {
 	const Tile_coord pos = obj->get_tile();
 	Actor*           npc;
 	const bool       is_near = gwin->get_win_tile_rect().has_world_point(pos.tx, pos.ty) &&
-							   // Guessing: true if non-NPC, false if NPC is dead, asleep or
+						 // Guessing: true if non-NPC, false if NPC is dead, asleep or
 						 // paralyzed.
 						 ((npc = as_actor(obj)) == nullptr || npc->can_act());
 	Usecode_value u(is_near);
@@ -1431,7 +1431,7 @@ USECODE_INTRINSIC(summon) {
 	}
 	const Tile_coord start = gwin->get_main_actor()->get_tile();
 	const Tile_coord dest  = Map_chunk::find_spot(
-			start, 5, shapenum, 0, 1, -1, gwin->is_main_actor_inside() ? Map_chunk::inside : Map_chunk::outside);
+            start, 5, shapenum, 0, 1, -1, gwin->is_main_actor_inside() ? Map_chunk::inside : Map_chunk::outside);
 	if (dest.tx == -1) {
 		return Usecode_value(0);
 	}
@@ -1482,7 +1482,7 @@ public:
 			return;
 		}
 		if (layer < 0) {
-			layer = gwin->create_layer(w, h, 255, 0, display_map_layer_z);
+			layer = gwin->create_layer("map", w, h, 255, 0, display_map_layer_z);
 			if (layer < 0) {
 				return;
 			}
@@ -1963,10 +1963,9 @@ USECODE_INTRINSIC(sprite_effect) {
 	// Validate sprite number is in valid range before creating effect
 	Shape_manager* sman = Shape_manager::get_instance();
 	if (sprite_num >= 0 && sprite_num < sman->get_file(SF_SPRITES_VGA).get_num_shapes()) {
-		gwin->get_effects()->add_effect(
-				std::make_unique<Sprites_effect>(
-						sprite_num, Tile_coord(parms[1].get_int_value(), parms[2].get_int_value(), 0), parms[3].get_int_value(),
-						parms[4].get_int_value(), 0, parms[5].get_int_value(), parms[6].get_int_value()));
+		gwin->get_effects()->add_effect(std::make_unique<Sprites_effect>(
+				sprite_num, Tile_coord(parms[1].get_int_value(), parms[2].get_int_value(), 0), parms[3].get_int_value(),
+				parms[4].get_int_value(), 0, parms[5].get_int_value(), parms[6].get_int_value()));
 	}
 	return no_ret;
 }
@@ -1980,10 +1979,9 @@ USECODE_INTRINSIC(obj_sprite_effect) {
 		// Validate sprite number is in valid range before creating effect
 		Shape_manager* sman = Shape_manager::get_instance();
 		if (sprite_num >= 0 && sprite_num < sman->get_file(SF_SPRITES_VGA).get_num_shapes()) {
-			gwin->get_effects()->add_effect(
-					std::make_unique<Sprites_effect>(
-							sprite_num, obj, -parms[2].get_int_value(), -parms[3].get_int_value(), parms[4].get_int_value(),
-							parms[5].get_int_value(), parms[6].get_int_value(), parms[7].get_int_value()));
+			gwin->get_effects()->add_effect(std::make_unique<Sprites_effect>(
+					sprite_num, obj, -parms[2].get_int_value(), -parms[3].get_int_value(), parms[4].get_int_value(),
+					parms[5].get_int_value(), parms[6].get_int_value(), parms[7].get_int_value()));
 		}
 	}
 	return no_ret;
@@ -3037,8 +3035,8 @@ USECODE_INTRINSIC(is_not_blocked) {
 	// Find out about given shape.
 	const Shape_info& info = ShapeID::get_info(shapenum);
 	const TileRect    footprint(
-			tile.tx - info.get_3d_xtiles(framenum) + 1, tile.ty - info.get_3d_ytiles(framenum) + 1, info.get_3d_xtiles(framenum),
-			info.get_3d_ytiles(framenum));
+            tile.tx - info.get_3d_xtiles(framenum) + 1, tile.ty - info.get_3d_ytiles(framenum) + 1, info.get_3d_xtiles(framenum),
+            info.get_3d_ytiles(framenum));
 	int        new_lift;
 	const bool blocked = Map_chunk::is_blocked(
 			info.get_3d_height(), tile.tz, footprint.x, footprint.y, footprint.w, footprint.h, new_lift, MOVE_ALL_TERRAIN, 1);


### PR DESCRIPTION
Some changes to how scaling and surface creation works.

Mostly this is to fix SDLScaler and to improve efficency by removing the copying between Display_surface and Screen_texture

Primarily this is accomplished by getting rid of display_surface in the Image_window class and instead directly drawing to screen_texture by using SDL_LockTextureToSurface to create a temporary display_surface in Image_window::show().
Image_windows::updateRect() no longer takes a surface as a parameter but now takes a SDL_FRect that contains the region of screen_texture that needs to be rendered.

As display_surface no longer exists, inter_surface can't be set to it when creating surfaces and instead will be set to nullptr to indicate that it doesn't exist. in show() inter_surface will be set to the temporary display_surface as needed. 
Screen_texture no longer has the same size as the displsy resolution. It now includes the guardband. This was done to simply things an so the guardband offset hack could be removed and to ensure that edge clamping works as expected when using SDLScaler. Texture edge clamping on non pow of 2 textures is dependant on Hardware support so it was just easier to assume it isn't supported and just use the guardband to ensure consistent behaviour. 

SDLscaler behavior has slightly changed. The SDL scale mode used when SDLScaler is in use will now match what  Scaler is set to. If Scaler is point and FillScaler is SDLSCaler,the SDScaler will use nearest scale mode and scale the same as point. The allows for complete hardware acceleration of point scaling . Does have the downside that its no longer possible to use Scaler Point and use SDL for HW accrlerated bilinear aspect correction. The visual difference is so small that I didn't think it really mattered if I made this change in order to get fully HW accelerated point scaling.

This set of changes includes my Performance metrics overlay,toggleable with Alt-2. The overlay show how long it takes to do scaling and how long certasin fperfrmabce critical bits of code are taking. It also times how long it takes to composite layers. Each layer is now given a name. The layer name is non optional when creating layers but can explicitly be set to "" to not have one .

I addded a config setting  <config/video/vsync> to control vsync. defaults to 1  but cab be set to anything SDL accepts. 0 disables vsync and is useful if testing performance and you want o know the maximum you can get. Not going to add this to the gump bcause the default 1 should be fine for everyone but people want to change it they can in exult.cfg

In the surface creation related changes I removed as much of the vestigial support for 8 bit display modes that still seemed to remain. 8 bit modes wouldn't work anyway with current exult so there was no reason to keep this code. I also remove the fallback unscaled surface creation in  Image_window::create_surface. Now if try_scaler fails when trying the point scaler fallback, it is a fatal error. I;m not sure of any scenario that would occur where try_scaler would fail and the fallback surface creation wouldn't also have problems, but I need to look at this some more in case there is a situation I've missed

I removed some Layer related code duplication in Text Gumps that codefactor complained about.

Still have a few things I want to do such as looking to speed up compositing of big layers like the Performance Metric Overlay. For me it is by far the slowest part of drawing a frame

When performance Metrics are being shown The Screen will be constantly redrawn to get an accurate idea of the framerate. For Slow systems this would be bad so Metrics overlay is off by default and must be turned on with Alt-2. Pressing Alt-2 once shows only fps and frame time. Pressing Alt-2  a second time shows the detailed metrics display. Pressing it a third time hides it.

This set of changes Requires SDL 3.2. I'm not sure if we check for a minimum version of SDL. I may need to update that 

@DominusExult can you test this  to see if scaling is working properly for you as this gets rid of your attempted fix of the SDLScaler problems that only seemed to affect you.